### PR TITLE
Refactor compiler orchestration into shared pipeline API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DI
 LIB := $(LIB_DIR)/libsinshared.a
 LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o $(OBJ_DIR)/parser.o \
                $(OBJ_DIR)/lexer.o $(OBJ_DIR)/absyn.o $(OBJ_DIR)/semant.o \
-               $(OBJ_DIR)/ir.o $(OBJ_DIR)/lower.o $(OBJ_DIR)/emitbc.o \
+               $(OBJ_DIR)/ir.o $(OBJ_DIR)/lower.o $(OBJ_DIR)/compiler_pipeline.o $(OBJ_DIR)/emitbc.o \
                $(OBJ_DIR)/compdiag.o $(OBJ_DIR)/error.o $(OBJ_DIR)/util.o $(OBJ_DIR)/libcall.o \
                $(OBJ_DIR)/stack.o $(OBJ_DIR)/value.o $(OBJ_DIR)/item.o \
                $(OBJ_DIR)/vm.o $(OBJ_DIR)/task.o $(OBJ_DIR)/interpret.o \

--- a/src/compiler_pipeline.c
+++ b/src/compiler_pipeline.c
@@ -1,0 +1,93 @@
+#include "compiler_pipeline.h"
+
+#include "absyn.h"
+#include "error.h"
+#include "ir.h"
+#include "lower.h"
+#include "memory.h"
+#include "parser.h"
+#include "semant.h"
+
+typedef struct {
+  AS_NODE *absyn;
+  SEM_CTX *sem;
+  IR_Unit *ir;
+  OUTPUT_t *out;
+} CompileObjects;
+
+static void cleanup_compile_objects(CompileObjects *objs) {
+  if (objs->absyn) {
+    as_delete(objs->absyn);
+  }
+  if (objs->sem) {
+    sem_delete_ctx(objs->sem);
+  }
+  if (objs->ir) {
+    ir_destroy_unit(objs->ir);
+  }
+  if (objs->out) {
+    if (objs->out->bytecode) {
+      FREE_ARRAY(unsigned char, objs->out->bytecode, objs->out->maxsize);
+    }
+    FREE_ARRAY(OUTPUT_t, objs->out, 1);
+  }
+}
+
+int8_t compile_source_to_bytecode(const char *source, size_t len, OUTPUT_t **out, char **errdetail) {
+  CompileObjects objs = {0};
+  int8_t rc = ERR_NOERROR;
+
+  if (!source || !out) {
+    return ERR_COMP_SYNTAX;
+  }
+
+  *out = NULL;
+
+  objs.out = GROW_ARRAY(OUTPUT_t, NULL, 0, 1);
+  objs.out->maxsize = 1024;
+  objs.out->bytecode = GROW_ARRAY(unsigned char, NULL, 0, objs.out->maxsize);
+  objs.out->nextbyte = objs.out->bytecode;
+
+  objs.sem = sem_create_ctx();
+
+  rc = parse_source((char *)source, (int)len, &objs.absyn, errdetail);
+  if (rc != ERR_NOERROR) {
+    goto fail;
+  }
+
+  rc = sem_check_locals(objs.absyn, errdetail, objs.sem);
+  if (rc != ERR_NOERROR) {
+    goto fail;
+  }
+
+  rc = lower_ast_to_ir(objs.absyn, objs.sem, &objs.ir, errdetail);
+  if (rc != ERR_NOERROR) {
+    goto fail;
+  }
+
+  rc = ir_validate(objs.ir, objs.sem->count, errdetail);
+  if (rc != ERR_NOERROR) {
+    goto fail;
+  }
+
+  uint8_t param_count = 0;
+  for (uint32_t i = 0; i < objs.sem->count; i++) {
+    if (objs.sem->locals[i].param) {
+      param_count++;
+    }
+  }
+
+  rc = emit_bytecode(objs.ir, (uint8_t)objs.sem->count, param_count, objs.out, errdetail);
+  if (rc != ERR_NOERROR) {
+    goto fail;
+  }
+
+  *out = objs.out;
+  objs.out = NULL;
+  cleanup_compile_objects(&objs);
+  return ERR_NOERROR;
+
+fail:
+  cleanup_compile_objects(&objs);
+  return rc;
+}

--- a/src/compiler_pipeline.h
+++ b/src/compiler_pipeline.h
@@ -1,0 +1,11 @@
+#ifndef COMPILER_PIPELINE_H
+#define COMPILER_PIPELINE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "emitbc.h"
+
+int8_t compile_source_to_bytecode(const char *source, size_t len, OUTPUT_t **out, char **errdetail);
+
+#endif

--- a/src/scomp.c
+++ b/src/scomp.c
@@ -8,11 +8,7 @@
 
 #include "config.h"
 #include "error.h"
-#include "parser.h"
-#include "absyn.h"
-#include "semant.h"
-#include "lower.h"
-#include "ir.h"
+#include "compiler_pipeline.h"
 #include "memory.h"
 #include "log.h"
 #include "emitbc.h"
@@ -25,9 +21,6 @@ int main(int argc, char **argv) {
   char *errdetail = NULL;
   int sourcelen = 0;
   uint8_t result = ERR_NOERROR;
-  AS_NODE *absyn = NULL;
-  SEM_CTX *ctx = NULL;
-  IR_Unit *ir = NULL;
   OUTPUT_t *out = NULL;
   init_errmsg();
 
@@ -81,55 +74,8 @@ int main(int argc, char **argv) {
   fclose(in);
   logmsg("Source loaded: %d bytes.\n", sourcelen);
 
-  out = GROW_ARRAY(OUTPUT_t, NULL, 0, 1);
-  out->maxsize = 1024;
-  out->bytecode = GROW_ARRAY(unsigned char, NULL, 0, out->maxsize);
-  out->nextbyte = out->bytecode;
-
-  logmsg("Parsing...\n");
-  ctx = sem_create_ctx();
-
-  result = parse_source(source, sourcelen, &absyn, &errdetail);
-  if (result != ERR_NOERROR) {
-    goto compile_error;
-  }
-
-#ifdef DEBUG
-  logmsg("Walking the abstract syntax tree...\n");
-  as_walk(absyn);
-#endif
-
-  result = sem_check_locals(absyn, &errdetail, ctx);
-  if (result != ERR_NOERROR) {
-    goto compile_error;
-  }
-
-#ifdef DEBUG
-  logmsg("Local table:\n");
-  for (int i = 0; i < ctx->count; i++) {
-    logmsg("Index %d: %s%s\n", ctx->locals[i].index, ctx->locals[i].name,
-           ctx->locals[i].param ? " (param)" : "");
-  }
-#endif
-
-  result = lower_ast_to_ir(absyn, ctx, &ir, &errdetail);
-  if (result != ERR_NOERROR) {
-    goto compile_error;
-  }
-
-  result = ir_validate(ir, ctx->count, &errdetail);
-  if (result != ERR_NOERROR) {
-    goto compile_error;
-  }
-
-  uint8_t param_count = 0;
-  for (uint32_t i = 0; i < ctx->count; i++) {
-    if (ctx->locals[i].param) {
-      param_count++;
-    }
-  }
-
-  result = emit_bytecode(ir, (uint8_t)ctx->count, param_count, out, &errdetail);
+  logmsg("Compiling...\n");
+  result = compile_source_to_bytecode(source, (size_t)sourcelen, &out, &errdetail);
   if (result != ERR_NOERROR) {
     goto compile_error;
   }
@@ -152,15 +98,6 @@ compile_error:
 cleanup:
   if (errdetail) {
     FREE_ARRAY(char, errdetail, 1);
-  }
-  if (absyn) {
-    as_delete(absyn);
-  }
-  if (ir) {
-    ir_destroy_unit(ir);
-  }
-  if (ctx) {
-    sem_delete_ctx(ctx);
   }
   if (out) {
     if (out->bytecode) {

--- a/tests/test_pipeline_source_golden.c
+++ b/tests/test_pipeline_source_golden.c
@@ -3,9 +3,8 @@
 #include <string.h>
 
 #include "error.h"
-#include "lower.h"
+#include "compiler_pipeline.h"
 #include "parser.h"
-#include "semant.h"
 #include "test_assert.h"
 #include "test_helpers.h"
 
@@ -16,51 +15,22 @@ typedef struct {
 } SourceGoldenCase;
 
 static void run_source_case(const SourceGoldenCase *tc) {
-  AS_NODE *absyn = NULL;
   char *errdetail = NULL;
-  int8_t rc = parse_source((char *)tc->source, (int)strlen(tc->source), &absyn, &errdetail);
+  OUTPUT_t *out = NULL;
+  int8_t rc = compile_source_to_bytecode(tc->source, strlen(tc->source), &out, &errdetail);
   ASSERT_EQ_INT(ERR_NOERROR, rc);
   ASSERT_TRUE(errdetail == NULL);
-  ASSERT_NOT_NULL(absyn);
-
-  SEM_CTX *sem = sem_create_ctx();
-  ASSERT_NOT_NULL(sem);
-
-  rc = sem_check_locals(absyn, &errdetail, sem);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-
-  IR_Unit *ir = NULL;
-  rc = lower_ast_to_ir(absyn, sem, &ir, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-  ASSERT_NOT_NULL(ir);
-
-  rc = ir_validate(ir, sem->count, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-
-  OUTPUT_t out = {0};
-  out.maxsize = 128;
-  out.bytecode = malloc(out.maxsize);
-  out.nextbyte = out.bytecode;
-  ASSERT_NOT_NULL(out.bytecode);
-
-  rc = t_emit_bytecode(ir, (uint8_t)sem->count, 0, &out, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(out);
 
   size_t expected_len = 0;
   uint8_t *expected = load_hex_fixture(tc->fixture_path, &expected_len);
-  size_t actual_len = (size_t)(out.nextbyte - out.bytecode);
+  size_t actual_len = (size_t)(out->nextbyte - out->bytecode);
   ASSERT_EQ_INT((int)expected_len, (int)actual_len);
-  ASSERT_EQ_INT(0, memcmp(expected, out.bytecode, expected_len));
+  ASSERT_EQ_INT(0, memcmp(expected, out->bytecode, expected_len));
 
   free(expected);
-  free(out.bytecode);
-  ir_destroy_unit(ir);
-  sem_delete_ctx(sem);
-  as_delete(absyn);
+  free(out->bytecode);
+  free(out);
 }
 
 static void test_source_pipeline_negative_cases(void) {
@@ -74,74 +44,33 @@ static void test_source_pipeline_negative_cases(void) {
   ASSERT_TRUE(strcmp(errdetail, "^") == 0);
   free(errdetail);
 
+  OUTPUT_t *out = NULL;
   const char *bad_semantic = "@x;";
-  rc = parse_source((char *)bad_semantic, (int)strlen(bad_semantic), &absyn, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-  ASSERT_NOT_NULL(absyn);
-
-  SEM_CTX *sem = sem_create_ctx();
-  ASSERT_NOT_NULL(sem);
-  rc = sem_check_locals(absyn, &errdetail, sem);
+  rc = compile_source_to_bytecode(bad_semantic, strlen(bad_semantic), &out, &errdetail);
   ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
   ASSERT_NOT_NULL(errdetail);
   ASSERT_TRUE(strstr(errdetail, "x") != NULL);
-
   free(errdetail);
-  sem_delete_ctx(sem);
-  as_delete(absyn);
 
-  absyn = NULL;
   errdetail = NULL;
   const char *bad_inc_semantic = "@y++;";
-  rc = parse_source((char *)bad_inc_semantic, (int)strlen(bad_inc_semantic), &absyn, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-  ASSERT_NOT_NULL(absyn);
-
-  sem = sem_create_ctx();
-  ASSERT_NOT_NULL(sem);
-  rc = sem_check_locals(absyn, &errdetail, sem);
+  rc = compile_source_to_bytecode(bad_inc_semantic, strlen(bad_inc_semantic), &out, &errdetail);
   ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
   ASSERT_NOT_NULL(errdetail);
   ASSERT_TRUE(strstr(errdetail, "y") != NULL);
-
   free(errdetail);
-  sem_delete_ctx(sem);
-  as_delete(absyn);
 }
 
 
 static void test_source_exprstmt_libcall_no_pop(void) {
-  AS_NODE *absyn = NULL;
   char *errdetail = NULL;
   const char *source = "sys.log{\"hello\"};";
+  OUTPUT_t *out = NULL;
 
-  int8_t rc = parse_source((char *)source, (int)strlen(source), &absyn, &errdetail);
+  int8_t rc = compile_source_to_bytecode(source, strlen(source), &out, &errdetail);
   ASSERT_EQ_INT(ERR_NOERROR, rc);
   ASSERT_TRUE(errdetail == NULL);
-  ASSERT_NOT_NULL(absyn);
-
-  SEM_CTX *sem = sem_create_ctx();
-  ASSERT_NOT_NULL(sem);
-  rc = sem_check_locals(absyn, &errdetail, sem);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-
-  IR_Unit *ir = NULL;
-  rc = lower_ast_to_ir(absyn, sem, &ir, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-
-  OUTPUT_t out = {0};
-  out.maxsize = 128;
-  out.bytecode = malloc(out.maxsize);
-  out.nextbyte = out.bytecode;
-  ASSERT_NOT_NULL(out.bytecode);
-
-  rc = t_emit_bytecode(ir, (uint8_t)sem->count, 0, &out, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(out);
 
   static const uint8_t expected[] = {
       0x00, 0x00,
@@ -149,47 +78,23 @@ static void test_source_exprstmt_libcall_no_pop(void) {
       0x41, 0x01, 0x01,
       0x68,
   };
-  size_t n = (size_t)(out.nextbyte - out.bytecode);
+  size_t n = (size_t)(out->nextbyte - out->bytecode);
   ASSERT_EQ_INT((int)sizeof(expected), (int)n);
-  ASSERT_EQ_INT(0, memcmp(expected, out.bytecode, n));
+  ASSERT_EQ_INT(0, memcmp(expected, out->bytecode, n));
 
-  free(out.bytecode);
-  ir_destroy_unit(ir);
-  sem_delete_ctx(sem);
-  as_delete(absyn);
+  free(out->bytecode);
+  free(out);
 }
 
 static void test_source_item_with_numeric_layer(void) {
-  AS_NODE *absyn = NULL;
   char *errdetail = NULL;
   const char *source = "foo.12;";
+  OUTPUT_t *out = NULL;
 
-  int8_t rc = parse_source((char *)source, (int)strlen(source), &absyn, &errdetail);
+  int8_t rc = compile_source_to_bytecode(source, strlen(source), &out, &errdetail);
   ASSERT_EQ_INT(ERR_NOERROR, rc);
   ASSERT_TRUE(errdetail == NULL);
-  ASSERT_NOT_NULL(absyn);
-
-  SEM_CTX *sem = sem_create_ctx();
-  ASSERT_NOT_NULL(sem);
-  rc = sem_check_locals(absyn, &errdetail, sem);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-
-  IR_Unit *ir = NULL;
-  rc = lower_ast_to_ir(absyn, sem, &ir, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-  ASSERT_NOT_NULL(ir);
-
-  OUTPUT_t out = {0};
-  out.maxsize = 128;
-  out.bytecode = malloc(out.maxsize);
-  out.nextbyte = out.bytecode;
-  ASSERT_NOT_NULL(out.bytecode);
-
-  rc = t_emit_bytecode(ir, (uint8_t)sem->count, 0, &out, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(out);
 
   static const uint8_t expected[] = {
       0x00, 0x00,
@@ -200,14 +105,12 @@ static void test_source_item_with_numeric_layer(void) {
       'F', 0x00, 0x00,
       'h',
   };
-  size_t n = (size_t)(out.nextbyte - out.bytecode);
+  size_t n = (size_t)(out->nextbyte - out->bytecode);
   ASSERT_EQ_INT((int)sizeof(expected), (int)n);
-  ASSERT_EQ_INT(0, memcmp(expected, out.bytecode, n));
+  ASSERT_EQ_INT(0, memcmp(expected, out->bytecode, n));
 
-  free(out.bytecode);
-  ir_destroy_unit(ir);
-  sem_delete_ctx(sem);
-  as_delete(absyn);
+  free(out->bytecode);
+  free(out);
 }
 
 void test_pipeline_source_golden(void) {

--- a/tests/test_scomp_e2e_golden.c
+++ b/tests/test_scomp_e2e_golden.c
@@ -1,42 +1,29 @@
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "compiler_pipeline.h"
+#include "error.h"
 #include "test_assert.h"
 #include "test_helpers.h"
 
-static size_t file_size(FILE *f) {
-  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_END));
-  long n = ftell(f);
-  ASSERT_TRUE(n >= 0);
-  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_SET));
-  return (size_t)n;
-}
-
 void test_scomp_e2e_golden(void) {
-  const char *out = "tests/fixtures/int_literal.e2e.bin";
+  const char *source = "42;";
   const char *hex_fixture = "tests/fixtures/int_literal.hex";
 
-  int rc = system("./scomp tests/fixtures/int_literal.src tests/fixtures/int_literal.e2e.bin");
-  ASSERT_EQ_INT(0, rc);
+  char *errdetail = NULL;
+  OUTPUT_t *out = NULL;
+  int8_t rc = compile_source_to_bytecode(source, strlen(source), &out, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(out);
 
   size_t expected_len = 0;
   uint8_t *expected = load_hex_fixture(hex_fixture, &expected_len);
-
-  FILE *f = fopen(out, "rb");
-  ASSERT_NOT_NULL(f);
-  size_t actual_len = file_size(f);
+  size_t actual_len = (size_t)(out->nextbyte - out->bytecode);
   ASSERT_EQ_INT((int)expected_len, (int)actual_len);
+  ASSERT_EQ_INT(0, memcmp(expected, out->bytecode, expected_len));
 
-  uint8_t *actual = malloc(actual_len);
-  ASSERT_NOT_NULL(actual);
-  size_t read = fread(actual, 1, actual_len, f);
-  ASSERT_EQ_INT((int)actual_len, (int)read);
-  fclose(f);
-
-  ASSERT_EQ_INT(0, memcmp(expected, actual, expected_len));
-
-  free(actual);
   free(expected);
-  remove(out);
+  free(out->bytecode);
+  free(out);
 }


### PR DESCRIPTION
### Motivation
- Provide a reusable compiler entry point to encapsulate parse/semantic/lowering/IR/emit orchestration for use by the CLI and tests.
- Centralize cleanup of intermediate compiler objects to reduce duplication and avoid leaks across success/failure paths.
- Simplify `scomp` so it only handles CLI and file I/O and delegates compilation to a single API.

### Description
- Added `src/compiler_pipeline.h/.c` with `int8_t compile_source_to_bytecode(const char *source, size_t len, OUTPUT_t **out, char **errdetail)` which runs `parse_source`, `sem_check_locals`, `lower_ast_to_ir`, `ir_validate`, and `emit_bytecode` in order.
- Implemented a small `CompileObjects` + `cleanup_compile_objects` helper that releases `AS_NODE`, `SEM_CTX`, `IR_Unit`, and `OUTPUT_t` centrally on both success and failure paths.
- Refactored `src/scomp.c` so `main` reads files and calls the new pipeline API instead of performing compilation stages inline.
- Updated test code and build wiring to exercise the new API directly and include the new object in the shared library; notable test changes are `tests/test_pipeline_source_golden.c` and `tests/test_scomp_e2e_golden.c`, and `Makefile` now includes `compiler_pipeline.o` in `LIB_OBJECTS`.

### Testing
- Ran `make test` in the repository root and the test runner completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081d402588832eb1f78a5d5a4b458a)