### PR TITLE
Add emitbc jump offset and label error tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c
 
 
 # Library of shared functions

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -8,6 +8,7 @@
 void test_emitbc_header(void);
 void test_emitbc_opcode_map(void);
 void test_emitbc_opcode_map_unsupported_ir_op(void);
+void test_emitbc_jumps(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -56,5 +57,6 @@ int main(void) {
   test_emitbc_header();
   test_emitbc_opcode_map();
   test_emitbc_opcode_map_unsupported_ir_op();
+  test_emitbc_jumps();
   return 0;
 }

--- a/tests/test_emitbc_jumps.c
+++ b/tests/test_emitbc_jumps.c
@@ -1,0 +1,160 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "error.h"
+#include "ir.h"
+#include "test_assert.h"
+#include "test_helpers.h"
+
+static OUTPUT_t t_out(void) {
+  OUTPUT_t out = {0};
+  out.maxsize = 64;
+  out.bytecode = malloc(out.maxsize);
+  out.nextbyte = out.bytecode;
+  ASSERT_NOT_NULL(out.bytecode);
+  return out;
+}
+
+static void test_emitbc_jump_forward_offsets(void) {
+  IR_Unit *unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+
+  int32_t l1 = ir_new_label(unit);
+  int32_t l2 = ir_new_label(unit);
+
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP, .a = l1});
+  t_emit(unit, (IR_Inst){.op = IR_OP_HALT});
+  t_bind(unit, l1);
+  t_emit(unit, (IR_Inst){.op = IR_OP_LABEL, .a = l1});
+
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP_IF_FALSE, .a = l2});
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = 1});
+  t_bind(unit, l2);
+  t_emit(unit, (IR_Inst){.op = IR_OP_LABEL, .a = l2});
+
+  OUTPUT_t out = t_out();
+  char *errdetail = NULL;
+  int8_t rc = t_emit_bytecode(unit, 0, 0, &out, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  ASSERT_EQ_INT('j', out.bytecode[2]);
+  ASSERT_EQ_INT(0x03, out.bytecode[3]);
+  ASSERT_EQ_INT(0x00, out.bytecode[4]);
+
+  ASSERT_EQ_INT('k', out.bytecode[6]);
+  ASSERT_EQ_INT(0x0B, out.bytecode[7]);
+  ASSERT_EQ_INT(0x00, out.bytecode[8]);
+
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+}
+
+static void test_emitbc_jump_backward_offset_negative(void) {
+  IR_Unit *unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+
+  int32_t loop = ir_new_label(unit);
+  t_bind(unit, loop);
+  t_emit(unit, (IR_Inst){.op = IR_OP_LABEL, .a = loop});
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = 7});
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP_IF_FALSE, .a = loop});
+
+  OUTPUT_t out = t_out();
+  char *errdetail = NULL;
+  int8_t rc = t_emit_bytecode(unit, 0, 0, &out, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  ASSERT_EQ_INT('k', out.bytecode[11]);
+  ASSERT_EQ_INT(0xF6, out.bytecode[12]);
+  ASSERT_EQ_INT(0xFF, out.bytecode[13]);
+
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+}
+
+static void test_emitbc_jump_label_errors(void) {
+  IR_Unit *unit = t_new_unit();
+  OUTPUT_t out = t_out();
+  char *errdetail = NULL;
+
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP, .a = -1});
+  ASSERT_TRUE(t_emit_bytecode(unit, 0, 0, &out, &errdetail) != ERR_NOERROR);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, "jump invalid label id") != NULL);
+  free(errdetail);
+  errdetail = NULL;
+  ir_destroy_unit(unit);
+
+  unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP_IF_FALSE, .a = 999});
+  ASSERT_TRUE(t_emit_bytecode(unit, 0, 0, &out, &errdetail) != ERR_NOERROR);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, "jump invalid label id") != NULL);
+  free(errdetail);
+  errdetail = NULL;
+  ir_destroy_unit(unit);
+
+  unit = t_new_unit();
+  int32_t unbound = ir_new_label(unit);
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP, .a = unbound});
+  ASSERT_TRUE(t_emit_bytecode(unit, 0, 0, &out, &errdetail) != ERR_NOERROR);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, "jump unbound label") != NULL);
+  free(errdetail);
+
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+}
+
+static void test_emitbc_jump_offset_out_of_range(void) {
+  const int filler_count = 3641;
+  IR_Unit *unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+
+  int32_t far = ir_new_label(unit);
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP, .a = far});
+  for (int i = 0; i < filler_count; i++) {
+    t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = i});
+  }
+  t_bind(unit, far);
+  t_emit(unit, (IR_Inst){.op = IR_OP_LABEL, .a = far});
+
+  OUTPUT_t out = t_out();
+  char *errdetail = NULL;
+  ASSERT_TRUE(t_emit_bytecode(unit, 0, 0, &out, &errdetail) != ERR_NOERROR);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, "jump offset out of range") != NULL);
+  free(errdetail);
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+
+  unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+  int32_t start = ir_new_label(unit);
+  t_bind(unit, start);
+  t_emit(unit, (IR_Inst){.op = IR_OP_LABEL, .a = start});
+  for (int i = 0; i < filler_count; i++) {
+    t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = i});
+  }
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP_IF_FALSE, .a = start});
+
+  out = t_out();
+  errdetail = NULL;
+  ASSERT_TRUE(t_emit_bytecode(unit, 0, 0, &out, &errdetail) != ERR_NOERROR);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, "jump offset out of range") != NULL);
+
+  free(errdetail);
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+}
+
+void test_emitbc_jumps(void) {
+  test_emitbc_jump_forward_offsets();
+  test_emitbc_jump_backward_offset_negative();
+  test_emitbc_jump_label_errors();
+  test_emitbc_jump_offset_out_of_range();
+}


### PR DESCRIPTION
### Motivation
- Verify that bytecode emission computes correct signed 16-bit little-endian displacements for `IR_OP_JUMP` and `IR_OP_JUMP_IF_FALSE` given the fixed `inst_size` layout in `src/emitbc.c`.
- Cover error cases for invalid label ids, unbound labels, and jump displacements that exceed `INT16_MIN..INT16_MAX` in both forward and backward directions.

### Description
- Add `tests/test_emitbc_jumps.c` with handcrafted IR programs that emit `IR_OP_LABEL`, `IR_OP_JUMP`, and `IR_OP_JUMP_IF_FALSE` and assert exact encoded offset bytes and negative displacements.
- Add assertions that invalid label ids and unbound labels return the expected error messages and that large displacements produce a `jump offset out of range` error.
- Wire the new test into the test runner by adding `test_emitbc_jumps()` to `tests/test_compiler.c` and include `tests/test_emitbc_jumps.c` in `Makefile` `TEST_SOURCES` so it builds into `tests/test-compiler`.

### Testing
- Ran `make test-compiler` to build the test binary and the build completed successfully.
- Executed the compiled test runner with `./tests/test-compiler` and the full test suite (including the new jump tests) passed.
- Note that `make test` is not a defined target in the repository and therefore fails if invoked directly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee0be9a30832ea3ce9b47ea351bd5)