### PR TITLE
Add fixture-driven golden bytecode pipeline tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_absyn_lifecycle.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_absyn_lifecycle.c
 
 
 # Library of shared functions

--- a/tests/fixtures/arithmetic_add.hex
+++ b/tests/fixtures/arithmetic_add.hex
@@ -1,0 +1,8 @@
+00 00          # header: locals=0 params=0
+70             # p: push int
+02 00 00 00 00 00 00 00  # 2
+70             # p: push int
+03 00 00 00 00 00 00 00  # 3
+61             # a: add
+00             # pop
+68             # h: halt

--- a/tests/fixtures/boolean_compare.hex
+++ b/tests/fixtures/boolean_compare.hex
@@ -1,0 +1,8 @@
+00 00          # header: locals=0 params=0
+70             # p: push int
+01 00 00 00 00 00 00 00  # 1
+70             # p: push int
+02 00 00 00 00 00 00 00  # 2
+72             # r: lt
+00             # pop
+68             # h: halt

--- a/tests/fixtures/int_literal.hex
+++ b/tests/fixtures/int_literal.hex
@@ -1,0 +1,5 @@
+00 00          # header: locals=0 params=0
+70             # p: push int
+2a 00 00 00 00 00 00 00  # int64 42 (LE)
+00             # pop (IR_OP_POP)
+68             # h: halt

--- a/tests/fixtures/locals_store_load.hex
+++ b/tests/fixtures/locals_store_load.hex
@@ -1,0 +1,7 @@
+01 00          # header: locals=1 params=0
+70             # p: push int
+07 00 00 00 00 00 00 00  # int64 7
+63 00          # c: store local 0
+65 00          # e: load local 0
+00             # pop
+68             # h: halt

--- a/tests/fixtures/simple_if.hex
+++ b/tests/fixtures/simple_if.hex
@@ -1,0 +1,12 @@
+00 00          # header: locals=0 params=0
+70             # p: push int
+01 00 00 00 00 00 00 00  # 1
+70             # p: push int
+02 00 00 00 00 00 00 00  # 2
+72             # r: lt
+6b 0f 00       # k: jump_if_false +15 bytes
+70             # p: push int
+09 00 00 00 00 00 00 00  # 9
+00             # pop
+6a 02 00       # j: jump +2 bytes to end
+68             # h: halt

--- a/tests/fixtures/string_literal.hex
+++ b/tests/fixtures/string_literal.hex
@@ -1,0 +1,6 @@
+00 00          # header: locals=0 params=0
+6c             # l: push string
+02 00          # uint16 length=2
+68 69          # "hi"
+00             # pop
+68             # h: halt

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -9,6 +9,7 @@ void test_emitbc_header(void);
 void test_emitbc_opcode_map(void);
 void test_emitbc_opcode_map_unsupported_ir_op(void);
 void test_emitbc_jumps(void);
+void test_pipeline_golden(void);
 void test_ir_validate(void);
 void test_absyn_nested_binary_expressions(void);
 void test_absyn_stmtlist_multiple_statements(void);
@@ -63,6 +64,7 @@ int main(void) {
   test_emitbc_opcode_map();
   test_emitbc_opcode_map_unsupported_ir_op();
   test_emitbc_jumps();
+  test_pipeline_golden();
   test_ir_validate();
   test_absyn_nested_binary_expressions();
   test_absyn_stmtlist_multiple_statements();

--- a/tests/test_pipeline_golden.c
+++ b/tests/test_pipeline_golden.c
@@ -1,0 +1,153 @@
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "error.h"
+#include "lower.h"
+#include "semant.h"
+#include "test_assert.h"
+#include "test_helpers.h"
+
+typedef AS_NODE *(*AstBuilder)(void);
+
+typedef struct {
+  const char *name;
+  AstBuilder build;
+  const char *fixture_path;
+} GoldenCase;
+
+static AS_NODE *v_int(int64_t n) { return t_int(n); }
+static AS_NODE *v_str(const char *s) { return as_new_valnode(V_STR, strdup(s)); }
+
+static uint8_t hex_nibble(char c) {
+  if (c >= '0' && c <= '9') return (uint8_t)(c - '0');
+  if (c >= 'a' && c <= 'f') return (uint8_t)(10 + c - 'a');
+  if (c >= 'A' && c <= 'F') return (uint8_t)(10 + c - 'A');
+  return 0xFF;
+}
+
+static uint8_t *load_hex_fixture(const char *path, size_t *out_len) {
+  FILE *f = fopen(path, "rb");
+  ASSERT_NOT_NULL(f);
+  uint8_t *buf = NULL;
+  size_t cap = 0, len = 0;
+  int c;
+  while ((c = fgetc(f)) != EOF) {
+    if (isspace(c)) continue;
+    if (c == '#') {
+      while ((c = fgetc(f)) != EOF && c != '\n') {
+      }
+      continue;
+    }
+    uint8_t hi = hex_nibble((char)c);
+    ASSERT_TRUE(hi != 0xFF);
+    int c2 = fgetc(f);
+    ASSERT_TRUE(c2 != EOF);
+    uint8_t lo = hex_nibble((char)c2);
+    ASSERT_TRUE(lo != 0xFF);
+    if (len == cap) {
+      cap = cap ? cap * 2 : 32;
+      buf = realloc(buf, cap);
+      ASSERT_NOT_NULL(buf);
+    }
+    buf[len++] = (uint8_t)((hi << 4) | lo);
+  }
+  fclose(f);
+  *out_len = len;
+  return buf;
+}
+
+static void run_case(const GoldenCase *tc) {
+  AS_NODE *root = tc->build();
+  ASSERT_NOT_NULL(root);
+
+  SEM_CTX *sem = sem_create_ctx();
+  ASSERT_NOT_NULL(sem);
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(root, &errdetail, sem);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  IR_Unit *ir = NULL;
+  rc = lower_ast_to_ir(root, sem, &ir, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(ir);
+
+  OUTPUT_t out = {0};
+  out.maxsize = 64;
+  out.bytecode = malloc(out.maxsize);
+  out.nextbyte = out.bytecode;
+  ASSERT_NOT_NULL(out.bytecode);
+
+  rc = t_emit_bytecode(ir, (uint8_t)sem->count, 0, &out, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  size_t expected_len = 0;
+  uint8_t *expected = load_hex_fixture(tc->fixture_path, &expected_len);
+  size_t actual_len = (size_t)(out.nextbyte - out.bytecode);
+  ASSERT_EQ_INT((int)expected_len, (int)actual_len);
+  ASSERT_EQ_INT(0, memcmp(expected, out.bytecode, expected_len));
+
+  free(expected);
+  free(out.bytecode);
+  ir_destroy_unit(ir);
+  sem_delete_ctx(sem);
+  as_delete(root);
+}
+
+static AS_NODE *build_int_literal_program(void) {
+  AS_NODE *stmt = t_node(N_EXPRSTMT, v_int(42), NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_string_literal_program(void) {
+  AS_NODE *stmt = t_node(N_EXPRSTMT, v_str("hi"), NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_locals_store_load_program(void) {
+  AS_NODE *list = as_new_stmtlist_node();
+  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("x"), v_int(7)));
+  list = as_stmtlist_append(list, t_node(N_EXPRSTMT, t_local("x"), NULL));
+  return list;
+}
+
+static AS_NODE *build_arithmetic_program(void) {
+  AS_NODE *add = t_node(N_ADD, v_int(2), v_int(3));
+  AS_NODE *stmt = t_node(N_EXPRSTMT, add, NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_boolean_compare_program(void) {
+  AS_NODE *cmp = t_node(N_LT, v_int(1), v_int(2));
+  AS_NODE *stmt = t_node(N_EXPRSTMT, cmp, NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_simple_if_program(void) {
+  AS_NODE *then_list = as_new_stmtlist_node();
+  then_list = as_stmtlist_append(then_list, t_node(N_EXPRSTMT, v_int(9), NULL));
+  AS_IF *branch = as_new_if(t_node(N_LT, v_int(1), v_int(2)), then_list, NULL);
+  AS_NODE *ifstmt = t_node(N_IFSTMT, branch, NULL);
+  AS_NODE *list = as_new_stmtlist_node();
+  return as_stmtlist_append(list, ifstmt);
+}
+
+void test_pipeline_golden(void) {
+  const GoldenCase cases[] = {
+      {"int_literal", build_int_literal_program, "tests/fixtures/int_literal.hex"},
+      {"string_literal", build_string_literal_program, "tests/fixtures/string_literal.hex"},
+      {"locals_store_load", build_locals_store_load_program, "tests/fixtures/locals_store_load.hex"},
+      {"arithmetic_add", build_arithmetic_program, "tests/fixtures/arithmetic_add.hex"},
+      {"boolean_compare", build_boolean_compare_program, "tests/fixtures/boolean_compare.hex"},
+      {"simple_if", build_simple_if_program, "tests/fixtures/simple_if.hex"},
+  };
+
+  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+    run_case(&cases[i]);
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide deterministic, end-to-end tests that validate the pipeline from AST through IR lowering to bytecode emission at the byte level.
- Capture stable primitives (integer and string literals, local store/load, arithmetic, boolean compare, and a simple conditional jump) so subsequent changes to encoding or lowering are detected by a golden baseline.
- Keep tests resilient to parser changes by building small ASTs directly and exercising semantic local resolution via `sem_check_locals` before lowering.

### Description

- Add `tests/test_pipeline_golden.c`, which contains per-case AST builders, a hex fixture loader that skips `#` comments and whitespace, and a runner that performs `sem_check_locals`, `lower_ast_to_ir`, and `emit_bytecode` then compares the exact output bytes to fixtures.
- Add hex-text fixtures under `tests/fixtures/*.hex` for the covered cases (`int_literal`, `string_literal`, `locals_store_load`, `arithmetic_add`, `boolean_compare`, `simple_if`) with per-byte comments mapping to opcode mnemonics.
- Wire the new test into the test runner by updating `tests/test_compiler.c` to call `test_pipeline_golden` and include the new source in the `Makefile` `TEST_SOURCES` list.
- Reuse existing test helpers (`t_int`, `t_local`, `t_node`, `t_stmtlist_with_one`, `t_emit_bytecode` wrappers) to build ASTs and invoke lowering/emit paths.

### Testing

- Ran `make test-compiler` which compiled the test runner and library successfully.
- Executed `./tests/test-compiler` and all tests including `test_pipeline_golden` passed.
- The added hex fixtures were exercised and the emitted byte arrays matched fixtures exactly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee80be014832e9a880d565cc50d2c)