### PR TITLE
Add IR-to-bytecode mapping docs and initial bytecode emitter (emitbc)

### DIFF
--- a/docs/ir-bytecode-mapping.md
+++ b/docs/ir-bytecode-mapping.md
@@ -1,0 +1,61 @@
+# IR to Bytecode Mapping
+
+This document defines how `IR_OP` instructions map to the bytecode stream consumed by the interpreter.
+
+## Bytecode container layout
+
+The runtime expects:
+
+- Byte `0`: number of locals
+- Byte `1`: number of parameters
+- Byte `2..`: opcode stream
+- Terminal opcode: `'h'` (HALT)
+
+## Direct opcode mappings
+
+| IR op | Opcode | Operand encoding | Nominal stack effect |
+|---|---:|---|---:|
+| `IR_OP_PUSH_INT` | `'p'` | `int64` (8 bytes, native-endian) | +1 |
+| `IR_OP_PUSH_STR` | `'l'` | `u16 length` + UTF-8 bytes | +1 |
+| `IR_OP_LOAD_LOCAL` | `'e'` | `u8 local` | +1 |
+| `IR_OP_STORE_LOCAL` | `'c'` | `u8 local` | -1 |
+| `IR_OP_INC_LOCAL` | `'f'` | `u8 local` | 0 |
+| `IR_OP_DEC_LOCAL` | `'g'` | `u8 local` | 0 |
+| `IR_OP_ADD` | `'a'` | none | -1 |
+| `IR_OP_SUB` | `'s'` | none | -1 |
+| `IR_OP_MUL` | `'m'` | none | -1 |
+| `IR_OP_DIV` | `'d'` | none | -1 |
+| `IR_OP_EQ` | `'o'` | none | -1 |
+| `IR_OP_NE` | `'q'` | none | -1 |
+| `IR_OP_LT` | `'r'` | none | -1 |
+| `IR_OP_LE` | `'u'` | none | -1 |
+| `IR_OP_GT` | `'t'` | none | -1 |
+| `IR_OP_GE` | `'v'` | none | -1 |
+| `IR_OP_NOT` | `'x'` | none | 0 |
+| `IR_OP_AND` | `'y'` | none | -1 |
+| `IR_OP_OR` | `'z'` | none | -1 |
+| `IR_OP_EXISTS` | `'X'` | none | 0 |
+| `IR_OP_DELETE` | `'W'` | none | -1 |
+| `IR_OP_NTHNAME` | `'Y'` | none | -1 |
+| `IR_OP_ROOTNAME` | `'Z'` | none | 0 |
+| `IR_OP_JUMP` | `'j'` | signed `i16` relative offset | 0 |
+| `IR_OP_JUMPFALSE` | `'k'` | signed `i16` relative offset | -1 |
+| `IR_OP_HALT` | `'h'` | none | 0 |
+
+## Composite/special mappings
+
+- `IR_OP_BUILD_ITEM`: emits `'I'` and the item assembly byte grammar consumed by `op_assembleitem`.
+- `IR_OP_DEREF`: encoded as part of item-assembly subgrammar (not a standalone VM opcode).
+- `IR_OP_LIBCALL`: emits `'A'` followed by library and function IDs (`u8`, `u8`).
+
+## Unresolved mappings (must be defined before enabling full lowering)
+
+- `IR_OP_CALL`: map to item fetch/execute (`'F'`) or split into a more explicit IR call protocol.
+- `IR_OP_RETURN`: either lower to jump-to-epilogue or keep function-end semantics based on terminal `'h'` and top-of-stack return.
+
+## Emitter invariants
+
+1. Jump offsets are relative to the byte immediately after the opcode byte (`nextop` model).
+2. Jump operand width is signed 16-bit; overflow is a compile-time error.
+3. Local indices are `u8`; overflow is a compile-time error.
+4. Emitter must always terminate stream with `'h'`.

--- a/src/emitbc.c
+++ b/src/emitbc.c
@@ -1,0 +1,126 @@
+// IR to bytecode emitter (scaffold)
+//
+// Licensed under the MIT License - see LICENSE file for details.
+
+#include "emitbc.h"
+
+#include <string.h>
+
+#include "memory.h"
+
+static bool bc_reserve(BC_BUF *out, size_t addl) {
+  if (out->len + addl <= out->cap) {
+    return true;
+  }
+  size_t oldcap = out->cap;
+  size_t newcap = out->cap ? out->cap : 16;
+  while (newcap < out->len + addl) {
+    newcap *= 2;
+  }
+  out->data = GROW_ARRAY(uint8_t, out->data, oldcap, newcap);
+  out->cap = newcap;
+  return out->data != NULL;
+}
+
+static bool bc_write_u8(BC_BUF *out, uint8_t b) {
+  if (!bc_reserve(out, 1)) return false;
+  out->data[out->len++] = b;
+  return true;
+}
+
+static bool bc_write_i16(BC_BUF *out, int16_t v) {
+  if (!bc_reserve(out, 2)) return false;
+  memcpy(out->data + out->len, &v, 2);
+  out->len += 2;
+  return true;
+}
+
+static bool bc_write_i64(BC_BUF *out, int64_t v) {
+  if (!bc_reserve(out, 8)) return false;
+  memcpy(out->data + out->len, &v, 8);
+  out->len += 8;
+  return true;
+}
+
+// TODO: complete switch coverage for all IR ops from docs/ir-bytecode-mapping.md.
+static bool emit_inst(const IR_INST *in, BC_BUF *out, char **errdetail) {
+  (void)errdetail;
+  switch (in->op) {
+    case IR_OP_PUSH_INT:
+      return bc_write_u8(out, 'p') && bc_write_i64(out, in->operand.i64);
+    case IR_OP_LOAD_LOCAL:
+      return bc_write_u8(out, 'e') && bc_write_u8(out, in->operand.local);
+    case IR_OP_STORE_LOCAL:
+      return bc_write_u8(out, 'c') && bc_write_u8(out, in->operand.local);
+    case IR_OP_ADD:
+      return bc_write_u8(out, 'a');
+    case IR_OP_SUB:
+      return bc_write_u8(out, 's');
+    case IR_OP_MUL:
+      return bc_write_u8(out, 'm');
+    case IR_OP_DIV:
+      return bc_write_u8(out, 'd');
+    case IR_OP_JUMP:
+      // Placeholder until label/pc fixup is implemented.
+      return bc_write_u8(out, 'j') && bc_write_i16(out, 0);
+    case IR_OP_JUMPFALSE:
+      // Placeholder until label/pc fixup is implemented.
+      return bc_write_u8(out, 'k') && bc_write_i16(out, 0);
+    case IR_OP_HALT:
+      return bc_write_u8(out, 'h');
+    default:
+      if (errdetail) {
+        *errdetail = "unimplemented IR opcode in emit_inst";
+      }
+      return false;
+  }
+}
+
+bool emit_bytecode_from_ir(const IR_CTX *ir,
+                           uint8_t numlocals,
+                           uint8_t numparams,
+                           BC_BUF *out,
+                           char **errdetail) {
+  if (errdetail) *errdetail = NULL;
+  if (!ir || !out) {
+    if (errdetail) *errdetail = "emit_bytecode_from_ir invalid arguments";
+    return false;
+  }
+
+  out->data = NULL;
+  out->len = 0;
+  out->cap = 0;
+
+  if (!bc_write_u8(out, numlocals) || !bc_write_u8(out, numparams)) {
+    if (errdetail) *errdetail = "oom while writing bytecode header";
+    emitbc_free(out);
+    return false;
+  }
+
+  for (uint32_t i = 0; i < ir->count; ++i) {
+    if (!emit_inst(&ir->code[i], out, errdetail)) {
+      emitbc_free(out);
+      return false;
+    }
+  }
+
+  if (ir->count == 0 || ir->code[ir->count - 1].op != IR_OP_HALT) {
+    if (!bc_write_u8(out, 'h')) {
+      if (errdetail) *errdetail = "oom while writing halt opcode";
+      emitbc_free(out);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void emitbc_free(BC_BUF *buf) {
+  if (!buf) return;
+  if (buf->data) {
+    FREE_ARRAY(uint8_t, buf->data, buf->cap);
+  }
+  buf->data = NULL;
+  buf->len = 0;
+  buf->cap = 0;
+}

--- a/src/emitbc.h
+++ b/src/emitbc.h
@@ -1,0 +1,27 @@
+// IR to bytecode emitter interface
+//
+// Licensed under the MIT License - see LICENSE file for details.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ir.h"
+
+typedef struct {
+  uint8_t *data;
+  size_t len;
+  size_t cap;
+} BC_BUF;
+
+// Emit a complete bytecode stream (header + opcodes + halt) from IR.
+// Returns true on success.
+bool emit_bytecode_from_ir(const IR_CTX *ir,
+                           uint8_t numlocals,
+                           uint8_t numparams,
+                           BC_BUF *out,
+                           char **errdetail);
+
+void emitbc_free(BC_BUF *buf);


### PR DESCRIPTION
### Motivation

- Define a concrete mapping from `IR_OP` instructions to the runtime bytecode stream so IR lowering can target a stable VM opcode layout.
- Provide an initial emitter implementation to produce a bytecode stream from an IR context and to serve as scaffolding for further lowering and label fixups.

### Description

- Add `docs/ir-bytecode-mapping.md` which documents the bytecode container layout, direct opcode mappings, composite mappings, unresolved mappings, and emitter invariants.
- Add `src/emitbc.h` which declares the `BC_BUF` buffer type and the interface `emit_bytecode_from_ir` and `emitbc_free` for emitting bytecode from an `IR_CTX`.
- Add `src/emitbc.c` which implements a growable `BC_BUF`, helpers to write `u8`, `i16`, and `i64` values, the emitter `emit_inst` with partial opcode coverage and placeholders for jump fixups, and `emit_bytecode_from_ir` which writes header bytes and ensures a terminating `'h'` opcode.
- Emit functions return errors for unimplemented IR opcodes and handle OOM and invalid-argument paths, and memory is freed via `emitbc_free`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7980b2644832e879999fe77167b2e)