### PR TITLE
Add IR validation and run it in scomp lowering flow

### DIFF
--- a/src/ir.c
+++ b/src/ir.c
@@ -6,7 +6,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 
+#include "error.h"
 #include "ir.h"
 #include "memory.h"
 
@@ -207,4 +209,98 @@ void ir_dump(FILE* out, IR_Unit* unit) {
     fprintf(out, "%04zu  %-14s a=%" PRId32 " b=%" PRId32 " imm=%" PRId64 "\n",
             i, ir_op_name(inst->op), inst->a, inst->b, inst->imm);
   }
+}
+
+static int8_t ir_validate_error(char **errdetail, int8_t errnum, const char *fmt, ...) {
+  if (errdetail != NULL) {
+    va_list args;
+    va_start(args, fmt);
+    int needed = vsnprintf(NULL, 0, fmt, args);
+    va_end(args);
+    if (needed < 0) {
+      *errdetail = NULL;
+    } else {
+      *errdetail = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+      va_start(args, fmt);
+      vsnprintf(*errdetail, (size_t)needed + 1, fmt, args);
+      va_end(args);
+    }
+  }
+  return errnum;
+}
+
+int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail) {
+  if (errdetail != NULL) {
+    *errdetail = NULL;
+  }
+
+  if (unit == NULL) {
+    return ir_validate_error(errdetail, ERR_COMP_SYNTAX, "IR unit is null.");
+  }
+
+  for (size_t i = 0; i < unit->labels.count; i++) {
+    IR_Label* label = &unit->labels.entries[i];
+    if (!label->bound) {
+      return ir_validate_error(errdetail, ERR_COMP_SYNTAX,
+                               "Unbound label .L%d.", label->id);
+    }
+  }
+
+  for (size_t i = 0; i < unit->function.count; i++) {
+    const IR_Inst* inst = &unit->function.code[i];
+    switch (inst->op) {
+      case IR_OP_JUMP:
+      case IR_OP_JUMP_IF_FALSE:
+      case IR_OP_LABEL: {
+        if (inst->a < 0 || (size_t)inst->a >= unit->labels.count) {
+          return ir_validate_error(errdetail, ERR_COMP_SYNTAX,
+                                   "Instruction %zu (%s) references invalid label id %d.",
+                                   i, ir_op_name(inst->op), inst->a);
+        }
+        if (!unit->labels.entries[inst->a].bound) {
+          return ir_validate_error(errdetail, ERR_COMP_SYNTAX,
+                                   "Instruction %zu (%s) references unbound label .L%d.",
+                                   i, ir_op_name(inst->op), inst->a);
+        }
+        break;
+      }
+      case IR_OP_LOAD_LOCAL:
+      case IR_OP_STORE_LOCAL:
+      case IR_OP_INC_LOCAL:
+      case IR_OP_DEC_LOCAL: {
+        if (inst->a < 0 || (uint32_t)inst->a >= local_count) {
+          return ir_validate_error(errdetail, ERR_COMP_LOCALBEFOREDEF,
+                                   "Instruction %zu (%s) has out-of-range local index %d (locals=%u).",
+                                   i, ir_op_name(inst->op), inst->a, local_count);
+        }
+        break;
+      }
+      case IR_OP_CALL:
+      case IR_OP_LIBCALL: {
+        if (inst->a < 0) {
+          return ir_validate_error(errdetail, ERR_COMP_TOOMANYARGS,
+                                   "Instruction %zu (%s) has negative arity %d.",
+                                   i, ir_op_name(inst->op), inst->a);
+        }
+        if (inst->op == IR_OP_LIBCALL) {
+          if (i < 2) {
+            return ir_validate_error(errdetail, ERR_COMP_SYNTAX,
+                                     "Instruction %zu (LIBCALL) is missing library/function name operands.",
+                                     i);
+          }
+          const IR_Inst *libname = &unit->function.code[i - 2];
+          const IR_Inst *funcname = &unit->function.code[i - 1];
+          if (libname->op != IR_OP_PUSH_STRING || funcname->op != IR_OP_PUSH_STRING) {
+            return ir_validate_error(errdetail, ERR_COMP_SYNTAX,
+                                     "Instruction %zu (LIBCALL) must be preceded by two PUSH_STRING instructions.",
+                                     i);
+          }
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return ERR_NOERROR;
 }

--- a/src/ir.h
+++ b/src/ir.h
@@ -126,3 +126,4 @@ bool ir_embedded_locals_from_params(AS_NODE* params, IR_EmbeddedCodePayload* pay
 void ir_dump(FILE* out, IR_Unit* unit);
 
 const char* ir_op_name(IR_Op op);
+int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail);

--- a/src/scomp.c
+++ b/src/scomp.c
@@ -10,6 +10,8 @@
 #include "parser.h"
 #include "absyn.h"
 #include "semant.h"
+#include "lower.h"
+#include "ir.h"
 #include "memory.h"
 #include "log.h"
 
@@ -21,6 +23,7 @@ int main(int argc, char **argv) {
   int sourcelen;
   AS_NODE *absyn;
   SEM_CTX *ctx;
+  IR_Unit *ir = NULL;
   OUTPUT_t *out;
 
   if (argc != 3) {
@@ -65,6 +68,16 @@ int main(int argc, char **argv) {
       logerr("Error: (#%d) %s\n", result, errmsg[result]);
       logerr("Detail: %s\n", errdetail);
       logerr("Compilation failed.\n");
+    } else {
+      result = lower_ast_to_ir(absyn, ctx, &ir, &errdetail);
+      if (result == ERR_NOERROR) {
+        result = ir_validate(ir, ctx->count, &errdetail);
+      }
+      if (result != ERR_NOERROR) {
+        logerr("Error: (#%d) %s\n", result, errmsg[result]);
+        logerr("Detail: %s\n", errdetail);
+        logerr("Compilation failed.\n");
+      }
     }
 // FIXME: WE HAVEN'T COMPILED THE BYTECODE YET! ONLY THE ABSTRACT SYNTAX!
 //    logmsg("Compilation completed: %ld bytes.\n",
@@ -88,6 +101,7 @@ int main(int argc, char **argv) {
     FREE_ARRAY(char, errdetail, 1);
   }
   as_delete(absyn);
+  ir_destroy_unit(ir);
   sem_delete_ctx(ctx);
   FREE_ARRAY(unsigned char, out->bytecode, out->maxsize);
   FREE_ARRAY(OUTPUT_t, out, 1);


### PR DESCRIPTION
### Motivation

- Ensure IR emitted by the lowering pass is structurally valid before bytecode generation. 
- Catch common lowering mistakes early (unbound labels, bad local indices, malformed call/libcall operands) and return compiler-style errors with diagnostic details.

### Description

- Added `int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail)` to `src/ir.h` and implemented it in `src/ir.c` with detailed `errdetail` messages using existing error codes.
- `ir_validate` checks that all labels are bound, that `JUMP`, `JUMP_IF_FALSE`, and `LABEL` operands reference valid/bound labels, that local access ops (`LOAD/STORE/INC/DEC_LOCAL`) use indices within `local_count`, and that `CALL`/`LIBCALL` arity is non-negative and `LIBCALL` is preceded by two `PUSH_STRING` instructions for library and function names.
- Added a helper `ir_validate_error` in `ir.c` to format and return error details consistently.
- Integrated lowering and IR validation into the compiler wrapper `src/scomp.c` by invoking `lower_ast_to_ir` and `ir_validate` after `sem_check_locals`, and ensured the created `IR_Unit` is destroyed during cleanup.

### Testing

- Ran `make -j4` and the project builds successfully (targets including `scomp`, `sdiss`, and `sin` compiled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe42a66f44832e8d615109e3df5792)