### PR TITLE
Optimize semantic local lookup with sorted index

### DIFF
--- a/src/lower.c
+++ b/src/lower.c
@@ -93,7 +93,12 @@ static bool lower_resolve_local_index(LOWER_CTX *ctx, AS_NODE *node, uint8_t *ou
     return false;
   }
 
-  if (!ctx->sem || !sem_get_local_index(ctx->sem, name, &index)) {
+  if (!ctx->sem) {
+    lower_set_error(ctx, ERR_COMP_LOCALBEFOREDEF, name);
+    return false;
+  }
+
+  if (!sem_get_local_index(ctx->sem, name, &index)) {
     lower_set_error(ctx, ERR_COMP_LOCALBEFOREDEF, name);
     return false;
   }

--- a/src/semant.c
+++ b/src/semant.c
@@ -15,27 +15,68 @@
 #include "semant.h"
  
 static bool sem_has_local(SEM_CTX *ctx, const char *name) {
-  for (uint32_t i = 0; i < ctx->count; i++) {
-    if (strcmp(ctx->locals[i].name, name) == 0) {
+  return sem_get_local_index(ctx, name, NULL);
+}
+
+static bool sem_find_local_index_slot(SEM_CTX *ctx, const char *name,
+                                      uint32_t *pos_out, bool *found_out) {
+  uint32_t lo = 0;
+  uint32_t hi = ctx->count;
+
+  while (lo < hi) {
+    uint32_t mid = lo + (hi - lo) / 2;
+    int cmp = strcmp(name, ctx->local_index[mid].name);
+    if (cmp == 0) {
+      if (pos_out) *pos_out = mid;
+      if (found_out) *found_out = true;
       return true;
     }
+    if (cmp < 0) {
+      hi = mid;
+    } else {
+      lo = mid + 1;
+    }
   }
-  return false;
+
+  if (pos_out) *pos_out = lo;
+  if (found_out) *found_out = false;
+  return true;
 }
 
 static void sem_add_local(SEM_CTX *ctx, const char *name) {
-  if (sem_has_local(ctx, name)) {
+  uint32_t slot = 0;
+  bool found = false;
+
+  sem_find_local_index_slot(ctx, name, &slot, &found);
+  if (found) {
     return;
   }
+
   if (ctx->count == ctx->capacity) {
     uint32_t oldcap = ctx->capacity;
     ctx->capacity = ctx->capacity == 0 ? 8 : ctx->capacity * 2;
     ctx->locals = GROW_ARRAY(SEM_LOCAL, ctx->locals, oldcap, ctx->capacity);
   }
+
+  if (ctx->count == ctx->index_capacity) {
+    uint32_t oldcap = ctx->index_capacity;
+    ctx->index_capacity = ctx->index_capacity == 0 ? 8 : ctx->index_capacity * 2;
+    ctx->local_index = GROW_ARRAY(SEM_LOCAL_INDEX, ctx->local_index,
+                                  oldcap, ctx->index_capacity);
+  }
+
   SEM_LOCAL *local = &ctx->locals[ctx->count];
   local->name = strdup(name);
   local->index = ctx->count;
   local->param = false;
+
+  if (slot < ctx->count) {
+    memmove(&ctx->local_index[slot + 1], &ctx->local_index[slot],
+            (ctx->count - slot) * sizeof(SEM_LOCAL_INDEX));
+  }
+  ctx->local_index[slot].name = local->name;
+  ctx->local_index[slot].index = local->index;
+
   ctx->count++;
 }
 
@@ -49,8 +90,10 @@ SEM_CTX *sem_create_ctx() {
   SEM_CTX *ctx = NULL;
   ctx = GROW_ARRAY(SEM_CTX, ctx, 0, 1);
   (*ctx).locals = NULL;
+  (*ctx).local_index = NULL;
   (*ctx).count = 0;
   (*ctx).capacity = 0;
+  (*ctx).index_capacity = 0;
   (*ctx).errnum = ERR_NOERROR;
   (*ctx).errdetail = NULL;
 
@@ -62,6 +105,7 @@ void sem_delete_ctx(SEM_CTX *ctx) {
     FREE_ARRAY(char *, ctx->locals[i].name, 0);
   }
   FREE_ARRAY(SEM_LOCAL, ctx->locals, 0);
+  FREE_ARRAY(SEM_LOCAL_INDEX, ctx->local_index, 0);
   compdiag_reset_detail(&ctx->errdetail);
   FREE_ARRAY(SEM_CTX, ctx, 0);
 }
@@ -152,14 +196,14 @@ bool sem_get_local_index(SEM_CTX *ctx, const char *name, uint8_t *index_out) {
   // Find a local in the locals lookup table.
   // Return true or false depending on whether the local is found.
   // If the local is found, return its index in *index_out.
-  if (!ctx || !name || !index_out) {
+  if (!ctx || !name) {
     return false;
   }
-  for (int i = 0; i < ctx->count; i++) {
-    if (strcmp(ctx->locals[i].name, name) == 0) {
-      *index_out = ctx->locals[i].index;
-      return true;
-    }
-  }
-  return false;
+  uint32_t slot = 0;
+  bool found = false;
+
+  sem_find_local_index_slot(ctx, name, &slot, &found);
+  if (!found) return false;
+  if (index_out) *index_out = ctx->local_index[slot].index;
+  return true;
 }

--- a/src/semant.h
+++ b/src/semant.h
@@ -16,9 +16,16 @@ typedef struct {
 } SEM_LOCAL;
 
 typedef struct {
+  const char *name;
+  uint8_t index;
+} SEM_LOCAL_INDEX;
+
+typedef struct {
   SEM_LOCAL *locals;
+  SEM_LOCAL_INDEX *local_index;
   uint32_t count;
   uint32_t capacity;
+  uint32_t index_capacity;
   int8_t errnum;
   char *errdetail;
 } SEM_CTX;

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -11,6 +11,7 @@ void test_emitbc_opcode_map_unsupported_ir_op(void);
 void test_emitbc_opcode_map_call_item_deref_alias_layout(void);
 void test_emitbc_jumps(void);
 void test_pipeline_golden(void);
+void test_pipeline_large_local_lookup_duplicate(void);
 void test_pipeline_source_golden(void);
 void test_scomp_e2e_golden(void);
 void test_ir_validate(void);
@@ -19,6 +20,7 @@ void test_absyn_stmtlist_multiple_statements(void);
 void test_absyn_if_elsif_else_chain(void);
 void test_absyn_item_deref_chains(void);
 void test_sem_check_locals_reusable_context(void);
+void test_sem_duplicate_local_keeps_original_index(void);
 void test_sdiss_fixture_basic(void);
 void test_parser_examples_obj_golden(void);
 
@@ -72,6 +74,7 @@ int main(void) {
   test_emitbc_opcode_map_unsupported_ir_op();
   test_emitbc_jumps();
   test_pipeline_golden();
+  test_pipeline_large_local_lookup_duplicate();
   test_pipeline_source_golden();
   test_scomp_e2e_golden();
   test_ir_validate();
@@ -80,6 +83,7 @@ int main(void) {
   test_absyn_if_elsif_else_chain();
   test_absyn_item_deref_chains();
   test_sem_check_locals_reusable_context();
+  test_sem_duplicate_local_keeps_original_index();
   test_sdiss_fixture_basic();
   test_parser_examples_obj_golden();
   return 0;

--- a/tests/test_pipeline_golden.c
+++ b/tests/test_pipeline_golden.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -97,6 +98,21 @@ static AS_NODE *build_simple_if_program(void) {
   return as_stmtlist_append(list, ifstmt);
 }
 
+static AS_NODE *build_many_locals_with_duplicate_program(void) {
+  AS_NODE *list = as_new_stmtlist_node();
+  char name[32];
+
+  for (int i = 0; i < 120; i++) {
+    snprintf(name, sizeof(name), "local_%03d", i);
+    list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local(name), v_int(i)));
+  }
+
+  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("local_057"), v_int(999)));
+  list = as_stmtlist_append(list, t_node(N_EXPRSTMT, t_local("local_057"), NULL));
+  list = as_stmtlist_append(list, t_node(N_EXPRSTMT, t_local("local_119"), NULL));
+  return list;
+}
+
 void test_pipeline_golden(void) {
   const GoldenCase cases[] = {
       {"int_literal", build_int_literal_program, "tests/fixtures/int_literal.hex"},
@@ -110,4 +126,33 @@ void test_pipeline_golden(void) {
   for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
     run_case(&cases[i]);
   }
+}
+
+void test_pipeline_large_local_lookup_duplicate(void) {
+  AS_NODE *root = build_many_locals_with_duplicate_program();
+  ASSERT_NOT_NULL(root);
+
+  SEM_CTX *sem = sem_create_ctx();
+  ASSERT_NOT_NULL(sem);
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(root, &errdetail, sem);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_EQ_INT(120, (int)sem->count);
+
+  uint8_t idx = 255;
+  ASSERT_TRUE(sem_get_local_index(sem, "local_057", &idx));
+  ASSERT_EQ_INT(57, (int)idx);
+  ASSERT_TRUE(sem_get_local_index(sem, "local_119", &idx));
+  ASSERT_EQ_INT(119, (int)idx);
+
+  IR_Unit *ir = NULL;
+  rc = lower_ast_to_ir(root, sem, &ir, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(ir);
+
+  ir_destroy_unit(ir);
+  sem_delete_ctx(sem);
+  as_delete(root);
 }

--- a/tests/test_semant.c
+++ b/tests/test_semant.c
@@ -40,3 +40,28 @@ void test_sem_check_locals_reusable_context(void) {
   as_delete(bad_prog);
   sem_delete_ctx(ctx);
 }
+
+void test_sem_duplicate_local_keeps_original_index(void) {
+  SEM_CTX *ctx = sem_create_ctx();
+  ASSERT_NOT_NULL(ctx);
+
+  AS_NODE *list = as_new_stmtlist_node();
+  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("x"), t_int(1)));
+  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("y"), t_int(2)));
+  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("x"), t_int(3)));
+
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(list, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_EQ_INT(2, (int)ctx->count);
+
+  uint8_t idx = 255;
+  ASSERT_TRUE(sem_get_local_index(ctx, "x", &idx));
+  ASSERT_EQ_INT(0, (int)idx);
+  ASSERT_TRUE(sem_get_local_index(ctx, "y", &idx));
+  ASSERT_EQ_INT(1, (int)idx);
+
+  as_delete(list);
+  sem_delete_ctx(ctx);
+}


### PR DESCRIPTION
### Motivation
- Improve performance and invariants for local name → index lookups by introducing a dedicated index structure while preserving the existing emission order in `locals[]`.
- Make lowering code rely on the faster/cleaner `sem_get_local_index` semantics to simplify error handling and remove linear lookup hotspots.

### Description
- Extend `SEM_CTX` with a sorted name→index array `SEM_LOCAL_INDEX *local_index` and a separate `index_capacity` field, and keep `SEM_LOCAL *locals` as the canonical emission order (`src/semant.h`, `src/semant.c`).
- Add a binary-search helper `sem_find_local_index_slot` and refactor `sem_add_local`, `sem_has_local`, and `sem_get_local_index` to use the sorted index for fast existence/index lookup while still appending to `locals[]` to preserve indices (`src/semant.c`).
- Initialize and free the new index storage in the context lifecycle (`sem_create_ctx`, `sem_delete_ctx`).
- Simplify `lower_resolve_local_index` flow to explicitly check `ctx->sem` and then call `sem_get_local_index`, keeping behavior unchanged but clearer (`src/lower.c`).
- Add tests to cover duplicate-local handling and large-local-count lookups: `test_sem_duplicate_local_keeps_original_index` and `test_pipeline_large_local_lookup_duplicate`, and wire them into the test runner (`tests/test_semant.c`, `tests/test_pipeline_golden.c`, `tests/test_compiler.c`).

### Testing
- Built and ran the full test runner via `make test` which compiles the library and tests and then executes the test binary, and the run completed successfully (all automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081ffb2e98832e94c0e2a89fc66ee7)