### PR TITLE
Add ir_validate unit tests for success and rejection paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_ir_validate.c
 
 
 # Library of shared functions

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -9,6 +9,7 @@ void test_emitbc_header(void);
 void test_emitbc_opcode_map(void);
 void test_emitbc_opcode_map_unsupported_ir_op(void);
 void test_emitbc_jumps(void);
+void test_ir_validate(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -58,5 +59,6 @@ int main(void) {
   test_emitbc_opcode_map();
   test_emitbc_opcode_map_unsupported_ir_op();
   test_emitbc_jumps();
+  test_ir_validate();
   return 0;
 }

--- a/tests/test_ir_validate.c
+++ b/tests/test_ir_validate.c
@@ -1,0 +1,106 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "error.h"
+#include "ir.h"
+#include "test_assert.h"
+#include "test_helpers.h"
+
+static void assert_validate_error(IR_Unit *unit, uint32_t local_count,
+                                  int8_t expected_code,
+                                  const char *expected_substring) {
+  char *errdetail = NULL;
+  int8_t rc = ir_validate(unit, local_count, &errdetail);
+  ASSERT_EQ_INT(expected_code, rc);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, expected_substring) != NULL);
+  free(errdetail);
+}
+
+static void test_ir_validate_ok_case(void) {
+  IR_Unit *unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+
+  int32_t done = ir_new_label(unit);
+
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_STRING, .imm = (int64_t)(intptr_t)"std"});
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_STRING, .imm = (int64_t)(intptr_t)"f"});
+  t_emit(unit, (IR_Inst){.op = IR_OP_LIBCALL, .a = 0});
+  t_emit(unit, (IR_Inst){.op = IR_OP_LOAD_LOCAL, .a = 1});
+  t_emit(unit, (IR_Inst){.op = IR_OP_CALL, .a = 2});
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP, .a = done});
+  t_bind(unit, done);
+  t_emit(unit, (IR_Inst){.op = IR_OP_LABEL, .a = done});
+
+  char *errdetail = NULL;
+  ASSERT_EQ_INT(ERR_NOERROR, ir_validate(unit, 2, &errdetail));
+  ASSERT_TRUE(errdetail == NULL);
+
+  ir_destroy_unit(unit);
+}
+
+static void test_ir_validate_unbound_label_rejected(void) {
+  IR_Unit *unit = t_new_unit();
+  int32_t l0 = ir_new_label(unit);
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP, .a = l0});
+
+  assert_validate_error(unit, 0, ERR_COMP_SYNTAX, "Unbound label");
+  ir_destroy_unit(unit);
+}
+
+static void test_ir_validate_invalid_label_ids_rejected(void) {
+  IR_Unit *unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP, .a = -1});
+  assert_validate_error(unit, 0, ERR_COMP_SYNTAX, "references invalid label id");
+  ir_destroy_unit(unit);
+
+  unit = t_new_unit();
+  int32_t l0 = ir_new_label(unit);
+  t_bind(unit, l0);
+  t_emit(unit, (IR_Inst){.op = IR_OP_LABEL, .a = 999});
+  assert_validate_error(unit, 0, ERR_COMP_SYNTAX, "references invalid label id");
+  ir_destroy_unit(unit);
+}
+
+static void test_ir_validate_local_index_out_of_range_rejected(void) {
+  IR_Unit *unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = IR_OP_STORE_LOCAL, .a = 2});
+
+  assert_validate_error(unit, 2, ERR_COMP_LOCALBEFOREDEF, "out-of-range local index");
+  ir_destroy_unit(unit);
+}
+
+static void test_ir_validate_negative_arity_rejected(void) {
+  IR_Unit *unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = IR_OP_CALL, .a = -1});
+  assert_validate_error(unit, 0, ERR_COMP_TOOMANYARGS, "negative arity");
+  ir_destroy_unit(unit);
+
+  unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_STRING, .imm = (int64_t)(intptr_t)"lib"});
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_STRING, .imm = (int64_t)(intptr_t)"func"});
+  t_emit(unit, (IR_Inst){.op = IR_OP_LIBCALL, .a = -2});
+  assert_validate_error(unit, 0, ERR_COMP_TOOMANYARGS, "negative arity");
+  ir_destroy_unit(unit);
+}
+
+static void test_ir_validate_libcall_requires_two_push_string_operands(void) {
+  IR_Unit *unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = 123});
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_STRING, .imm = (int64_t)(intptr_t)"func"});
+  t_emit(unit, (IR_Inst){.op = IR_OP_LIBCALL, .a = 0});
+
+  assert_validate_error(unit, 0, ERR_COMP_SYNTAX,
+                        "must be preceded by two PUSH_STRING");
+  ir_destroy_unit(unit);
+}
+
+void test_ir_validate(void) {
+  test_ir_validate_ok_case();
+  test_ir_validate_unbound_label_rejected();
+  test_ir_validate_invalid_label_ids_rejected();
+  test_ir_validate_local_index_out_of_range_rejected();
+  test_ir_validate_negative_arity_rejected();
+  test_ir_validate_libcall_requires_two_push_string_operands();
+}


### PR DESCRIPTION
### Motivation
- Provide direct unit coverage for `ir_validate()` to ensure validation logic rejects malformed IR and accepts valid sequences.
- Catch regressions in label handling, local-index bounds, call arity checking, and `LIBCALL` operand preconditions by exercising negative and positive cases.

### Description
- Add `tests/test_ir_validate.c` which exercises `ir_validate()` with a positive case and negative cases for unbound labels, invalid label ids, out-of-range local indexes, negative arity for `IR_OP_CALL`/`IR_OP_LIBCALL`, and missing `PUSH_STRING` operands before `IR_OP_LIBCALL`.
- Each negative test asserts both the returned error code and that `errdetail` contains a key substring (for example, `Unbound label`, `out-of-range local index`, `negative arity`, `must be preceded by two PUSH_STRING`).
- Wire the new tests into the test runner by declaring and invoking `test_ir_validate()` from `tests/test_compiler.c` and registering `tests/test_ir_validate.c` in `TEST_SOURCES` in the `Makefile`.

### Testing
- Built the test runner with `make test-compiler` and executed the binary with `./tests/test-compiler`, which completed successfully.
- All added test cases in `tests/test_ir_validate.c` passed when run as part of the full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee6265fac832e90c8eb79a1af8c35)