### PR TITLE
Add core compiler CI gate and contributor checklist

### DIFF
--- a/.github/workflows/core-compiler-gate.yml
+++ b/.github/workflows/core-compiler-gate.yml
@@ -1,0 +1,39 @@
+name: Core compiler gate
+
+on:
+  pull_request:
+    paths:
+      - 'src/absyn.c'
+      - 'src/absyn.h'
+      - 'src/ir.c'
+      - 'src/ir.h'
+      - 'src/emitbc.c'
+      - 'src/emitbc.h'
+      - 'tests/**'
+      - 'Makefile'
+      - 'ci/gate_ir_absyn_emitbc.sh'
+      - '.github/workflows/core-compiler-gate.yml'
+  push:
+    paths:
+      - 'src/absyn.c'
+      - 'src/absyn.h'
+      - 'src/ir.c'
+      - 'src/ir.h'
+      - 'src/emitbc.c'
+      - 'src/emitbc.h'
+      - 'tests/**'
+      - 'Makefile'
+      - 'ci/gate_ir_absyn_emitbc.sh'
+      - '.github/workflows/core-compiler-gate.yml'
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential bison flex libuv1-dev
+      - name: Run core compiler gate
+        run: ./ci/gate_ir_absyn_emitbc.sh

--- a/README.md
+++ b/README.md
@@ -33,3 +33,16 @@ The echoserver is now running.  Telnet to port 4001 and watch it reflect your in
 ## Contributions ##
 Are welcomed.  In fact, they are positively encouraged.  Send me a pull request.  *This project uses the MIT License*.
 
+
+## Contributor Checklist ##
+Before opening or updating a PR, confirm the following where applicable:
+
+- **Any new `IR_Op`** includes all of:
+  - validator updates,
+  - emitter mapping update,
+  - opcode-spec update,
+  - at least one positive test and one negative test.
+- **Any bytecode format change** updates:
+  - `bytecode.txt`, and
+  - associated header/encoding tests.
+- If you touch `src/absyn.c/.h`, `src/ir.c/.h`, or `src/emitbc.c/.h`, make sure the core gate passes (`./ci/gate_ir_absyn_emitbc.sh`).

--- a/ci/gate_ir_absyn_emitbc.sh
+++ b/ci/gate_ir_absyn_emitbc.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Gate for core compiler subsystems. This script must pass before merge when
+# changes touch src/absyn.*, src/ir.*, or src/emitbc.*.
+
+make test-compiler
+./tests/test-compiler


### PR DESCRIPTION
### Motivation
- Prevent regressions in critical compiler subsystems by requiring tests to pass when `src/absyn.*`, `src/ir.*`, or `src/emitbc.*` are modified. 
- Document contributor expectations around adding new IR ops and making bytecode changes to keep opcode/bytecode specs and tests in sync. 
- Provide a reproducible local gate script and CI workflow so the check is enforced both locally and on PRs/pushes. 

### Description
- Add a GitHub Actions workflow at `.github/workflows/core-compiler-gate.yml` that triggers on PRs and pushes touching `src/absyn.*`, `src/ir.*`, `src/emitbc.*`, tests, `Makefile`, or the gate script, installs build deps, and runs the gate. 
- Add a local gate script `ci/gate_ir_absyn_emitbc.sh` which runs `make test-compiler` and `./tests/test-compiler` to build and execute the compiler test suite. 
- Update `README.md` with a contributor checklist requiring validator/emitter/opcode-spec/test updates for any new `IR_Op` and `bytecode.txt` plus header/encoding test updates for any bytecode format change, and noting the gate requirement when touching the targeted files. 

### Testing
- Ran `./ci/gate_ir_absyn_emitbc.sh` which invokes `make test-compiler` and `./tests/test-compiler`, and the script completed successfully. 
- The test build step compiled the library and test binary successfully when run locally. 
- The CI workflow was added and validated syntactically by committing the workflow file (no remote run performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feecf9ec84832e8a76a3df1d573924)