### PR TITLE
Add hermetic compiler test target and helper test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ SRC_DIR := src
 OBJ_DIR := obj
 LIB_DIR := lib
 
+# Test runner
+TEST_DIR := tests
+TEST_BIN := $(TEST_DIR)/test-compiler
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c
+
+
 # Library of shared functions
 LIB := $(LIB_DIR)/libsinshared.a
 LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o \
@@ -48,7 +54,7 @@ $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	@mkdir -p $(@D)
 	$(CC) -c $(CFLAGS) $(DEBUG) $< -o $@
 
-.PHONY: all clean lib
+.PHONY: all clean lib test-compiler
 
 all: $(LIB) scomp sdiss sin
 
@@ -84,7 +90,12 @@ $(OBJ_DIR)/lexer.o: $(SRC_DIR)/lexer.c
 # Include dependency files
 -include $(DEPS)
 
+test-compiler: $(TEST_BIN)
+
+$(TEST_BIN): $(TEST_SOURCES) $(LIB)
+	$(CC) $(CFLAGS) $(DEBUG) -Isrc -o $@ $(TEST_SOURCES) $(LIB) $(LDFLAGS) $(LIBS)
+
 clean:
 	rm -rf $(OBJ_DIR)/*.o $(OBJ_DIR)/*.d $(LIB) $(LIB_DIR) \
-         $(PARSER_GENERATED) $(LEXER_GENERATED)
+         $(PARSER_GENERATED) $(LEXER_GENERATED) $(TEST_BIN)
 

--- a/tests/test_assert.h
+++ b/tests/test_assert.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_FAILF(fmt, ...) \
+  do { \
+    fprintf(stderr, "ASSERTION FAILED at %s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+    exit(1); \
+  } while (0)
+
+#define ASSERT_TRUE(cond) \
+  do { \
+    if (!(cond)) { \
+      TEST_FAILF("%s", #cond); \
+    } \
+  } while (0)
+
+#define ASSERT_EQ_INT(expected, actual) \
+  do { \
+    long long _exp = (long long)(expected); \
+    long long _act = (long long)(actual); \
+    if (_exp != _act) { \
+      TEST_FAILF("expected %lld, got %lld", _exp, _act); \
+    } \
+  } while (0)
+
+#define ASSERT_NOT_NULL(ptr) \
+  do { \
+    if ((ptr) == NULL) { \
+      TEST_FAILF("%s was NULL", #ptr); \
+    } \
+  } while (0)

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -1,0 +1,53 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "ir.h"
+#include "test_assert.h"
+#include "test_helpers.h"
+
+static void test_absyn_helpers(void) {
+  AS_NODE *lhs = t_int(1);
+  AS_NODE *rhs = t_int(2);
+  AS_NODE *sum = t_node(N_ADD, lhs, rhs);
+  AS_NODE *stmt = t_node(N_EXPRSTMT, sum, NULL);
+  AS_NODE *list = t_stmtlist_with_one(stmt);
+
+  ASSERT_NOT_NULL(list);
+  ASSERT_EQ_INT(N_STMTLIST, list->nodetype);
+  ASSERT_TRUE(((AS_STMTLIST *)list->lhs)->count == 1);
+
+  as_delete(list);
+}
+
+static void test_ir_and_emitbc_helpers(void) {
+  IR_Unit *unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+
+  int32_t done = ir_new_label(unit);
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = 7});
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP, .a = done});
+  t_bind(unit, done);
+  t_emit(unit, (IR_Inst){.op = IR_OP_LABEL, .a = done});
+  t_emit(unit, (IR_Inst){.op = IR_OP_HALT});
+
+  OUTPUT_t out = {0};
+  out.maxsize = 64;
+  out.bytecode = malloc(out.maxsize);
+  out.nextbyte = out.bytecode;
+  ASSERT_NOT_NULL(out.bytecode);
+
+  char *errdetail = NULL;
+  int8_t rc = t_emit_bytecode(unit, 0, 0, &out, &errdetail);
+  ASSERT_EQ_INT(0, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_TRUE((size_t)(out.nextbyte - out.bytecode) > 0);
+
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+}
+
+int main(void) {
+  test_absyn_helpers();
+  test_ir_and_emitbc_helpers();
+  return 0;
+}

--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -1,0 +1,41 @@
+#include "test_helpers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+AS_NODE *t_int(int64_t value) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%lld", (long long)value);
+  return as_new_valnode(V_INT, strdup(buf));
+}
+
+AS_NODE *t_local(const char *name) {
+  return as_new_valnode(V_LOCAL, strdup(name));
+}
+
+AS_NODE *t_node(ENUM_NODE nodetype, void *lhs, void *rhs) {
+  return as_new_node(nodetype, lhs, rhs);
+}
+
+AS_NODE *t_stmtlist_with_one(AS_NODE *stmt) {
+  AS_NODE *list = as_new_stmtlist_node();
+  return as_stmtlist_append(list, stmt);
+}
+
+IR_Unit *t_new_unit(void) {
+  return ir_create_unit();
+}
+
+void t_emit(IR_Unit *unit, IR_Inst inst) {
+  (void)ir_emit(unit, inst);
+}
+
+void t_bind(IR_Unit *unit, int32_t label_id) {
+  (void)ir_bind_label(unit, label_id);
+}
+
+int8_t t_emit_bytecode(IR_Unit *unit, uint8_t local_count, uint8_t param_count,
+                       OUTPUT_t *out, char **errdetail) {
+  return emit_bytecode(unit, local_count, param_count, out, errdetail);
+}

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "absyn.h"
+#include "emitbc.h"
+#include "ir.h"
+
+AS_NODE *t_int(int64_t value);
+AS_NODE *t_local(const char *name);
+AS_NODE *t_node(ENUM_NODE nodetype, void *lhs, void *rhs);
+AS_NODE *t_stmtlist_with_one(AS_NODE *stmt);
+
+IR_Unit *t_new_unit(void);
+void t_emit(IR_Unit *unit, IR_Inst inst);
+void t_bind(IR_Unit *unit, int32_t label_id);
+
+int8_t t_emit_bytecode(IR_Unit *unit, uint8_t local_count, uint8_t param_count,
+                       OUTPUT_t *out, char **errdetail);


### PR DESCRIPTION
### Motivation
- Provide a small, hermetic C test runner that exercises AST helpers, IR construction, and bytecode emission without starting the VM, using network, or relying on filesystem inputs. 
- Make it easy to run fast compiler-unit tests from the top-level `Makefile` via a dedicated `test-compiler` target. 
- Offer simple assertion and helper APIs so future tests can build AST/IR fragments and call `emit_bytecode` directly.

### Description
- Added a new Makefile test runner: defined `TEST_DIR`, `TEST_BIN`, `TEST_SOURCES`, added `test-compiler` to `.PHONY`, created a `test-compiler` target that compiles `tests/test_compiler.c` and `tests/test_helpers.c` against the shared library, and wired `$(TEST_BIN)` into `clean`. 
- Added `tests/test_assert.h` providing minimal assertion macros (`TEST_FAILF`, `ASSERT_TRUE`, `ASSERT_EQ_INT`, `ASSERT_NOT_NULL`) that print file/line and exit non-zero on failure. 
- Added test helper wrappers in `tests/test_helpers.h`/`tests/test_helpers.c` to construct AST nodes (`t_int`, `t_local`, `t_node`, `t_stmtlist_with_one`) using `as_new_valnode`, `as_new_node`, `as_stmtlist_append`, and to manage IR operations (`t_new_unit` -> `ir_create_unit`, `t_emit` -> `ir_emit`, `t_bind` -> `ir_bind_label`) and to call `emit_bytecode`. 
- Added `tests/test_compiler.c` containing hermetic unit tests that validate AST list behavior and an IR+bytecode emission path that uses `ir_new_label`, `ir_emit`, `ir_bind_label`, and `emit_bytecode`. 
- Fixed a test helper memory ownership issue by `strdup`-ing string values passed to `as_new_valnode` to avoid invalid frees in the test harness.

### Testing
- Built the project and test binary with `make test-compiler`, which compiled the shared library and the test runner successfully. 
- Executed the test runner with `./tests/test-compiler`, which returned exit code `0` indicating all assertions passed. 
- An initial run produced `free(): invalid pointer` which was resolved by changing helper code to `strdup` string inputs, and after that change the test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe50d8d000832ebf1ba9bb25c03cad)