### PR TITLE
Add parser golden test for examples/*.obj outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_scomp_e2e_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_scomp_e2e_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c
 
 
 # Library of shared functions

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -20,6 +20,7 @@ void test_absyn_if_elsif_else_chain(void);
 void test_absyn_item_deref_chains(void);
 void test_sem_check_locals_reusable_context(void);
 void test_sdiss_fixture_basic(void);
+void test_parser_examples_obj_golden(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -80,5 +81,6 @@ int main(void) {
   test_absyn_item_deref_chains();
   test_sem_check_locals_reusable_context();
   test_sdiss_fixture_basic();
+  test_parser_examples_obj_golden();
   return 0;
 }

--- a/tests/test_parser_examples_obj_golden.c
+++ b/tests/test_parser_examples_obj_golden.c
@@ -1,0 +1,71 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "test_assert.h"
+
+typedef struct {
+  const char *name;
+  const char *src_path;
+  const char *obj_path;
+  const char *out_path;
+} ParserObjGoldenCase;
+
+static size_t file_size(FILE *f) {
+  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_END));
+  long n = ftell(f);
+  ASSERT_TRUE(n >= 0);
+  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_SET));
+  return (size_t)n;
+}
+
+static void run_case(const ParserObjGoldenCase *tc) {
+  char cmd[512];
+  int rc = snprintf(cmd, sizeof(cmd), "./scomp %s %s", tc->src_path, tc->out_path);
+  ASSERT_TRUE(rc > 0 && (size_t)rc < sizeof(cmd));
+
+  rc = system(cmd);
+  ASSERT_EQ_INT(0, rc);
+
+  FILE *expected_f = fopen(tc->obj_path, "rb");
+  ASSERT_NOT_NULL(expected_f);
+
+  FILE *actual_f = fopen(tc->out_path, "rb");
+  ASSERT_NOT_NULL(actual_f);
+
+  size_t expected_len = file_size(expected_f);
+  size_t actual_len = file_size(actual_f);
+  ASSERT_EQ_INT((int)expected_len, (int)actual_len);
+
+  uint8_t *expected = malloc(expected_len);
+  uint8_t *actual = malloc(actual_len);
+  ASSERT_NOT_NULL(expected);
+  ASSERT_NOT_NULL(actual);
+
+  size_t expected_read = fread(expected, 1, expected_len, expected_f);
+  size_t actual_read = fread(actual, 1, actual_len, actual_f);
+  ASSERT_EQ_INT((int)expected_len, (int)expected_read);
+  ASSERT_EQ_INT((int)actual_len, (int)actual_read);
+
+  ASSERT_EQ_INT(0, memcmp(expected, actual, expected_len));
+
+  fclose(expected_f);
+  fclose(actual_f);
+  free(expected);
+  free(actual);
+  remove(tc->out_path);
+}
+
+void test_parser_examples_obj_golden(void) {
+  const ParserObjGoldenCase cases[] = {
+      {"chat_boot", "examples/chat-boot.src", "examples/chat-boot.obj", "tests/fixtures/chat-boot.generated.obj"},
+      {"chat_load", "examples/chat-load.src", "examples/chat-load.obj", "tests/fixtures/chat-load.generated.obj"},
+      {"echo_boot", "examples/echo-boot.src", "examples/echo-boot.obj", "tests/fixtures/echo-boot.generated.obj"},
+      {"echo_load", "examples/echo-load.src", "examples/echo-load.obj", "tests/fixtures/echo-load.generated.obj"},
+  };
+
+  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+    run_case(&cases[i]);
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure the `scomp` parser/compiler produces identical object bytes for example sources by comparing generated objects to the known-good `examples/*.obj` files. 
- Detect regressions in parsing or bytecode emission for real example programs. 

### Description
- Add `tests/test_parser_examples_obj_golden.c` which runs `./scomp` on each `examples/*.src`, writes a generated object to `tests/fixtures/*.generated.obj`, and performs a byte-for-byte comparison with the corresponding `examples/*.obj` file. 
- Register the new test runner function in `tests/test_compiler.c` so it is invoked by the test binary. 
- Add the new test source to `TEST_SOURCES` in `Makefile` so it is compiled into `tests/test-compiler`. 
- Include `<stdint.h>` in the new test file to define `uint8_t` used for binary buffers. 

### Testing
- Built the test suite with `make test`, which produced the `tests/test-compiler` binary successfully. 
- Executed `./tests/test-compiler`, and the new golden test detected a mismatch for `examples/chat-boot` (expected 46 bytes, generated 57 bytes), causing the test run to fail as intended to surface the regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0777dd57c8832e8e9cb4dd583c79d6)