### PR TITLE
Lower local increment/decrement to IR and add source golden tests

### DIFF
--- a/src/lower.c
+++ b/src/lower.c
@@ -380,6 +380,33 @@ static void lower_stmt(LOWER_CTX *ctx, AS_NODE *node) {
       return;
     }
 
+    case N_INC:
+    case N_DEC: {
+      AS_NODE *local = (AS_NODE *)node->lhs;
+      AS_VALUE *value;
+      uint8_t index = 0;
+
+      if (!local || local->nodetype != N_VALUE) {
+        lower_set_unsupported(ctx, node, "inc/dec target is not a local value");
+        return;
+      }
+
+      value = (AS_VALUE *)local->lhs;
+      if (!value || value->valtype != V_LOCAL || !value->value.s) {
+        lower_set_unsupported(ctx, node, "missing local inc/dec target");
+        return;
+      }
+
+      if (!ctx->sem || !sem_get_local_index(ctx->sem, value->value.s, &index)) {
+        lower_set_error(ctx, ERR_COMP_LOCALBEFOREDEF, value->value.s);
+        return;
+      }
+
+      ir_emit(ctx->ir, (IR_Inst){.op = node->nodetype == N_INC ? IR_OP_INC_LOCAL : IR_OP_DEC_LOCAL,
+                                 .a = index});
+      return;
+    }
+
     case N_ASSITEM:
       lower_item(ctx, (AS_NODE *)node->lhs);
       if (ctx->errnum != ERR_NOERROR) return;

--- a/tests/test_pipeline_source_golden.c
+++ b/tests/test_pipeline_source_golden.c
@@ -198,6 +198,8 @@ void test_pipeline_source_golden(void) {
       {"locals_store_load", "@x = 7; @x;", "tests/fixtures/locals_store_load.hex"},
       {"arithmetic_add", "2 + 3;", "tests/fixtures/arithmetic_add.hex"},
       {"if_elsif_else", "if 1 < 2 then 9; elsif 0 < 1 then 8; else 7; endif;", "tests/fixtures/if_elsif_else.hex"},
+      {"locals_inc", "@x = 1; @x++; @x;", "tests/fixtures/locals_inc.hex"},
+      {"locals_dec", "@x = 2; @x--; @x;", "tests/fixtures/locals_dec.hex"},
   };
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {


### PR DESCRIPTION
### Motivation
- Ensure `N_INC` and `N_DEC` statements targeting locals are lowered to the dedicated IR ops for correct runtime semantics.
- Reuse the same validation and error reporting used for `N_ASSLOCAL` to keep diagnostics consistent for undefined or malformed locals.
- Add pipeline-level golden tests to lock expected bytecode for common local inc/dec use-cases.

### Description
- Added `case N_INC:` and `case N_DEC:` branches inside `lower_stmt()` in `src/lower.c` that read `AS_NODE *local = (AS_NODE *)node->lhs` and validate the target shape (`nodetype == N_VALUE`, payload `AS_VALUE` with `valtype == V_LOCAL` and non-null `value.s`).
- Resolve the local slot with `sem_get_local_index(ctx->sem, value->value.s, &index)` and emit `IR_OP_INC_LOCAL` for `N_INC` or `IR_OP_DEC_LOCAL` for `N_DEC` (using node type to choose the op).
- Preserve existing error behavior for undefined locals by returning `ERR_COMP_LOCALBEFOREDEF` via `lower_set_error`, and reuse `lower_set_unsupported` for unsupported shapes.
- Extended `tests/test_pipeline_source_golden.c` to include two source golden cases: `@x = 1; @x++; @x;` and `@x = 2; @x--; @x;`, with corresponding fixtures added under `tests/fixtures/`.

### Testing
- Ran the full test suite via `make test` and the build-and-test run completed successfully with all tests passing.
- The new source golden cases are validated by `tests/test_pipeline_source_golden.c` which compares emitted bytecode against the added fixtures and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07832c2600832e8f3e55f4d1730472)