### PR TITLE
Add shared compiler diagnostic helper and standardize phase-tagged error details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LIB := $(LIB_DIR)/libsinshared.a
 LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o $(OBJ_DIR)/parser.o \
                $(OBJ_DIR)/lexer.o $(OBJ_DIR)/absyn.o $(OBJ_DIR)/semant.o \
                $(OBJ_DIR)/ir.o $(OBJ_DIR)/lower.o $(OBJ_DIR)/emitbc.o \
-               $(OBJ_DIR)/error.o $(OBJ_DIR)/util.o $(OBJ_DIR)/libcall.o \
+               $(OBJ_DIR)/compdiag.o $(OBJ_DIR)/error.o $(OBJ_DIR)/util.o $(OBJ_DIR)/libcall.o \
                $(OBJ_DIR)/stack.o $(OBJ_DIR)/value.o $(OBJ_DIR)/item.o \
                $(OBJ_DIR)/vm.o $(OBJ_DIR)/task.o $(OBJ_DIR)/interpret.o \
                $(OBJ_DIR)/network.o $(OBJ_DIR)/libtelnet.o

--- a/src/compdiag.c
+++ b/src/compdiag.c
@@ -1,0 +1,73 @@
+#include "compdiag.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "error.h"
+#include "memory.h"
+
+static char *compdiag_alloc_detail(const char *phase, const char *msg) {
+  const char *safe_phase = phase ? phase : "comp";
+  const char *safe_msg = msg ? msg : "unknown";
+
+  int needed = snprintf(NULL, 0, "%s: %s", safe_phase, safe_msg);
+  if (needed < 0) return NULL;
+
+  char *buf = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+  if (!buf) return NULL;
+
+  snprintf(buf, (size_t)needed + 1, "%s: %s", safe_phase, safe_msg);
+  return buf;
+}
+
+bool compdiag_set_once(int8_t *current_errnum, char **errdetail,
+                       int8_t new_errnum, const char *phase,
+                       const char *detail) {
+  if (!current_errnum || *current_errnum != ERR_NOERROR) return false;
+
+  *current_errnum = new_errnum;
+  if (errdetail) {
+    compdiag_reset_detail(errdetail);
+    *errdetail = compdiag_alloc_detail(phase, detail);
+  }
+  return true;
+}
+
+bool compdiag_setf_once(int8_t *current_errnum, char **errdetail,
+                        int8_t new_errnum, const char *phase,
+                        const char *fmt, ...) {
+  if (!current_errnum || *current_errnum != ERR_NOERROR) return false;
+
+  va_list args;
+  va_start(args, fmt);
+  int needed = vsnprintf(NULL, 0, fmt, args);
+  va_end(args);
+  if (needed < 0) {
+    return compdiag_set_once(current_errnum, errdetail, new_errnum, phase,
+                             "formatting error");
+  }
+
+  char *msg = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+  if (!msg) {
+    return compdiag_set_once(current_errnum, errdetail, new_errnum, phase,
+                             "out of memory");
+  }
+
+  va_start(args, fmt);
+  vsnprintf(msg, (size_t)needed + 1, fmt, args);
+  va_end(args);
+
+  bool recorded = compdiag_set_once(current_errnum, errdetail, new_errnum, phase, msg);
+  FREE_ARRAY(char, msg, (size_t)needed + 1);
+  return recorded;
+}
+
+void compdiag_reset_detail(char **errdetail) {
+  if (!errdetail || !*errdetail) return;
+
+  size_t len = strlen(*errdetail);
+  FREE_ARRAY(char, *errdetail, len + 1);
+  *errdetail = NULL;
+}

--- a/src/compdiag.h
+++ b/src/compdiag.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+bool compdiag_set_once(int8_t *current_errnum, char **errdetail,
+                       int8_t new_errnum, const char *phase,
+                       const char *detail);
+bool compdiag_setf_once(int8_t *current_errnum, char **errdetail,
+                        int8_t new_errnum, const char *phase,
+                        const char *fmt, ...);
+void compdiag_reset_detail(char **errdetail);

--- a/src/emitbc.c
+++ b/src/emitbc.c
@@ -5,24 +5,42 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "compdiag.h"
 #include "error.h"
 #include "memory.h"
 
 static int8_t emit_error(char **errdetail, int8_t errnum, const char *fmt, ...) {
-  if (errdetail) {
-    va_list args;
-    va_start(args, fmt);
-    int needed = vsnprintf(NULL, 0, fmt, args);
-    va_end(args);
-    if (needed >= 0) {
-      *errdetail = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
-      va_start(args, fmt);
-      vsnprintf(*errdetail, (size_t)needed + 1, fmt, args);
-      va_end(args);
-    } else {
-      *errdetail = NULL;
-    }
+  va_list args;
+  int needed;
+  char *msg;
+
+  if (!errdetail) return errnum;
+
+  va_start(args, fmt);
+  needed = vsnprintf(NULL, 0, fmt, args);
+  va_end(args);
+  if (needed < 0) {
+    int8_t current = ERR_NOERROR;
+    compdiag_set_once(&current, errdetail, errnum, "emitbc", "formatting error");
+    return errnum;
   }
+
+  msg = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+  if (!msg) {
+    int8_t current = ERR_NOERROR;
+    compdiag_set_once(&current, errdetail, errnum, "emitbc", "out of memory");
+    return errnum;
+  }
+
+  va_start(args, fmt);
+  vsnprintf(msg, (size_t)needed + 1, fmt, args);
+  va_end(args);
+
+  {
+    int8_t current = ERR_NOERROR;
+    compdiag_set_once(&current, errdetail, errnum, "emitbc", msg);
+  }
+  FREE_ARRAY(char, msg, (size_t)needed + 1);
   return errnum;
 }
 
@@ -95,7 +113,7 @@ static uint8_t map_opcode(IR_Op op) {
 
 int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
                      OUTPUT_t *out, char **errdetail) {
-  if (errdetail) *errdetail = NULL;
+  if (errdetail) compdiag_reset_detail(errdetail);
   if (!ir || !out) return emit_error(errdetail, ERR_COMP_SYNTAX, "emit_bytecode: null input");
 
   size_t *pos = GROW_ARRAY(size_t, NULL, 0, ir->function.count > 0 ? ir->function.count : 1);

--- a/src/ir.c
+++ b/src/ir.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdarg.h>
 
+#include "compdiag.h"
 #include "error.h"
 #include "ir.h"
 #include "memory.h"
@@ -211,26 +212,43 @@ void ir_dump(FILE* out, IR_Unit* unit) {
 }
 
 static int8_t ir_validate_error(char **errdetail, int8_t errnum, const char *fmt, ...) {
-  if (errdetail != NULL) {
-    va_list args;
-    va_start(args, fmt);
-    int needed = vsnprintf(NULL, 0, fmt, args);
-    va_end(args);
-    if (needed < 0) {
-      *errdetail = NULL;
-    } else {
-      *errdetail = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
-      va_start(args, fmt);
-      vsnprintf(*errdetail, (size_t)needed + 1, fmt, args);
-      va_end(args);
-    }
+  va_list args;
+  int needed;
+  char *msg;
+
+  if (errdetail == NULL) return errnum;
+
+  va_start(args, fmt);
+  needed = vsnprintf(NULL, 0, fmt, args);
+  va_end(args);
+  if (needed < 0) {
+    int8_t current = ERR_NOERROR;
+    compdiag_set_once(&current, errdetail, errnum, "ir", "formatting error");
+    return errnum;
   }
+
+  msg = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+  if (!msg) {
+    int8_t current = ERR_NOERROR;
+    compdiag_set_once(&current, errdetail, errnum, "ir", "out of memory");
+    return errnum;
+  }
+
+  va_start(args, fmt);
+  vsnprintf(msg, (size_t)needed + 1, fmt, args);
+  va_end(args);
+
+  {
+    int8_t current = ERR_NOERROR;
+    compdiag_set_once(&current, errdetail, errnum, "ir", msg);
+  }
+  FREE_ARRAY(char, msg, (size_t)needed + 1);
   return errnum;
 }
 
 int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail) {
   if (errdetail != NULL) {
-    *errdetail = NULL;
+    compdiag_reset_detail(errdetail);
   }
 
   if (unit == NULL) {

--- a/src/lower.c
+++ b/src/lower.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "compdiag.h"
 #include "error.h"
 
 typedef struct {
@@ -48,12 +49,8 @@ static bool lower_lookup_libcall(const char *lib, const char *func,
 }
 
 static void lower_set_error(LOWER_CTX *ctx, int8_t errnum, const char *detail) {
-  if (!ctx || ctx->errnum != ERR_NOERROR) return;
-
-  ctx->errnum = errnum;
-  if (detail) {
-    ctx->errdetail = strdup(detail);
-  }
+  if (!ctx) return;
+  compdiag_set_once(&ctx->errnum, &ctx->errdetail, errnum, "lower", detail);
 }
 
 static void lower_set_unsupported(LOWER_CTX *ctx, const AS_NODE *node, const char *reason) {
@@ -555,7 +552,7 @@ int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **err
   LOWER_CTX ctx;
 
   if (!out_ir) {
-    if (errdetail) *errdetail = strdup("out_ir is NULL");
+    if (errdetail) *errdetail = strdup("lower: out_ir is NULL");
     return ERR_COMP_SYNTAX;
   }
 
@@ -568,7 +565,7 @@ int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **err
   ctx.errnum = ERR_NOERROR;
 
   if (!ctx.ir) {
-    if (errdetail) *errdetail = strdup("failed to allocate IR unit");
+    if (errdetail) *errdetail = strdup("lower: failed to allocate IR unit");
     return ERR_COMP_INUSE;
   }
 

--- a/src/semant.c
+++ b/src/semant.c
@@ -11,6 +11,7 @@
 #include "absyn.h"
 #include "error.h"
 #include "memory.h"
+#include "compdiag.h"
 #include "semant.h"
  
 static bool sem_has_local(SEM_CTX *ctx, const char *name) {
@@ -39,13 +40,10 @@ static void sem_add_local(SEM_CTX *ctx, const char *name) {
 }
 
 static void sem_set_error(SEM_CTX *ctx, int8_t errnum, const char *local_name) {
-  if (ctx->errnum != ERR_NOERROR) {
-    return;
-  }
-  ctx->errnum = errnum;
-  if (local_name) {
-    ctx->errdetail = strdup(local_name);
-  }
+  if (!ctx) return;
+  compdiag_setf_once(&ctx->errnum, &ctx->errdetail, errnum, "semant",
+                     "undefined local %s",
+                     local_name ? local_name : "<null>");
 }
 
 SEM_CTX *sem_create_ctx() {
@@ -65,9 +63,7 @@ void sem_delete_ctx(SEM_CTX *ctx) {
     FREE_ARRAY(char *, ctx->locals[i].name, 0);
   }
   FREE_ARRAY(SEM_LOCAL, ctx->locals, 0);
-  if (ctx->errdetail) {
-    free(ctx->errdetail);
-  }
+  compdiag_reset_detail(&ctx->errdetail);
   FREE_ARRAY(SEM_CTX, ctx, 0);
 }
 
@@ -141,10 +137,7 @@ static void sem_walk(SEM_CTX *ctx, AS_NODE *node) {
 int8_t sem_check_locals(AS_NODE *root, char **errdetail, SEM_CTX *ctx) {
   // sem_check_locals is reusable per SEM_CTX. It preserves discovered locals
   // across calls, but resets and re-computes per-call error state.
-  if (ctx->errdetail) {
-    free(ctx->errdetail);
-    ctx->errdetail = NULL;
-  }
+  compdiag_reset_detail(&ctx->errdetail);
   ctx->errnum = ERR_NOERROR;
 
   sem_walk(ctx, root);


### PR DESCRIPTION
### Motivation
- Centralize common compiler diagnostic tasks (set-once error recording, printf-style allocation, and safe free/reset of detail strings) to avoid duplicated logic across phases.
- Standardize error-detail formatting so phase/context is explicit (e.g. `lower: ...`, `ir: ...`, `emitbc: ...`, `semant: ...`) and ownership rules are consistent.

### Description
- Add a new helper module `src/compdiag.h` / `src/compdiag.c` providing `compdiag_set_once`, `compdiag_setf_once`, and `compdiag_reset_detail` for set-once diagnostics and safe detail allocation/freeing.
- Refactor semantic analysis to route `sem_set_error` through `compdiag_setf_once` and use `compdiag_reset_detail` for context teardown, with details tagged `semant: ...`.
- Refactor lowering to use `compdiag_set_once` in `lower_set_error` and produce `lower: ...` detail strings for startup/allocation failures and unsupported forms.
- Refactor IR validation (`ir_validate_error`) and bytecode emission (`emit_error`) to use the shared allocation/reset flow and tag messages with `ir: ...` and `emitbc: ...` respectively.
- Wire the new module into the build by adding `obj/compdiag.o` to `LIB_OBJECTS` in the `Makefile`.

### Testing
- Built and ran the test suite with `make test -j4`, which completed successfully.
- Project compiled (object `obj/compdiag.o` created) and unit tests executed as part of the test run without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0815cc9bb8832ea6b830957a235fe8)