### PR TITLE
Refactor local index resolution in lowering

### DIFF
--- a/src/lower.c
+++ b/src/lower.c
@@ -69,6 +69,38 @@ static void lower_arglist(LOWER_CTX *ctx, AS_NODE *arglist, int32_t *argc);
 
 static void lower_item(LOWER_CTX *ctx, AS_NODE *item);
 static bool lower_build_embedded_payload(LOWER_CTX *ctx, AS_NODE *node, int32_t *payload_index);
+static bool lower_resolve_local_index(LOWER_CTX *ctx, AS_NODE *node, uint8_t *out_index);
+
+static bool lower_resolve_local_index(LOWER_CTX *ctx, AS_NODE *node, uint8_t *out_index) {
+  AS_VALUE *value;
+  const char *name;
+  uint8_t index = 0;
+
+  if (!node || node->nodetype != N_VALUE) {
+    lower_set_unsupported(ctx, node, "local target must be value(V_LOCAL)");
+    return false;
+  }
+
+  value = (AS_VALUE *)node->lhs;
+  if (!value || value->valtype != V_LOCAL) {
+    lower_set_unsupported(ctx, node, "local target must be value(V_LOCAL)");
+    return false;
+  }
+
+  name = value->value.s;
+  if (!name) {
+    lower_set_error(ctx, ERR_COMP_LOCALBEFOREDEF, "<null>");
+    return false;
+  }
+
+  if (!ctx->sem || !sem_get_local_index(ctx->sem, name, &index)) {
+    lower_set_error(ctx, ERR_COMP_LOCALBEFOREDEF, name);
+    return false;
+  }
+
+  if (out_index) *out_index = index;
+  return true;
+}
 
 static void lower_layer_part(LOWER_CTX *ctx, AS_NODE *part) {
   AS_VALUE *value;
@@ -186,10 +218,7 @@ static void lower_value_expr(LOWER_CTX *ctx, AS_NODE *node) {
       return;
     case V_LOCAL: {
       uint8_t index = 0;
-      if (!ctx->sem || !value->value.s ||
-          !sem_get_local_index(ctx->sem, value->value.s, &index)) {
-        lower_set_error(ctx, ERR_COMP_LOCALBEFOREDEF,
-                        value->value.s ? value->value.s : "<null>");
+      if (!lower_resolve_local_index(ctx, node, &index)) {
         return;
       }
       ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_LOAD_LOCAL, .a = index});
@@ -397,22 +426,8 @@ static void lower_stmt(LOWER_CTX *ctx, AS_NODE *node) {
 
     case N_ASSLOCAL: {
       AS_NODE *local = (AS_NODE *)node->lhs;
-      AS_VALUE *value;
       uint8_t index = 0;
-
-      if (!local || local->nodetype != N_VALUE) {
-        lower_set_unsupported(ctx, node, "assignment target is not a local value");
-        return;
-      }
-
-      value = (AS_VALUE *)local->lhs;
-      if (!value || value->valtype != V_LOCAL || !value->value.s) {
-        lower_set_unsupported(ctx, node, "missing local assignment target");
-        return;
-      }
-
-      if (!ctx->sem || !sem_get_local_index(ctx->sem, value->value.s, &index)) {
-        lower_set_error(ctx, ERR_COMP_LOCALBEFOREDEF, value->value.s);
+      if (!lower_resolve_local_index(ctx, local, &index)) {
         return;
       }
 
@@ -425,22 +440,8 @@ static void lower_stmt(LOWER_CTX *ctx, AS_NODE *node) {
     case N_INC:
     case N_DEC: {
       AS_NODE *local = (AS_NODE *)node->lhs;
-      AS_VALUE *value;
       uint8_t index = 0;
-
-      if (!local || local->nodetype != N_VALUE) {
-        lower_set_unsupported(ctx, node, "inc/dec target is not a local value");
-        return;
-      }
-
-      value = (AS_VALUE *)local->lhs;
-      if (!value || value->valtype != V_LOCAL || !value->value.s) {
-        lower_set_unsupported(ctx, node, "missing local inc/dec target");
-        return;
-      }
-
-      if (!ctx->sem || !sem_get_local_index(ctx->sem, value->value.s, &index)) {
-        lower_set_error(ctx, ERR_COMP_LOCALBEFOREDEF, value->value.s);
+      if (!lower_resolve_local_index(ctx, local, &index)) {
         return;
       }
 

--- a/tests/test_ir_validate.c
+++ b/tests/test_ir_validate.c
@@ -4,6 +4,8 @@
 
 #include "error.h"
 #include "ir.h"
+#include "lower.h"
+#include "semant.h"
 #include "test_assert.h"
 #include "test_helpers.h"
 
@@ -89,6 +91,38 @@ static void test_ir_validate_libcall_negative_function_index_rejected(void) {
   ir_destroy_unit(unit);
 }
 
+static void assert_lower_local_error(AS_NODE *root, const char *expected_name) {
+  IR_Unit *ir = NULL;
+  char *errdetail = NULL;
+  int8_t rc = lower_ast_to_ir(root, NULL, &ir, &errdetail);
+  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
+  ASSERT_TRUE(ir == NULL);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, expected_name) != NULL);
+  free(errdetail);
+}
+
+static void test_lower_local_resolution_errors_consistent(void) {
+  AS_NODE *expr_stmt = t_node(N_EXPRSTMT, t_local("x"), NULL);
+  AS_NODE *asslocal = t_node(N_ASSLOCAL, t_local("x"), t_int(1));
+  AS_NODE *inc = t_node(N_INC, t_local("x"), NULL);
+  AS_NODE *dec = t_node(N_DEC, t_local("x"), NULL);
+  AS_NODE *null_named_local = as_new_node(N_VALUE, as_new_value(V_LOCAL, 0, NULL), NULL);
+  AS_NODE *null_expr_stmt = t_node(N_EXPRSTMT, null_named_local, NULL);
+
+  assert_lower_local_error(expr_stmt, "x");
+  assert_lower_local_error(asslocal, "x");
+  assert_lower_local_error(inc, "x");
+  assert_lower_local_error(dec, "x");
+  assert_lower_local_error(null_expr_stmt, "<null>");
+
+  as_delete(expr_stmt);
+  as_delete(asslocal);
+  as_delete(inc);
+  as_delete(dec);
+  as_delete(null_expr_stmt);
+}
+
 void test_ir_validate(void) {
   test_ir_validate_ok_case();
   test_ir_validate_unbound_label_rejected();
@@ -96,4 +130,5 @@ void test_ir_validate(void) {
   test_ir_validate_local_index_out_of_range_rejected();
   test_ir_validate_negative_arity_rejected();
   test_ir_validate_libcall_negative_function_index_rejected();
+  test_lower_local_resolution_errors_consistent();
 }


### PR DESCRIPTION
### Motivation

- Centralize and standardize the logic that resolves local variable names to indices to remove duplicated code paths and reduce the risk of inconsistent error messages. 
- Ensure all AST node forms that refer to locals produce identical `ERR_COMP_LOCALBEFOREDEF` details including a `<null>` detail for null names. 
- Add tests to lock in the lowered behavior for expression, assignment, and inc/dec forms that use locals. 

### Description

- Add a helper `lower_resolve_local_index` in `src/lower.c` that validates node shape (`N_VALUE` + `V_LOCAL`), validates the name pointer, maps the name via `sem_get_local_index`, and emits consistent `ERR_COMP_LOCALBEFOREDEF` details. 
- Replace the duplicated local-resolution code with calls to `lower_resolve_local_index` in the `V_LOCAL` case of `lower_value_expr` and in `lower_stmt` for `N_ASSLOCAL` and `N_INC`/`N_DEC`. 
- Extend `tests/test_ir_validate.c` with `test_lower_local_resolution_errors_consistent` and helper `assert_lower_local_error` to verify consistent error details for expression-statement locals, assignment locals, inc/dec locals, and a null-named local; add necessary includes (`lower.h`, `semant.h`). 

### Testing

- Built and ran the automated test suite with `make test -j4`, and all tests completed successfully. 
- Added unit assertions in `tests/test_ir_validate.c` that verify `lower_ast_to_ir` returns `ERR_COMP_LOCALBEFOREDEF` and that the `errdetail` contains the expected local name or `<null>`. 
- Existing IR validation tests continue to run and pass alongside the new local-resolution consistency tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081830b548832eafeb9f05a1c6d606)