### PR TITLE
Add absyn lifecycle construction and cleanup tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_ir_validate.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_absyn_lifecycle.c
 
 
 # Library of shared functions

--- a/tests/test_absyn_lifecycle.c
+++ b/tests/test_absyn_lifecycle.c
@@ -1,0 +1,95 @@
+#include <string.h>
+
+#include "absyn.h"
+#include "test_assert.h"
+#include "test_helpers.h"
+
+void test_absyn_nested_binary_expressions(void) {
+  AS_NODE *left = t_node(N_ADD, t_int(1), t_int(2));
+  AS_NODE *right = t_node(N_SUB, t_int(8), t_int(3));
+  AS_NODE *root = t_node(N_MUL, left, right);
+
+  ASSERT_EQ_INT(N_MUL, root->nodetype);
+  ASSERT_EQ_INT(N_ADD, ((AS_NODE *)root->lhs)->nodetype);
+  ASSERT_EQ_INT(N_SUB, ((AS_NODE *)root->rhs)->nodetype);
+  ASSERT_EQ_INT(N_VALUE, ((AS_NODE *)((AS_NODE *)root->lhs)->lhs)->nodetype);
+  ASSERT_EQ_INT(N_VALUE, ((AS_NODE *)((AS_NODE *)root->rhs)->rhs)->nodetype);
+
+  as_delete(root);
+}
+
+void test_absyn_stmtlist_multiple_statements(void) {
+  AS_NODE *stmtlist = as_new_stmtlist_node();
+  AS_NODE *stmt1 = t_node(N_EXPRSTMT, t_int(10), NULL);
+  AS_NODE *stmt2 = t_node(N_EXPRSTMT, t_node(N_ADD, t_int(3), t_int(4)), NULL);
+  AS_NODE *stmt3 = t_node(N_RETURN, t_local("answer"), NULL);
+
+  as_stmtlist_append(stmtlist, stmt1);
+  as_stmtlist_append(stmtlist, stmt2);
+  as_stmtlist_append(stmtlist, stmt3);
+
+  AS_STMTLIST *list = (AS_STMTLIST *)stmtlist->lhs;
+  ASSERT_EQ_INT(N_STMTLIST, stmtlist->nodetype);
+  ASSERT_EQ_INT(3, list->count);
+  ASSERT_TRUE(list->stmts[0] == stmt1);
+  ASSERT_TRUE(list->stmts[1] == stmt2);
+  ASSERT_TRUE(list->stmts[2] == stmt3);
+
+  as_delete(stmtlist);
+}
+
+void test_absyn_if_elsif_else_chain(void) {
+  AS_IF *else_branch = as_new_if(NULL, t_stmtlist_with_one(t_node(N_RETURN, t_int(0), NULL)), NULL);
+  AS_IF *elsif_branch = as_new_if(t_node(N_GT, t_int(10), t_int(5)),
+                                  t_stmtlist_with_one(t_node(N_RETURN, t_int(1), NULL)),
+                                  else_branch);
+  AS_IF *if_chain = as_new_if(t_node(N_EQUAL, t_int(2), t_int(2)),
+                              t_stmtlist_with_one(t_node(N_RETURN, t_int(2), NULL)),
+                              elsif_branch);
+
+  AS_NODE *if_stmt = as_new_node(N_IFSTMT, if_chain, NULL);
+
+  ASSERT_EQ_INT(N_IFSTMT, if_stmt->nodetype);
+  AS_IF *root_if = (AS_IF *)if_stmt->lhs;
+  ASSERT_NOT_NULL(root_if->condition);
+  ASSERT_EQ_INT(N_EQUAL, root_if->condition->nodetype);
+  ASSERT_NOT_NULL(root_if->elsif);
+  ASSERT_EQ_INT(N_GT, root_if->elsif->condition->nodetype);
+  ASSERT_NOT_NULL(root_if->elsif->elsif);
+  ASSERT_TRUE(root_if->elsif->elsif->condition == NULL);
+
+  as_delete(if_stmt);
+}
+
+void test_absyn_item_deref_chains(void) {
+  AS_NODE *chain =
+      t_node(N_ITEM,
+             t_node(N_DEREF,
+                    t_node(N_ITEM,
+                           t_node(N_DEREF,
+                                  t_node(N_VALUE, as_new_value(V_LOCAL, 0, strdup("player")), NULL),
+                                  NULL),
+                           t_node(N_ITEM,
+                                  t_node(N_VALUE, as_new_value(V_LAYER, 0, strdup("stats")), NULL),
+                                  NULL)),
+                    NULL),
+             t_node(N_ITEM,
+                    t_node(N_VALUE, as_new_value(V_LOCAL, 0, strdup("hp")), NULL),
+                    NULL));
+
+  ASSERT_EQ_INT(N_ITEM, chain->nodetype);
+  AS_NODE *first = (AS_NODE *)chain->lhs;
+  ASSERT_EQ_INT(N_DEREF, first->nodetype);
+  AS_NODE *inner_item = (AS_NODE *)first->lhs;
+  ASSERT_EQ_INT(N_ITEM, inner_item->nodetype);
+  AS_NODE *local_value = (AS_NODE *)((AS_NODE *)inner_item->lhs)->lhs;
+  ASSERT_EQ_INT(N_VALUE, local_value->nodetype);
+  ASSERT_EQ_INT(V_LOCAL, ((AS_VALUE *)local_value->lhs)->valtype);
+  AS_NODE *layer_item = (AS_NODE *)inner_item->rhs;
+  ASSERT_EQ_INT(N_ITEM, layer_item->nodetype);
+  ASSERT_EQ_INT(V_LAYER, ((AS_VALUE *)((AS_NODE *)layer_item->lhs)->lhs)->valtype);
+  ASSERT_EQ_INT(V_LOCAL, ((AS_VALUE *)((AS_NODE *)((AS_NODE *)chain->rhs)->lhs)->lhs)->valtype);
+
+  as_delete(chain);
+}
+

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -10,6 +10,10 @@ void test_emitbc_opcode_map(void);
 void test_emitbc_opcode_map_unsupported_ir_op(void);
 void test_emitbc_jumps(void);
 void test_ir_validate(void);
+void test_absyn_nested_binary_expressions(void);
+void test_absyn_stmtlist_multiple_statements(void);
+void test_absyn_if_elsif_else_chain(void);
+void test_absyn_item_deref_chains(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -60,5 +64,9 @@ int main(void) {
   test_emitbc_opcode_map_unsupported_ir_op();
   test_emitbc_jumps();
   test_ir_validate();
+  test_absyn_nested_binary_expressions();
+  test_absyn_stmtlist_multiple_statements();
+  test_absyn_if_elsif_else_chain();
+  test_absyn_item_deref_chains();
   return 0;
 }


### PR DESCRIPTION
### Motivation

- Add unit tests that exercise representative AST construction paths so tree shape and child placement are validated.  
- Ensure recursive cleanup logic is exercised by calling `as_delete`/`as_delete_if` from each test to cover delete traversal code.  
- Provide a foundation for future sanitizer-based CI jobs (ASan/UBSan) to detect leaks and use-after-free in AST operations.

### Description

- Add `tests/test_absyn_lifecycle.c` containing tests for nested binary expression trees, multi-statement `N_STMTLIST` append ordering, IF/ELSIF/ELSE chains built with `as_new_if`, and item/deref chains using `N_ITEM`, `N_DEREF`, `V_LOCAL`, and `V_LAYER`, with each test invoking `as_delete` to free constructed trees.  
- Register and invoke the new tests from the test runner by declaring the functions and calling them in `tests/test_compiler.c`.  
- Include the new test source in the build by updating `TEST_SOURCES` in the `Makefile` to compile `tests/test_absyn_lifecycle.c` into `tests/test-compiler`.

### Testing

- Built the test runner with `make test-compiler` which completed successfully.  
- Ran the test binary with `./tests/test-compiler` and all tests executed and returned success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee754e3b0832ebfc33dd46dbab437)