### PR TITLE
Unify error reporting via compdiag in emitter, lowerer, and semantic analyzer

### DIFF
--- a/src/emitbc.c
+++ b/src/emitbc.c
@@ -1,48 +1,12 @@
 #include "emitbc.h"
 
 #include <limits.h>
-#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 
 #include "compdiag.h"
 #include "error.h"
 #include "memory.h"
-
-static int8_t emit_error(char **errdetail, int8_t errnum, const char *fmt, ...) {
-  va_list args;
-  int needed;
-  char *msg;
-
-  if (!errdetail) return errnum;
-
-  va_start(args, fmt);
-  needed = vsnprintf(NULL, 0, fmt, args);
-  va_end(args);
-  if (needed < 0) {
-    int8_t current = ERR_NOERROR;
-    compdiag_set_once(&current, errdetail, errnum, "emitbc", "formatting error");
-    return errnum;
-  }
-
-  msg = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
-  if (!msg) {
-    int8_t current = ERR_NOERROR;
-    compdiag_set_once(&current, errdetail, errnum, "emitbc", "out of memory");
-    return errnum;
-  }
-
-  va_start(args, fmt);
-  vsnprintf(msg, (size_t)needed + 1, fmt, args);
-  va_end(args);
-
-  {
-    int8_t current = ERR_NOERROR;
-    compdiag_set_once(&current, errdetail, errnum, "emitbc", msg);
-  }
-  FREE_ARRAY(char, msg, (size_t)needed + 1);
-  return errnum;
-}
 
 static int ensure_out(OUTPUT_t *out, size_t extra) {
   size_t used = (size_t)(out->nextbyte - out->bytecode);
@@ -114,7 +78,11 @@ static uint8_t map_opcode(IR_Op op) {
 int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
                      OUTPUT_t *out, char **errdetail) {
   if (errdetail) compdiag_reset_detail(errdetail);
-  if (!ir || !out) return emit_error(errdetail, ERR_COMP_SYNTAX, "emit_bytecode: null input");
+  if (!ir || !out) {
+    int8_t errnum = ERR_NOERROR;
+    compdiag_set_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "null input");
+    return errnum;
+  }
 
   size_t *pos = GROW_ARRAY(size_t, NULL, 0, ir->function.count > 0 ? ir->function.count : 1);
   size_t pc = 2;
@@ -143,7 +111,11 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
     uint8_t op = map_opcode(in->op);
     if (op == 0) {
       FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-      return emit_error(errdetail, ERR_COMP_SYNTAX, "unsupported IR op %d", in->op);
+      {
+        int8_t errnum = ERR_NOERROR;
+        compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "unsupported IR op %d", in->op);
+        return errnum;
+      }
     }
     write_u8(out, op);
     switch (in->op) {
@@ -153,7 +125,9 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         size_t len = strlen(s);
         if (len > UINT16_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-          return emit_error(errdetail, ERR_COMP_SYNTAX, "string literal too long: %zu", len);
+          int8_t errnum = ERR_NOERROR;
+          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "string literal too long: %zu", len);
+          return errnum;
         }
         write_u16(out, (uint16_t)len);
         ensure_out(out, len);
@@ -178,19 +152,25 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
       case IR_OP_JUMP_IF_FALSE: {
         if (in->a < 0 || (size_t)in->a >= ir->labels.count) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-          return emit_error(errdetail, ERR_COMP_SYNTAX, "jump invalid label id %d", in->a);
+          int8_t errnum = ERR_NOERROR;
+          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "jump invalid label id %d", in->a);
+          return errnum;
         }
         IR_Label *label = &ir->labels.entries[in->a];
         if (!label->bound) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-          return emit_error(errdetail, ERR_COMP_SYNTAX, "jump unbound label %d", in->a);
+          int8_t errnum = ERR_NOERROR;
+          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "jump unbound label %d", in->a);
+          return errnum;
         }
         size_t from = pos[i] + 1;
         size_t to = pos[label->position];
         long diff = (long)to - (long)from;
         if (diff < INT16_MIN || diff > INT16_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-          return emit_error(errdetail, ERR_COMP_SYNTAX, "jump offset out of range: %ld", diff);
+          int8_t errnum = ERR_NOERROR;
+          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "jump offset out of range: %ld", diff);
+          return errnum;
         }
         write_u16(out, (uint16_t)(int16_t)diff);
         break;
@@ -199,12 +179,16 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         const char *s = (const char *)(intptr_t)in->imm;
         if (!s) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-          return emit_error(errdetail, ERR_COMP_SYNTAX, "null layer name");
+          int8_t errnum = ERR_NOERROR;
+          compdiag_set_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "null layer name");
+          return errnum;
         }
         size_t len = strlen(s);
         if (len > UINT8_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-          return emit_error(errdetail, ERR_COMP_SYNTAX, "layer name too long: %zu", len);
+          int8_t errnum = ERR_NOERROR;
+          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "layer name too long: %zu", len);
+          return errnum;
         }
         write_u8(out, (uint8_t)len);
         ensure_out(out, len);
@@ -215,17 +199,23 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
       case IR_OP_ITEM_SAVE_CODE: {
         if (in->a < 0 || (size_t)in->a >= ir->embedded_code.count) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-          return emit_error(errdetail, ERR_COMP_SYNTAX, "invalid embedded code payload index %d", in->a);
+          int8_t errnum = ERR_NOERROR;
+          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "invalid embedded code payload index %d", in->a);
+          return errnum;
         }
         const IR_EmbeddedCodePayload *payload = &ir->embedded_code.entries[in->a];
         if (!payload->source) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-          return emit_error(errdetail, ERR_COMP_SYNTAX, "embedded code payload %d has null source", in->a);
+          int8_t errnum = ERR_NOERROR;
+          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "embedded code payload %d has null source", in->a);
+          return errnum;
         }
         size_t len = strlen(payload->source);
         if (len > UINT16_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
-          return emit_error(errdetail, ERR_COMP_SYNTAX, "embedded code too long: %zu", len);
+          int8_t errnum = ERR_NOERROR;
+          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "embedded code too long: %zu", len);
+          return errnum;
         }
         write_u16(out, (uint16_t)len);
         ensure_out(out, len);

--- a/src/lower.c
+++ b/src/lower.c
@@ -551,14 +551,14 @@ static void lower_node(LOWER_CTX *ctx, AS_NODE *node) {
 
 int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **errdetail) {
   LOWER_CTX ctx;
+  int8_t startup_errnum = ERR_NOERROR;
 
   if (!out_ir) {
-    if (errdetail) *errdetail = strdup("lower: out_ir is NULL");
-    return ERR_COMP_SYNTAX;
+    compdiag_set_once(&startup_errnum, errdetail, ERR_COMP_SYNTAX, "lower", "out_ir is NULL");
+    return startup_errnum;
   }
 
   *out_ir = NULL;
-  if (errdetail) *errdetail = NULL;
 
   memset(&ctx, 0, sizeof(ctx));
   ctx.sem = sem;
@@ -566,8 +566,8 @@ int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **err
   ctx.errnum = ERR_NOERROR;
 
   if (!ctx.ir) {
-    if (errdetail) *errdetail = strdup("lower: failed to allocate IR unit");
-    return ERR_COMP_INUSE;
+    compdiag_set_once(&startup_errnum, errdetail, ERR_COMP_INUSE, "lower", "failed to allocate IR unit");
+    return startup_errnum;
   }
 
   lower_node(&ctx, root);

--- a/src/semant.c
+++ b/src/semant.c
@@ -40,11 +40,9 @@ static void sem_add_local(SEM_CTX *ctx, const char *name) {
 }
 
 static void sem_set_error(SEM_CTX *ctx, int8_t errnum, const char *local_name) {
-  if (!ctx || ctx->errnum != ERR_NOERROR) return;
-
-  ctx->errnum = errnum;
-  compdiag_reset_detail(&ctx->errdetail);
-  ctx->errdetail = strdup(local_name ? local_name : "<null>");
+  if (!ctx) return;
+  compdiag_set_once(&ctx->errnum, &ctx->errdetail, errnum, "semant",
+                    local_name ? local_name : "<null>");
 }
 
 SEM_CTX *sem_create_ctx() {

--- a/tests/test_semant.c
+++ b/tests/test_semant.c
@@ -24,14 +24,14 @@ void test_sem_check_locals_reusable_context(void) {
   rc = sem_check_locals(bad_prog, &errdetail, ctx);
   ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
   ASSERT_NOT_NULL(errdetail);
-  ASSERT_TRUE(strcmp(errdetail, "missing") == 0);
+  ASSERT_TRUE(strcmp(errdetail, "semant: missing") == 0);
 
   char *first_errdetail = errdetail;
 
   rc = sem_check_locals(bad_prog, &errdetail, ctx);
   ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
   ASSERT_NOT_NULL(errdetail);
-  ASSERT_TRUE(strcmp(errdetail, "missing") == 0);
+  ASSERT_TRUE(strcmp(errdetail, "semant: missing") == 0);
   ASSERT_TRUE(errdetail != first_errdetail);
   free(first_errdetail);
   free(errdetail);


### PR DESCRIPTION
### Motivation
- Replace ad-hoc string allocation for error details with centralized `compdiag` helpers to produce consistent diagnostic prefixes and avoid manual `strdup`/`va_list` handling.
- Ensure error details are set in a uniform way across `emitbc`, `lower`, and `semant` code paths.
- Update tests to reflect the new diagnostic message format produced by `compdiag`.

### Description
- Removed the local `emit_error` helper and `#include <stdarg.h>` from `src/emitbc.c`, and replaced its call sites with `compdiag_set_once` / `compdiag_setf_once` to report errors (e.g. null input, unsupported op, too-long literals, invalid labels, etc.).
- Adjusted `emit_bytecode` to initialize and return an `int8_t` error number when setting diagnostics through `compdiag` helpers.
- Modified `src/lower.c` to use `compdiag_set_once` for startup errors (missing `out_ir` and allocation failures) and introduced a `startup_errnum` variable for reporting.
- Changed `src/semant.c` `sem_set_error` to use `compdiag_set_once` for setting `ctx->errnum` and `ctx->errdetail` instead of manual `strdup` and reset logic.
- Updated `tests/test_semant.c` expected diagnostic string to include the `compdiag`-generated prefix (from `"missing"` to `"semant: missing"`).

### Testing
- Compiled the project after changes to `src/emitbc.c`, `src/lower.c`, and `src/semant.c` with no compile errors.
- Ran the unit test containing `tests/test_semant.c` (updated expectation) and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081e3b57a0832e8e51833869f7976b)