### PR TITLE
Lower expressions recursively and map AST nodes to IR ops

### DIFF
--- a/src/lower.c
+++ b/src/lower.c
@@ -29,6 +29,7 @@ static void lower_set_unsupported(LOWER_CTX *ctx, const AS_NODE *node, const cha
 }
 
 static void lower_node(LOWER_CTX *ctx, AS_NODE *node);
+static void lower_expr(LOWER_CTX *ctx, AS_NODE *node);
 
 static void lower_value_expr(LOWER_CTX *ctx, AS_NODE *node) {
   AS_VALUE *value;
@@ -49,7 +50,7 @@ static void lower_value_expr(LOWER_CTX *ctx, AS_NODE *node) {
       ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = value->value.i});
       return;
     case V_STR:
-      lower_set_unsupported(ctx, node, "string lowering not implemented");
+      ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_PUSH_STRING, .imm = (int64_t)(intptr_t)value->value.s});
       return;
     case V_LOCAL: {
       uint8_t index = 0;
@@ -69,11 +70,44 @@ static void lower_value_expr(LOWER_CTX *ctx, AS_NODE *node) {
 }
 
 static void lower_binary_expr(LOWER_CTX *ctx, AS_NODE *node, IR_Op op) {
-  lower_node(ctx, (AS_NODE *)node->lhs);
+  lower_expr(ctx, (AS_NODE *)node->lhs);
   if (ctx->errnum != ERR_NOERROR) return;
-  lower_node(ctx, (AS_NODE *)node->rhs);
+  lower_expr(ctx, (AS_NODE *)node->rhs);
   if (ctx->errnum != ERR_NOERROR) return;
   ir_emit(ctx->ir, (IR_Inst){.op = op});
+}
+
+static void lower_expr(LOWER_CTX *ctx, AS_NODE *node) {
+  if (!ctx || !node || ctx->errnum != ERR_NOERROR) return;
+
+  switch (node->nodetype) {
+    case N_VALUE:
+      lower_value_expr(ctx, node);
+      return;
+
+    case N_ADD: lower_binary_expr(ctx, node, IR_OP_ADD); return;
+    case N_SUB: lower_binary_expr(ctx, node, IR_OP_SUB); return;
+    case N_MUL: lower_binary_expr(ctx, node, IR_OP_MUL); return;
+    case N_DIV: lower_binary_expr(ctx, node, IR_OP_DIV); return;
+    case N_EQUAL: lower_binary_expr(ctx, node, IR_OP_EQ); return;
+    case N_NOTEQ: lower_binary_expr(ctx, node, IR_OP_NEQ); return;
+    case N_LT: lower_binary_expr(ctx, node, IR_OP_LT); return;
+    case N_LTEQ: lower_binary_expr(ctx, node, IR_OP_LE); return;
+    case N_GT: lower_binary_expr(ctx, node, IR_OP_GT); return;
+    case N_GTEQ: lower_binary_expr(ctx, node, IR_OP_GE); return;
+    case N_AND: lower_binary_expr(ctx, node, IR_OP_AND); return;
+    case N_OR: lower_binary_expr(ctx, node, IR_OP_OR); return;
+
+    case N_NOT:
+      lower_expr(ctx, (AS_NODE *)node->lhs);
+      if (ctx->errnum != ERR_NOERROR) return;
+      ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_NOT});
+      return;
+
+    default:
+      lower_set_unsupported(ctx, node, "expression node type unsupported");
+      return;
+  }
 }
 
 static void lower_node(LOWER_CTX *ctx, AS_NODE *node) {
@@ -93,36 +127,13 @@ static void lower_node(LOWER_CTX *ctx, AS_NODE *node) {
 
     case N_STMT:
     case N_EXPRSTMT:
-      lower_node(ctx, (AS_NODE *)node->lhs);
+      lower_expr(ctx, (AS_NODE *)node->lhs);
       return;
 
     case N_RETURN:
-      lower_node(ctx, (AS_NODE *)node->lhs);
+      lower_expr(ctx, (AS_NODE *)node->lhs);
       if (ctx->errnum != ERR_NOERROR) return;
       ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_HALT});
-      return;
-
-    case N_VALUE:
-      lower_value_expr(ctx, node);
-      return;
-
-    case N_ADD: lower_binary_expr(ctx, node, IR_OP_ADD); return;
-    case N_SUB: lower_binary_expr(ctx, node, IR_OP_SUB); return;
-    case N_MUL: lower_binary_expr(ctx, node, IR_OP_MUL); return;
-    case N_DIV: lower_binary_expr(ctx, node, IR_OP_DIV); return;
-    case N_EQUAL: lower_binary_expr(ctx, node, IR_OP_EQ); return;
-    case N_NOTEQ: lower_binary_expr(ctx, node, IR_OP_NEQ); return;
-    case N_LT: lower_binary_expr(ctx, node, IR_OP_LT); return;
-    case N_LTEQ: lower_binary_expr(ctx, node, IR_OP_LE); return;
-    case N_GT: lower_binary_expr(ctx, node, IR_OP_GT); return;
-    case N_GTEQ: lower_binary_expr(ctx, node, IR_OP_GE); return;
-    case N_AND: lower_binary_expr(ctx, node, IR_OP_AND); return;
-    case N_OR: lower_binary_expr(ctx, node, IR_OP_OR); return;
-
-    case N_NOT:
-      lower_node(ctx, (AS_NODE *)node->lhs);
-      if (ctx->errnum != ERR_NOERROR) return;
-      ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_NOT});
       return;
 
     default:
@@ -167,4 +178,3 @@ int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **err
   }
   return ctx.errnum;
 }
-


### PR DESCRIPTION
### Motivation
- Provide a dedicated, recursive lowering path for expressions so expression AST nodes are lowered consistently and separately from statement handling.
- Map common AST expression kinds to IR operations to enable correct IR emission for arithmetic, comparison, logical ops and values.
- Support string and local value lowering so `V_STR` and `V_LOCAL` can be emitted into IR and locals are resolved via semantic context.
- Preserve existing parser semantics for unary minus (parser encodes it as `N_SUB(0, expr)`) and ensure unsupported nodes return lowering errors.

### Description
- Add a new function `lower_expr(LOWER_CTX*, AS_NODE*)` and route expression lowering through it while keeping statement lowering in `lower_node`.
- Update `lower_binary_expr` to recursively use `lower_expr` for both operands and then emit the provided binary `IR_Op`.
- Move expression cases (`N_VALUE`, `N_ADD`, `N_SUB`, `N_MUL`, `N_DIV`, `N_EQUAL`, `N_NOTEQ`, `N_LT`, `N_LTEQ`, `N_GT`, `N_GTEQ`, `N_AND`, `N_OR`, `N_NOT`) into `lower_expr` and make `lower_node` call `lower_expr` for expression statements and returns.
- Implement value mappings: `V_INT` -> `IR_OP_PUSH_INT`, `V_STR` -> `IR_OP_PUSH_STRING` (string pointer stored in `imm` via cast), and `V_LOCAL` -> `IR_OP_LOAD_LOCAL` (index retrieved with `sem_get_local_index`); unknown expression node kinds call `lower_set_unsupported`.

### Testing
- Ran `make -C /workspace/sin` to build the project and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe07917fe8832eb00b0e18eaa879d7)