### PR TITLE
Harden scomp source file loading and usage text

### DIFF
--- a/src/scomp.c
+++ b/src/scomp.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include "config.h"
 #include "error.h"
@@ -22,15 +23,16 @@ CONFIG_t config;
 int main(int argc, char **argv) {
   char *source = NULL;
   char *errdetail = NULL;
-  int sourcelen;
+  int sourcelen = 0;
   uint8_t result = ERR_NOERROR;
   AS_NODE *absyn = NULL;
   SEM_CTX *ctx = NULL;
   IR_Unit *ir = NULL;
   OUTPUT_t *out = NULL;
+  init_errmsg();
 
   if (argc != 3) {
-    printf("Syntax: maketest <input file> <output file>\n");
+    printf("Syntax: scomp <input file> <output file>\n");
     return 1;
   }
 
@@ -40,11 +42,42 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  fseek(in, 0, SEEK_END);
-  sourcelen = ftell(in);
-  fseek(in, 0, SEEK_SET);
+  if (fseek(in, 0, SEEK_END) != 0) {
+    errdetail = GROW_ARRAY(char, NULL, 0, 128);
+    snprintf(errdetail, 128, "Unable to seek to end of input file '%s'.", argv[1]);
+    result = ERR_COMP_SYNTAX;
+    fclose(in);
+    goto compile_error;
+  }
+  long sourcefilelen = ftell(in);
+  if (sourcefilelen < 0 || sourcefilelen > INT_MAX) {
+    errdetail = GROW_ARRAY(char, NULL, 0, 160);
+    snprintf(errdetail, 160,
+             "Invalid input file length %ld for '%s' (must be 0..%d bytes).",
+             sourcefilelen, argv[1], INT_MAX);
+    result = ERR_COMP_SYNTAX;
+    fclose(in);
+    goto compile_error;
+  }
+  sourcelen = (int)sourcefilelen;
+  if (fseek(in, 0, SEEK_SET) != 0) {
+    errdetail = GROW_ARRAY(char, NULL, 0, 128);
+    snprintf(errdetail, 128, "Unable to rewind input file '%s'.", argv[1]);
+    result = ERR_COMP_SYNTAX;
+    fclose(in);
+    goto compile_error;
+  }
   source = GROW_ARRAY(char, NULL, 0, sourcelen);
-  fread(source, sourcelen, sizeof(char), in);
+  size_t bytesread = fread(source, sizeof(char), sourcelen, in);
+  if (bytesread != (size_t)sourcelen) {
+    errdetail = GROW_ARRAY(char, NULL, 0, 192);
+    snprintf(errdetail, 192,
+             "Input load failed for '%s': expected %d bytes but read %zu.",
+             argv[1], sourcelen, bytesread);
+    result = ERR_COMP_SYNTAX;
+    fclose(in);
+    goto compile_error;
+  }
   fclose(in);
   logmsg("Source loaded: %d bytes.\n", sourcelen);
 
@@ -54,7 +87,6 @@ int main(int argc, char **argv) {
   out->nextbyte = out->bytecode;
 
   logmsg("Parsing...\n");
-  init_errmsg();
   ctx = sem_create_ctx();
 
   result = parse_source(source, sourcelen, &absyn, &errdetail);


### PR DESCRIPTION
### Motivation

- Fix the incorrect CLI usage string and make it display the real executable name `scomp` instead of `maketest`.
- Prevent unsafe allocations by validating `fseek`/`ftell` results and rejecting negative or out-of-range input lengths before allocating a buffer.
- Detect short/partial `fread` results and emit a clear load/compile error while preserving the existing cleanup flow and providing informative `errdetail` messages.

### Description

- Updated the usage text printed by `main` to `Syntax: scomp <input file> <output file>`.
- Added `#include <limits.h>` and initialized `init_errmsg()` early so error messages are available for pre-parse failures.
- Replaced the previous unguarded `fseek`/`ftell` sequence with checks for `fseek` return values and `ftell` validity, rejecting negative or greater-than-`INT_MAX` lengths and setting `errdetail` with a descriptive message before jumping to `compile_error`.
- After allocation, replaced the unchecked `fread` with a verified read that compares `bytesread` to `sourcelen`, and on mismatch sets an informative `errdetail`, closes the input file, and routes to `compile_error`; all new error branches use `GROW_ARRAY` for `errdetail` and keep the `goto cleanup` behavior unchanged.

### Testing

- Ran `make -s` and the project built successfully with the updated `src/scomp.c`.
- Verified the modified program path and error paths compile cleanly under the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feefae5204832eb4f9a026118a6c80)