### PR TITLE
Make `sem_check_locals` reusable and return owned error detail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_absyn_lifecycle.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c
 
 
 # Library of shared functions

--- a/src/semant.c
+++ b/src/semant.c
@@ -65,6 +65,9 @@ void sem_delete_ctx(SEM_CTX *ctx) {
     FREE_ARRAY(char *, ctx->locals[i].name, 0);
   }
   FREE_ARRAY(SEM_LOCAL, ctx->locals, 0);
+  if (ctx->errdetail) {
+    free(ctx->errdetail);
+  }
   FREE_ARRAY(SEM_CTX, ctx, 0);
 }
 
@@ -136,12 +139,18 @@ static void sem_walk(SEM_CTX *ctx, AS_NODE *node) {
 }
 
 int8_t sem_check_locals(AS_NODE *root, char **errdetail, SEM_CTX *ctx) {
+  // sem_check_locals is reusable per SEM_CTX. It preserves discovered locals
+  // across calls, but resets and re-computes per-call error state.
+  if (ctx->errdetail) {
+    free(ctx->errdetail);
+    ctx->errdetail = NULL;
+  }
+  ctx->errnum = ERR_NOERROR;
+
   sem_walk(ctx, root);
 
   if (errdetail) {
-    *errdetail = ctx->errdetail;
-  } else if (ctx->errdetail) {
-    free(ctx->errdetail);
+    *errdetail = ctx->errdetail ? strdup(ctx->errdetail) : NULL;
   }
 
   return ctx->errnum;

--- a/src/semant.h
+++ b/src/semant.h
@@ -25,5 +25,10 @@ typedef struct {
 
 SEM_CTX *sem_create_ctx();
 void sem_delete_ctx(SEM_CTX *ctx);
+
+// Reusable per context:
+// - preserves discovered locals in ctx
+// - resets ctx error state on each call
+// - if errdetail is non-NULL, returns an owned heap copy (caller frees)
 int8_t sem_check_locals(AS_NODE *root, char **errdetail, SEM_CTX *ctx);
 bool sem_get_local_index(SEM_CTX *ctx, const char *name, uint8_t *index_out);

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -15,6 +15,7 @@ void test_absyn_nested_binary_expressions(void);
 void test_absyn_stmtlist_multiple_statements(void);
 void test_absyn_if_elsif_else_chain(void);
 void test_absyn_item_deref_chains(void);
+void test_sem_check_locals_reusable_context(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -70,5 +71,6 @@ int main(void) {
   test_absyn_stmtlist_multiple_statements();
   test_absyn_if_elsif_else_chain();
   test_absyn_item_deref_chains();
+  test_sem_check_locals_reusable_context();
   return 0;
 }

--- a/tests/test_semant.c
+++ b/tests/test_semant.c
@@ -1,0 +1,42 @@
+#include <string.h>
+#include <stdlib.h>
+
+#include "error.h"
+#include "semant.h"
+#include "test_assert.h"
+#include "test_helpers.h"
+
+void test_sem_check_locals_reusable_context(void) {
+  SEM_CTX *ctx = sem_create_ctx();
+  ASSERT_NOT_NULL(ctx);
+
+  AS_NODE *ok_stmt = t_node(N_ASSLOCAL, t_local("defined"), t_int(1));
+  AS_NODE *ok_prog = t_stmtlist_with_one(ok_stmt);
+
+  char *errdetail = (char *)0x1;
+  int8_t rc = sem_check_locals(ok_prog, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  AS_NODE *bad_stmt = t_node(N_EXPRSTMT, t_local("missing"), NULL);
+  AS_NODE *bad_prog = t_stmtlist_with_one(bad_stmt);
+
+  rc = sem_check_locals(bad_prog, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strcmp(errdetail, "missing") == 0);
+
+  char *first_errdetail = errdetail;
+
+  rc = sem_check_locals(bad_prog, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strcmp(errdetail, "missing") == 0);
+  ASSERT_TRUE(errdetail != first_errdetail);
+  free(first_errdetail);
+  free(errdetail);
+
+  as_delete(ok_prog);
+  as_delete(bad_prog);
+  sem_delete_ctx(ctx);
+}


### PR DESCRIPTION
### Motivation
- Unclear ownership/usage of `ctx->errdetail` made repeated calls to `sem_check_locals` on the same `SEM_CTX` error-prone and non-deterministic.  
- The goal is to allow reuse of a `SEM_CTX` across multiple calls while avoiding exposing internal pointers and leaking or double-freeing error detail.

### Description
- Documented the contract in `src/semant.h`: `sem_check_locals` is reusable per `SEM_CTX`, preserves discovered locals, and resets per-call error state; callers receive an owned copy of error detail.  
- In `src/semant.c` updated `sem_check_locals` to free any previous `ctx->errdetail`, reset `ctx->errnum` to `ERR_NOERROR` at entry, run semantic checks, and return an owned copy (`strdup`) into the caller-provided `errdetail` pointer.  
- Updated `sem_delete_ctx` to free any retained internal `ctx->errdetail` when destroying the context.  
- Added a focused test `tests/test_semant.c` (`test_sem_check_locals_reusable_context`) that calls `sem_check_locals` multiple times on the same `SEM_CTX` and verifies deterministic behavior and owned-copy semantics, and wired the test into `tests/test_compiler.c` and the `Makefile`.

### Testing
- Built the test runner with `make test-compiler` which completed successfully.  
- Ran the full test runner `./tests/test-compiler` and the new semantic test passed (test run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef08763c4832e92809cfbb5f9bd1e)