### PR TITLE
Add IR-to-bytecode emitter and integrate into scomp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LIB := $(LIB_DIR)/libsinshared.a
 LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o \
                $(OBJ_DIR)/parser.o $(OBJ_DIR)/lexer.o $(OBJ_DIR)/absyn.o \
                $(OBJ_DIR)/semant.o $(OBJ_DIR)/ir.o $(OBJ_DIR)/lower.o \
-               $(OBJ_DIR)/error.o $(OBJ_DIR)/util.o $(OBJ_DIR)/libcall.o \
+               $(OBJ_DIR)/emitbc.o $(OBJ_DIR)/error.o $(OBJ_DIR)/util.o $(OBJ_DIR)/libcall.o \
                $(OBJ_DIR)/stack.o $(OBJ_DIR)/value.o $(OBJ_DIR)/item.o \
                $(OBJ_DIR)/vm.o $(OBJ_DIR)/task.o $(OBJ_DIR)/interpret.o \
                $(OBJ_DIR)/network.o $(OBJ_DIR)/libtelnet.o

--- a/src/emitbc.c
+++ b/src/emitbc.c
@@ -1,0 +1,174 @@
+#include "emitbc.h"
+
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "error.h"
+#include "memory.h"
+
+static int8_t emit_error(char **errdetail, int8_t errnum, const char *fmt, ...) {
+  if (errdetail) {
+    va_list args;
+    va_start(args, fmt);
+    int needed = vsnprintf(NULL, 0, fmt, args);
+    va_end(args);
+    if (needed >= 0) {
+      *errdetail = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+      va_start(args, fmt);
+      vsnprintf(*errdetail, (size_t)needed + 1, fmt, args);
+      va_end(args);
+    } else {
+      *errdetail = NULL;
+    }
+  }
+  return errnum;
+}
+
+static int ensure_out(OUTPUT_t *out, size_t extra) {
+  size_t used = (size_t)(out->nextbyte - out->bytecode);
+  size_t needed = used + extra;
+  if (needed <= out->maxsize) return 1;
+  size_t oldcap = out->maxsize;
+  size_t newcap = GROW_CAPACITY(oldcap);
+  while (newcap < needed) newcap = GROW_CAPACITY(newcap);
+  out->bytecode = GROW_ARRAY(unsigned char, out->bytecode, oldcap, newcap);
+  out->nextbyte = out->bytecode + used;
+  out->maxsize = newcap;
+  return 1;
+}
+
+static void write_u8(OUTPUT_t *out, uint8_t v) { ensure_out(out, 1); *out->nextbyte++ = v; }
+static void write_u16(OUTPUT_t *out, uint16_t v) { ensure_out(out, 2); memcpy(out->nextbyte, &v, 2); out->nextbyte += 2; }
+static void write_i64(OUTPUT_t *out, int64_t v) { ensure_out(out, 8); memcpy(out->nextbyte, &v, 8); out->nextbyte += 8; }
+
+static int inst_size(const IR_Inst *in) {
+  switch (in->op) {
+    case IR_OP_LABEL: return 0;
+    case IR_OP_PUSH_INT: return 1 + 8;
+    case IR_OP_PUSH_STRING: return 1 + 2 + (int)strlen((const char *)(intptr_t)in->imm);
+    case IR_OP_LOAD_LOCAL:
+    case IR_OP_STORE_LOCAL:
+    case IR_OP_INC_LOCAL:
+    case IR_OP_DEC_LOCAL:
+    case IR_OP_CALL:
+    case IR_OP_LIBCALL: return 2;
+    case IR_OP_JUMP:
+    case IR_OP_JUMP_IF_FALSE: return 3;
+    default: return 1;
+  }
+}
+
+static uint8_t map_opcode(IR_Op op) {
+  switch (op) {
+    case IR_OP_HALT: return 'h';
+    case IR_OP_PUSH_INT: return 'p';
+    case IR_OP_PUSH_STRING: return 'l';
+    case IR_OP_ADD: return 'a'; case IR_OP_SUB: return 's'; case IR_OP_MUL: return 'm'; case IR_OP_DIV: return 'd';
+    case IR_OP_NEG: return 'n';
+    case IR_OP_EQ: return 'o'; case IR_OP_NEQ: return 'q'; case IR_OP_LT: return 'r'; case IR_OP_GT: return 't'; case IR_OP_LE: return 'u'; case IR_OP_GE: return 'v';
+    case IR_OP_NOT: return 'x'; case IR_OP_AND: return 'y'; case IR_OP_OR: return 'z';
+    case IR_OP_LOAD_LOCAL: return 'e'; case IR_OP_STORE_LOCAL: return 'c'; case IR_OP_INC_LOCAL: return 'f'; case IR_OP_DEC_LOCAL: return 'g';
+    case IR_OP_JUMP: return 'j'; case IR_OP_JUMP_IF_FALSE: return 'k';
+    case IR_OP_ITEM_BEGIN: return 'I'; case IR_OP_ITEM_PUSH_LAYER: return 'L'; case IR_OP_ITEM_PUSH_DEREF: return 'D'; case IR_OP_ITEM_END: return 'E'; case IR_OP_ITEM_DEREF: return 'F';
+    case IR_OP_ITEM_SAVE: return 'C'; case IR_OP_EXISTS: return 'X'; case IR_OP_DELETE: return 'W'; case IR_OP_NTHNAME: return 'Y'; case IR_OP_ROOTNAME: return 'Z';
+    case IR_OP_POP: return 0;
+    case IR_OP_CALL: return 'F';
+    case IR_OP_LIBCALL: return 'A';
+    case IR_OP_ITEM_SAVE_CODE: return 'B';
+    default: return 0;
+  }
+}
+
+int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
+                     OUTPUT_t *out, char **errdetail) {
+  if (errdetail) *errdetail = NULL;
+  if (!ir || !out) return emit_error(errdetail, ERR_COMP_SYNTAX, "emit_bytecode: null input");
+
+  size_t *pos = GROW_ARRAY(size_t, NULL, 0, ir->function.count > 0 ? ir->function.count : 1);
+  size_t pc = 2;
+  for (size_t i = 0; i < ir->function.count; i++) {
+    pos[i] = pc;
+    pc += (size_t)inst_size(&ir->function.code[i]);
+  }
+
+  ensure_out(out, 2);
+  out->nextbyte = out->bytecode;
+  write_u8(out, local_count);
+  write_u8(out, param_count);
+
+  for (size_t i = 0; i < ir->function.count; i++) {
+    IR_Inst *in = &ir->function.code[i];
+    if (in->op == IR_OP_LABEL) continue;
+    if (in->op == IR_OP_POP) { write_u8(out, 0); continue; }
+    uint8_t op = map_opcode(in->op);
+    if (op == 0) {
+      FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
+      return emit_error(errdetail, ERR_COMP_SYNTAX, "unsupported IR op %d", in->op);
+    }
+    write_u8(out, op);
+    switch (in->op) {
+      case IR_OP_PUSH_INT: write_i64(out, in->imm); break;
+      case IR_OP_PUSH_STRING: {
+        const char *s = (const char *)(intptr_t)in->imm;
+        size_t len = strlen(s);
+        if (len > UINT16_MAX) {
+          FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
+          return emit_error(errdetail, ERR_COMP_SYNTAX, "string literal too long: %zu", len);
+        }
+        write_u16(out, (uint16_t)len);
+        ensure_out(out, len);
+        memcpy(out->nextbyte, s, len);
+        out->nextbyte += len;
+        break;
+      }
+      case IR_OP_LOAD_LOCAL:
+      case IR_OP_STORE_LOCAL:
+      case IR_OP_INC_LOCAL:
+      case IR_OP_DEC_LOCAL:
+      case IR_OP_CALL:
+      case IR_OP_LIBCALL:
+        write_u8(out, (uint8_t)in->a);
+        break;
+      case IR_OP_JUMP:
+      case IR_OP_JUMP_IF_FALSE: {
+        if (in->a < 0 || (size_t)in->a >= ir->labels.count) {
+          FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
+          return emit_error(errdetail, ERR_COMP_SYNTAX, "jump invalid label id %d", in->a);
+        }
+        IR_Label *label = &ir->labels.entries[in->a];
+        if (!label->bound) {
+          FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
+          return emit_error(errdetail, ERR_COMP_SYNTAX, "jump unbound label %d", in->a);
+        }
+        size_t from = pos[i] + 1;
+        size_t to = pos[label->position];
+        long diff = (long)to - (long)from;
+        if (diff < INT16_MIN || diff > INT16_MAX) {
+          FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
+          return emit_error(errdetail, ERR_COMP_SYNTAX, "jump offset out of range: %ld", diff);
+        }
+        write_u16(out, (uint16_t)(int16_t)diff);
+        break;
+      }
+      case IR_OP_ITEM_PUSH_LAYER: {
+        const char *s = (const char *)(intptr_t)in->imm;
+        size_t len = strlen(s);
+        if (len > UINT8_MAX) {
+          FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
+          return emit_error(errdetail, ERR_COMP_SYNTAX, "layer name too long: %zu", len);
+        }
+        write_u8(out, (uint8_t)len);
+        ensure_out(out, len);
+        memcpy(out->nextbyte, s, len);
+        out->nextbyte += len;
+        break;
+      }
+      default: break;
+    }
+  }
+
+  FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
+  return ERR_NOERROR;
+}

--- a/src/emitbc.h
+++ b/src/emitbc.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "ir.h"
+#include "parser.h"
+
+int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
+                     OUTPUT_t *out, char **errdetail);

--- a/src/scomp.c
+++ b/src/scomp.c
@@ -14,6 +14,7 @@
 #include "ir.h"
 #include "memory.h"
 #include "log.h"
+#include "emitbc.h"
 
 // Things which need to be known
 CONFIG_t config;
@@ -79,18 +80,27 @@ int main(int argc, char **argv) {
         logerr("Compilation failed.\n");
       }
     }
-// FIXME: WE HAVEN'T COMPILED THE BYTECODE YET! ONLY THE ABSTRACT SYNTAX!
-//    logmsg("Compilation completed: %ld bytes.\n",
-//                                          out->nextbyte - out->bytecode);
-//    FILE *output;
-//    output = fopen(argv[2], "w");
-//    if (!output) {
-//      printf("Unable to open output file.");
-//      exit(1);
-//    } else {
-//      fwrite(out->bytecode, out->nextbyte - out->bytecode, 1, output);
-//      fclose(output);
-//    }
+      if (result == ERR_NOERROR) {
+        uint8_t param_count = 0;
+        for (uint32_t i = 0; i < ctx->count; i++) {
+          if (ctx->locals[i].param) param_count++;
+        }
+        result = emit_bytecode(ir, (uint8_t)ctx->count, param_count, out, &errdetail);
+      }
+
+      if (result == ERR_NOERROR) {
+        logmsg("Compilation completed: %ld bytes.\n",
+               out->nextbyte - out->bytecode);
+        FILE *output;
+        output = fopen(argv[2], "w");
+        if (!output) {
+          printf("Unable to open output file.");
+          exit(1);
+        } else {
+          fwrite(out->bytecode, out->nextbyte - out->bytecode, 1, output);
+          fclose(output);
+        }
+      }
   } else {
     logerr("Error: (#%d) %s\n", result, errmsg[result]);
     logerr("Detail: %s\n", errdetail);


### PR DESCRIPTION
### Motivation

- Provide a backend that lowers validated IR into the VM's concrete bytecode so compiled programs can be executed by the interpreter.
- Resolve control-flow labels to signed 16-bit jump offsets, which requires computing instruction byte positions before emission.
- Emit the bytecode header (`locals` and `params`) per the layout in `bytecode.txt` so the VM can initialize frames correctly.
- Reuse the existing `OUTPUT_t` growth semantics so the emitter can write into the same expandable output buffer used elsewhere.

### Description

- Added `src/emitbc.h` and `src/emitbc.c` implementing `int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count, OUTPUT_t *out, char **errdetail)` to convert IR instructions into VM opcodes and operands.
- Implemented a two-pass emission strategy where pass 1 computes per-instruction byte positions (`inst_size`) and pass 2 writes opcodes/operands and signed 16-bit jump offsets (with range checks) using an opcode map derived from `opcodes.txt`.
- Serializes operands for `PUSH_INT`, `PUSH_STRING`, local indices, layer names, and other instruction formats, and emits the 2-byte header (`locals`, `params`) before the instruction stream.
- Integrated the emitter into `scomp` by computing parameter count from `ctx->locals`, calling `emit_bytecode(...)` after `ir_validate`, and updated the `Makefile` to build `emitbc.o` into the shared library.
- Ensured the emitter uses and extends `OUTPUT_t` growth logic (`ensure_out`, `GROW_ARRAY`) so `out->nextbyte`/`out->maxsize` are maintained correctly.

### Testing

- Built the project with `make -j4 scomp`, which completed successfully.
- Compiled an example with `./scomp examples/echo-boot.src /tmp/out.bc`, which ran successfully and produced output.
- Verified the emitted file size with `wc -c /tmp/out.bc`, which returned a non-zero byte count (validated emission completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe437ccea0832ea63fd7ee15297709)