### PR TITLE
Add emit_bytecode header-focused unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c
 
 
 # Library of shared functions

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -5,6 +5,8 @@
 #include "test_assert.h"
 #include "test_helpers.h"
 
+void test_emitbc_header(void);
+
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
   AS_NODE *rhs = t_int(2);
@@ -49,5 +51,6 @@ static void test_ir_and_emitbc_helpers(void) {
 int main(void) {
   test_absyn_helpers();
   test_ir_and_emitbc_helpers();
+  test_emitbc_header();
   return 0;
 }

--- a/tests/test_emitbc_header.c
+++ b/tests/test_emitbc_header.c
@@ -1,0 +1,46 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "ir.h"
+#include "test_assert.h"
+#include "test_helpers.h"
+
+static void run_header_case(uint8_t local_count, uint8_t param_count,
+                            size_t expected_total_len, int add_halt) {
+  IR_Unit *unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+
+  if (add_halt) {
+    t_emit(unit, (IR_Inst){.op = IR_OP_HALT});
+  }
+
+  OUTPUT_t out = {0};
+  out.maxsize = 2;
+  out.bytecode = malloc(out.maxsize);
+  out.nextbyte = out.bytecode;
+  ASSERT_NOT_NULL(out.bytecode);
+
+  char *errdetail = NULL;
+  int8_t rc = t_emit_bytecode(unit, local_count, param_count, &out, &errdetail);
+  ASSERT_EQ_INT(0, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  size_t out_len = (size_t)(out.nextbyte - out.bytecode);
+  ASSERT_TRUE(out_len >= 2);
+  ASSERT_EQ_INT(local_count, out.bytecode[0]);
+  ASSERT_EQ_INT(param_count, out.bytecode[1]);
+  ASSERT_EQ_INT(expected_total_len, out_len);
+
+  if (add_halt) {
+    ASSERT_EQ_INT('h', out.bytecode[2]);
+  }
+
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+}
+
+void test_emitbc_header(void) {
+  run_header_case(0, 0, 2, 0);
+  run_header_case(UINT8_MAX, UINT8_MAX, 2, 0);
+  run_header_case(3, 5, 3, 1);
+}


### PR DESCRIPTION
### Motivation
- Ensure `emit_bytecode` correctly emits the 2-byte header and that emitted bytecode layout is stable for callers and tooling. 
- Cover edge-cases around `local_count`/`param_count` handling and empty instruction streams to prevent regressions in bytecode format.

### Description
- Added `tests/test_emitbc_header.c` which constructs tiny `IR_Unit` values and exercises `emit_bytecode` with a helper `run_header_case` that asserts output length is at least 2, `bytecode[0] == local_count`, `bytecode[1] == param_count`, and that instruction bytes begin at index 2 (verified by emitting a `IR_OP_HALT`).
- The new tests include edge cases for zero locals/params, `UINT8_MAX` (255) locals/params, and an empty instruction stream that should produce the minimal 2-byte header.
- Registered the test by declaring and invoking `test_emitbc_header()` from `tests/test_compiler.c`.
- Updated `Makefile` `TEST_SOURCES` to include `tests/test_emitbc_header.c` so the test runner is built with the rest of the test suite.

### Testing
- Built and ran the test runner with `make test-compiler` and `./tests/test-compiler`, which executed the new tests; the build and test run completed successfully (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fede699fd8832e9c36f925afba6bb3)