### PR TITLE
Lower integer item layers to strings for IR_OP_ITEM_PUSH_LAYER

### DIFF
--- a/src/emitbc.c
+++ b/src/emitbc.c
@@ -166,6 +166,10 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
       }
       case IR_OP_ITEM_PUSH_LAYER: {
         const char *s = (const char *)(intptr_t)in->imm;
+        if (!s) {
+          FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
+          return emit_error(errdetail, ERR_COMP_SYNTAX, "null layer name");
+        }
         size_t len = strlen(s);
         if (len > UINT8_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);

--- a/src/lower.c
+++ b/src/lower.c
@@ -58,7 +58,24 @@ static void lower_layer_part(LOWER_CTX *ctx, AS_NODE *part) {
                                  .imm = (int64_t)(intptr_t)value->value.s});
       return;
     case V_INT:
-      ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_ITEM_PUSH_LAYER, .imm = value->value.i});
+      {
+        char buf[32];
+        int len = snprintf(buf, sizeof(buf), "%lld", (long long)value->value.i);
+        char *layer = NULL;
+        if (len < 0 || (size_t)len >= sizeof(buf)) {
+          lower_set_error(ctx, ERR_COMP_SYNTAX, "invalid integer layer literal");
+          return;
+        }
+        layer = strdup(buf);
+        if (!layer) {
+          lower_set_error(ctx, ERR_COMP_SYNTAX, "out of memory formatting integer layer");
+          return;
+        }
+        value->valtype = V_STR;
+        value->value.s = layer;
+        ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_ITEM_PUSH_LAYER,
+                                   .imm = (int64_t)(intptr_t)layer});
+      }
       return;
     default:
       lower_set_unsupported(ctx, part, "unsupported item layer value type");

--- a/tests/test_pipeline_source_golden.c
+++ b/tests/test_pipeline_source_golden.c
@@ -142,6 +142,56 @@ static void test_source_exprstmt_libcall_no_pop(void) {
   as_delete(absyn);
 }
 
+static void test_source_item_with_numeric_layer(void) {
+  AS_NODE *absyn = NULL;
+  char *errdetail = NULL;
+  const char *source = "foo.12;";
+
+  int8_t rc = parse_source((char *)source, (int)strlen(source), &absyn, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(absyn);
+
+  SEM_CTX *sem = sem_create_ctx();
+  ASSERT_NOT_NULL(sem);
+  rc = sem_check_locals(absyn, &errdetail, sem);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  IR_Unit *ir = NULL;
+  rc = lower_ast_to_ir(absyn, sem, &ir, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(ir);
+
+  OUTPUT_t out = {0};
+  out.maxsize = 128;
+  out.bytecode = malloc(out.maxsize);
+  out.nextbyte = out.bytecode;
+  ASSERT_NOT_NULL(out.bytecode);
+
+  rc = t_emit_bytecode(ir, (uint8_t)sem->count, 0, &out, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  static const uint8_t expected[] = {
+      0x00, 0x00,
+      'I',
+      'L', 0x03, 'f', 'o', 'o',
+      'L', 0x02, '1', '2',
+      'E',
+      'h',
+  };
+  size_t n = (size_t)(out.nextbyte - out.bytecode);
+  ASSERT_EQ_INT((int)sizeof(expected), (int)n);
+  ASSERT_EQ_INT(0, memcmp(expected, out.bytecode, n));
+
+  free(out.bytecode);
+  ir_destroy_unit(ir);
+  sem_delete_ctx(sem);
+  as_delete(absyn);
+}
+
 void test_pipeline_source_golden(void) {
   const SourceGoldenCase cases[] = {
       {"int_literal", "42;", "tests/fixtures/int_literal.hex"},
@@ -156,4 +206,5 @@ void test_pipeline_source_golden(void) {
 
   test_source_pipeline_negative_cases();
   test_source_exprstmt_libcall_no_pop();
+  test_source_item_with_numeric_layer();
 }


### PR DESCRIPTION
### Motivation
- Ensure `IR_OP_ITEM_PUSH_LAYER` remains string-only on the emitter wire so it can represent both textual and numeric layers without changing bytecode format and without crashes.
- Make ownership/lifetime of allocated layer names consistent with existing literal handling so AST cleanup (`as_delete`) continues to free layer strings correctly.

### Description
- In `src/lower.c`, `lower_layer_part` now formats `V_INT` layer values to a heap-allocated decimal string via `snprintf` + `strdup`, updates the `AS_VALUE` to `V_STR` and emits `IR_OP_ITEM_PUSH_LAYER` with the string pointer immediate, matching the `V_LAYER`/`V_STR` path.
- In `src/emitbc.c`, kept the `IR_OP_ITEM_PUSH_LAYER` serialization unchanged but added a defensive null-pointer check before calling `strlen` to avoid crashes on unexpected null immediates.
- Added a regression test `test_source_item_with_numeric_layer` in `tests/test_pipeline_source_golden.c` that parses and compiles `foo.12;`, emits bytecode and asserts exact emitted bytes include `foo` and the string "12" as layer bytes.

### Testing
- Ran the full test suite with `make -j4 test`, and the test run completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0780f2060c832ea21cb5fe4def36d6)