### PR TITLE
Add IR payload support for embedded code assignments

### DIFF
--- a/src/ir.c
+++ b/src/ir.c
@@ -4,6 +4,8 @@
 
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "ir.h"
 #include "memory.h"
@@ -49,6 +51,12 @@ void ir_destroy_unit(IR_Unit* unit) {
 
   FREE_ARRAY(IR_Inst, unit->function.code, unit->function.capacity);
   FREE_ARRAY(IR_Label, unit->labels.entries, unit->labels.capacity);
+  for (size_t i = 0; i < unit->embedded_code.count; i++) {
+    IR_EmbeddedCodePayload* payload = &unit->embedded_code.entries[i];
+    FREE_ARRAY(const char*, payload->params, payload->param_count);
+    FREE_ARRAY(IR_EmbeddedLocal, payload->locals, payload->local_count);
+  }
+  FREE_ARRAY(IR_EmbeddedCodePayload, unit->embedded_code.entries, unit->embedded_code.capacity);
   FREE_ARRAY(IR_Unit, unit, 1);
 }
 
@@ -81,6 +89,54 @@ bool ir_bind_label(IR_Unit* unit, int32_t label_id) {
   IR_Label* label = &unit->labels.entries[label_id];
   label->position = unit->function.count;
   label->bound = true;
+
+  return true;
+}
+
+static void ensure_embedded_capacity(IR_EmbeddedCodeTable* table, size_t needed) {
+  if (table->capacity >= needed) return;
+  size_t oldcap = table->capacity;
+  size_t newcap = GROW_CAPACITY(oldcap);
+  while (newcap < needed) newcap = GROW_CAPACITY(newcap);
+  table->entries = GROW_ARRAY(IR_EmbeddedCodePayload, table->entries, oldcap, newcap);
+  table->capacity = newcap;
+}
+
+int32_t ir_add_embedded_code_payload(IR_Unit* unit, IR_EmbeddedCodePayload payload) {
+  size_t idx = unit->embedded_code.count;
+  ensure_embedded_capacity(&unit->embedded_code, idx + 1);
+  unit->embedded_code.entries[idx] = payload;
+  unit->embedded_code.count++;
+  return (int32_t)idx;
+}
+
+bool ir_embedded_locals_from_params(AS_NODE* params, IR_EmbeddedCodePayload* payload) {
+  AS_NODE* cursor = params;
+  size_t count = 0;
+  while (cursor) {
+    if (cursor->nodetype != N_ARGLIST) return false;
+    count++;
+    cursor = (AS_NODE*)cursor->rhs;
+  }
+
+  payload->param_count = count;
+  payload->params = GROW_ARRAY(const char*, NULL, 0, count > 0 ? count : 1);
+  payload->locals = GROW_ARRAY(IR_EmbeddedLocal, NULL, 0, count > 0 ? count : 1);
+  payload->local_count = count;
+
+  cursor = params;
+  for (size_t i = 0; i < count; i++) {
+    AS_NODE* param = (AS_NODE*)cursor->lhs;
+    AS_VALUE* value;
+    if (!param || param->nodetype != N_VALUE) return false;
+    value = (AS_VALUE*)param->lhs;
+    if (!value || value->valtype != V_LOCAL || !value->value.s) return false;
+    payload->params[i] = value->value.s;
+    payload->locals[i].name = value->value.s;
+    payload->locals[i].index = (uint8_t)i;
+    payload->locals[i].param = true;
+    cursor = (AS_NODE*)cursor->rhs;
+  }
 
   return true;
 }
@@ -124,6 +180,7 @@ const char* ir_op_name(IR_Op op) {
     case IR_OP_NTHNAME: return "NTHNAME";
     case IR_OP_ROOTNAME: return "ROOTNAME";
     case IR_OP_POP: return "POP";
+    case IR_OP_ITEM_SAVE_CODE: return "ITEM_SAVE_CODE";
     default: return "<unknown>";
   }
 }

--- a/src/ir.h
+++ b/src/ir.h
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "absyn.h"
+
 typedef enum {
   IR_OP_HALT = 0,
 
@@ -56,7 +58,8 @@ typedef enum {
   IR_OP_DELETE,
   IR_OP_NTHNAME,
   IR_OP_ROOTNAME,
-  IR_OP_POP
+  IR_OP_POP,
+  IR_OP_ITEM_SAVE_CODE
 } IR_Op;
 
 typedef struct {
@@ -85,8 +88,29 @@ typedef struct {
 } IR_LabelTable;
 
 typedef struct {
+  char* name;
+  uint8_t index;
+  bool param;
+} IR_EmbeddedLocal;
+
+typedef struct {
+  const char* source;
+  size_t param_count;
+  const char** params;
+  size_t local_count;
+  IR_EmbeddedLocal* locals;
+} IR_EmbeddedCodePayload;
+
+typedef struct {
+  size_t count;
+  size_t capacity;
+  IR_EmbeddedCodePayload* entries;
+} IR_EmbeddedCodeTable;
+
+typedef struct {
   IR_Function function;
   IR_LabelTable labels;
+  IR_EmbeddedCodeTable embedded_code;
 } IR_Unit;
 
 IR_Unit* ir_create_unit(void);
@@ -96,6 +120,8 @@ size_t ir_emit(IR_Unit* unit, IR_Inst inst);
 
 int32_t ir_new_label(IR_Unit* unit);
 bool ir_bind_label(IR_Unit* unit, int32_t label_id);
+int32_t ir_add_embedded_code_payload(IR_Unit* unit, IR_EmbeddedCodePayload payload);
+bool ir_embedded_locals_from_params(AS_NODE* params, IR_EmbeddedCodePayload* payload);
 
 void ir_dump(FILE* out, IR_Unit* unit);
 

--- a/src/lower.c
+++ b/src/lower.c
@@ -35,6 +35,7 @@ static void lower_stmtlist(LOWER_CTX *ctx, AS_NODE *node);
 static void lower_arglist(LOWER_CTX *ctx, AS_NODE *arglist, int32_t *argc);
 
 static void lower_item(LOWER_CTX *ctx, AS_NODE *item);
+static bool lower_build_embedded_payload(LOWER_CTX *ctx, AS_NODE *node, int32_t *payload_index);
 
 static void lower_layer_part(LOWER_CTX *ctx, AS_NODE *part) {
   AS_VALUE *value;
@@ -266,18 +267,9 @@ static void lower_expr(LOWER_CTX *ctx, AS_NODE *node) {
       return;
 
     case N_CODE: {
-      AS_NODE *source = (AS_NODE *)node->rhs;
-      AS_VALUE *val;
-      if (!source || source->nodetype != N_VALUE) {
-        lower_set_unsupported(ctx, node, "code body must be value node");
-        return;
-      }
-      val = (AS_VALUE *)source->lhs;
-      if (!val || val->valtype != V_STR) {
-        lower_set_unsupported(ctx, node, "code body must be string");
-        return;
-      }
-      ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_PUSH_STRING, .imm = (int64_t)(intptr_t)val->value.s});
+      int32_t payload_index = -1;
+      if (!lower_build_embedded_payload(ctx, node, &payload_index)) return;
+      ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_ITEM_SAVE_CODE, .a = payload_index});
       return;
     }
 
@@ -373,9 +365,15 @@ static void lower_stmt(LOWER_CTX *ctx, AS_NODE *node) {
     case N_ASSITEM:
       lower_item(ctx, (AS_NODE *)node->lhs);
       if (ctx->errnum != ERR_NOERROR) return;
-      lower_expr(ctx, (AS_NODE *)node->rhs);
-      if (ctx->errnum != ERR_NOERROR) return;
-      ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_ITEM_SAVE});
+      if (((AS_NODE *)node->rhs)->nodetype == N_CODE) {
+        int32_t payload_index = -1;
+        if (!lower_build_embedded_payload(ctx, (AS_NODE *)node->rhs, &payload_index)) return;
+        ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_ITEM_SAVE_CODE, .a = payload_index});
+      } else {
+        lower_expr(ctx, (AS_NODE *)node->rhs);
+        if (ctx->errnum != ERR_NOERROR) return;
+        ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_ITEM_SAVE});
+      }
       return;
 
     case N_IFSTMT: {
@@ -429,6 +427,34 @@ static void lower_stmt(LOWER_CTX *ctx, AS_NODE *node) {
       lower_set_unsupported(ctx, node, "node type unsupported");
       return;
   }
+}
+
+static bool lower_build_embedded_payload(LOWER_CTX *ctx, AS_NODE *node, int32_t *payload_index) {
+  AS_NODE *source;
+  AS_VALUE *val;
+  IR_EmbeddedCodePayload payload = {0};
+
+  if (!node || node->nodetype != N_CODE) {
+    lower_set_unsupported(ctx, node, "expected code node");
+    return false;
+  }
+  source = (AS_NODE *)node->rhs;
+  if (!source || source->nodetype != N_VALUE) {
+    lower_set_unsupported(ctx, node, "code body must be value node");
+    return false;
+  }
+  val = (AS_VALUE *)source->lhs;
+  if (!val || val->valtype != V_STR) {
+    lower_set_unsupported(ctx, node, "code body must be string");
+    return false;
+  }
+  payload.source = val->value.s;
+  if (!ir_embedded_locals_from_params((AS_NODE *)node->lhs, &payload)) {
+    lower_set_unsupported(ctx, node, "code params must be local arg list");
+    return false;
+  }
+  *payload_index = ir_add_embedded_code_payload(ctx->ir, payload);
+  return true;
 }
 
 static void lower_node(LOWER_CTX *ctx, AS_NODE *node) {


### PR DESCRIPTION
### Motivation
- Lowering should represent embedded code as structured IR payload (source + params/locals) instead of emitting raw/serialized bytecode at lowering time.
- The IR must preserve parameter ordering and the code body string so final bytecode headers can be produced deterministically.
- A helper is needed to transform parameter locals into deterministic local-table entries that align with the bytecode header format.
- Final embedded-bytecode serialization should be deferred to the encoding phase while IR carries sufficient metadata.

### Description
- Added a new IR opcode `IR_OP_ITEM_SAVE_CODE` to distinguish embedded-code item assignments from normal `IR_OP_ITEM_SAVE` and to carry a payload index in `IR_Inst.a`.
- Introduced `IR_EmbeddedCodePayload`, `IR_EmbeddedLocal`, and `IR_EmbeddedCodeTable` and attached an `embedded_code` table to `IR_Unit` to store code source, ordered params, and deterministic locals metadata.
- Implemented `ir_add_embedded_code_payload(...)` to register payloads and `ir_embedded_locals_from_params(...)` to convert an `N_ARGLIST` params node into deterministic local entries (index/order/`param` bit).
- Extended lowering with `lower_build_embedded_payload(...)` to construct payloads from `N_CODE` nodes and emit `IR_OP_ITEM_SAVE_CODE` (used for standalone `N_CODE` expressions and for `ASSITEM` when RHS is `N_CODE`).
- Added cleanup of embedded payload storage in `ir_destroy_unit` and updated `ir_op_name` to include the new opcode.

### Testing
- Built the project successfully with `make -C /workspace/sin -j2`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3f0f5dc8832e9d8fd4cdd7ff94ef)