### PR TITLE
Fix semantic error detail for undefined locals

### DIFF
--- a/src/semant.c
+++ b/src/semant.c
@@ -40,10 +40,11 @@ static void sem_add_local(SEM_CTX *ctx, const char *name) {
 }
 
 static void sem_set_error(SEM_CTX *ctx, int8_t errnum, const char *local_name) {
-  if (!ctx) return;
-  compdiag_setf_once(&ctx->errnum, &ctx->errdetail, errnum, "semant",
-                     "undefined local %s",
-                     local_name ? local_name : "<null>");
+  if (!ctx || ctx->errnum != ERR_NOERROR) return;
+
+  ctx->errnum = errnum;
+  compdiag_reset_detail(&ctx->errdetail);
+  ctx->errdetail = strdup(local_name ? local_name : "<null>");
 }
 
 SEM_CTX *sem_create_ctx() {


### PR DESCRIPTION
### Motivation
- The `sem_check_locals` test expects the `errdetail` payload to be the raw missing local name (for example `"missing"`), but the previous implementation recorded a formatted diagnostic string instead, causing test failures.

### Description
- Update `sem_set_error` in `src/semant.c` to short-circuit when `ctx->errnum` is already set and to record only the missing local name in `ctx->errdetail` using `strdup(local_name ? local_name : "<null>")`, after resetting any previously owned detail.

### Testing
- Ran `make test` which builds the project and runs the full test suite; the tests completed successfully (previous failing assertion in `tests/test_semant.c` is resolved).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081b796494832ea58b8f7636f38aa5)