### PR TITLE
tests: deduplicate hex fixture loader helpers

### DIFF
--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -1,8 +1,11 @@
 #include "test_helpers.h"
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "test_assert.h"
 
 AS_NODE *t_int(int64_t value) {
   char buf[32];
@@ -38,4 +41,43 @@ void t_bind(IR_Unit *unit, int32_t label_id) {
 int8_t t_emit_bytecode(IR_Unit *unit, uint8_t local_count, uint8_t param_count,
                        OUTPUT_t *out, char **errdetail) {
   return emit_bytecode(unit, local_count, param_count, out, errdetail);
+}
+
+
+uint8_t hex_nibble(char c) {
+  if (c >= '0' && c <= '9') return (uint8_t)(c - '0');
+  if (c >= 'a' && c <= 'f') return (uint8_t)(10 + c - 'a');
+  if (c >= 'A' && c <= 'F') return (uint8_t)(10 + c - 'A');
+  return 0xFF;
+}
+
+uint8_t *load_hex_fixture(const char *path, size_t *out_len) {
+  FILE *f = fopen(path, "rb");
+  ASSERT_NOT_NULL(f);
+  uint8_t *buf = NULL;
+  size_t cap = 0, len = 0;
+  int c;
+  while ((c = fgetc(f)) != EOF) {
+    if (isspace(c)) continue;
+    if (c == '#') {
+      while ((c = fgetc(f)) != EOF && c != '\n') {
+      }
+      continue;
+    }
+    uint8_t hi = hex_nibble((char)c);
+    ASSERT_TRUE(hi != 0xFF);
+    int c2 = fgetc(f);
+    ASSERT_TRUE(c2 != EOF);
+    uint8_t lo = hex_nibble((char)c2);
+    ASSERT_TRUE(lo != 0xFF);
+    if (len == cap) {
+      cap = cap ? cap * 2 : 32;
+      buf = realloc(buf, cap);
+      ASSERT_NOT_NULL(buf);
+    }
+    buf[len++] = (uint8_t)((hi << 4) | lo);
+  }
+  fclose(f);
+  *out_len = len;
+  return buf;
 }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "absyn.h"
@@ -17,3 +18,6 @@ void t_bind(IR_Unit *unit, int32_t label_id);
 
 int8_t t_emit_bytecode(IR_Unit *unit, uint8_t local_count, uint8_t param_count,
                        OUTPUT_t *out, char **errdetail);
+
+uint8_t hex_nibble(char c);
+uint8_t *load_hex_fixture(const char *path, size_t *out_len);

--- a/tests/test_pipeline_golden.c
+++ b/tests/test_pipeline_golden.c
@@ -1,6 +1,4 @@
-#include <ctype.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -20,44 +18,6 @@ typedef struct {
 
 static AS_NODE *v_int(int64_t n) { return t_int(n); }
 static AS_NODE *v_str(const char *s) { return as_new_valnode(V_STR, strdup(s)); }
-
-static uint8_t hex_nibble(char c) {
-  if (c >= '0' && c <= '9') return (uint8_t)(c - '0');
-  if (c >= 'a' && c <= 'f') return (uint8_t)(10 + c - 'a');
-  if (c >= 'A' && c <= 'F') return (uint8_t)(10 + c - 'A');
-  return 0xFF;
-}
-
-static uint8_t *load_hex_fixture(const char *path, size_t *out_len) {
-  FILE *f = fopen(path, "rb");
-  ASSERT_NOT_NULL(f);
-  uint8_t *buf = NULL;
-  size_t cap = 0, len = 0;
-  int c;
-  while ((c = fgetc(f)) != EOF) {
-    if (isspace(c)) continue;
-    if (c == '#') {
-      while ((c = fgetc(f)) != EOF && c != '\n') {
-      }
-      continue;
-    }
-    uint8_t hi = hex_nibble((char)c);
-    ASSERT_TRUE(hi != 0xFF);
-    int c2 = fgetc(f);
-    ASSERT_TRUE(c2 != EOF);
-    uint8_t lo = hex_nibble((char)c2);
-    ASSERT_TRUE(lo != 0xFF);
-    if (len == cap) {
-      cap = cap ? cap * 2 : 32;
-      buf = realloc(buf, cap);
-      ASSERT_NOT_NULL(buf);
-    }
-    buf[len++] = (uint8_t)((hi << 4) | lo);
-  }
-  fclose(f);
-  *out_len = len;
-  return buf;
-}
 
 static void run_case(const GoldenCase *tc) {
   AS_NODE *root = tc->build();

--- a/tests/test_pipeline_source_golden.c
+++ b/tests/test_pipeline_source_golden.c
@@ -1,6 +1,4 @@
-#include <ctype.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -16,44 +14,6 @@ typedef struct {
   const char *source;
   const char *fixture_path;
 } SourceGoldenCase;
-
-static uint8_t hex_nibble(char c) {
-  if (c >= '0' && c <= '9') return (uint8_t)(c - '0');
-  if (c >= 'a' && c <= 'f') return (uint8_t)(10 + c - 'a');
-  if (c >= 'A' && c <= 'F') return (uint8_t)(10 + c - 'A');
-  return 0xFF;
-}
-
-static uint8_t *load_hex_fixture(const char *path, size_t *out_len) {
-  FILE *f = fopen(path, "rb");
-  ASSERT_NOT_NULL(f);
-  uint8_t *buf = NULL;
-  size_t cap = 0, len = 0;
-  int c;
-  while ((c = fgetc(f)) != EOF) {
-    if (isspace(c)) continue;
-    if (c == '#') {
-      while ((c = fgetc(f)) != EOF && c != '\n') {
-      }
-      continue;
-    }
-    uint8_t hi = hex_nibble((char)c);
-    ASSERT_TRUE(hi != 0xFF);
-    int c2 = fgetc(f);
-    ASSERT_TRUE(c2 != EOF);
-    uint8_t lo = hex_nibble((char)c2);
-    ASSERT_TRUE(lo != 0xFF);
-    if (len == cap) {
-      cap = cap ? cap * 2 : 32;
-      buf = realloc(buf, cap);
-      ASSERT_NOT_NULL(buf);
-    }
-    buf[len++] = (uint8_t)((hi << 4) | lo);
-  }
-  fclose(f);
-  *out_len = len;
-  return buf;
-}
 
 static void run_source_case(const SourceGoldenCase *tc) {
   AS_NODE *absyn = NULL;


### PR DESCRIPTION
### Motivation

- Reduce duplicated hex fixture parsing code across tests by centralizing the nibble/fixture loader helpers.  

### Description

- Add `hex_nibble()` and `load_hex_fixture()` declarations to `tests/test_helpers.h` and include `<stddef.h>` for `size_t`.  
- Implement `hex_nibble()` and `load_hex_fixture()` in `tests/test_helpers.c` with the same behavior as the previous copies (whitespace skipping, `#` comment skipping, nibble validation, dynamic buffer growth, and test assertions).  
- Remove the duplicated local implementations and related extraneous includes from `tests/test_pipeline_golden.c` and `tests/test_pipeline_source_golden.c` and use the shared helpers instead.  

### Testing

- Ran `make test`; the test binary compiled and tests ran successfully.  
- Ran `./tests/test-compiler`; it executed successfully and returned no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feff345b8c832eb286a4188eff8b21)