### PR TITLE
Add table-driven negative pipeline matrix test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_scomp_e2e_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_scomp_e2e_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_pipeline_negative_matrix.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c
 
 
 # Library of shared functions

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -15,6 +15,7 @@ void test_pipeline_large_local_lookup_duplicate(void);
 void test_pipeline_source_golden(void);
 void test_scomp_e2e_golden(void);
 void test_ir_validate(void);
+void test_pipeline_negative_matrix(void);
 void test_absyn_nested_binary_expressions(void);
 void test_absyn_stmtlist_multiple_statements(void);
 void test_absyn_if_elsif_else_chain(void);
@@ -79,6 +80,7 @@ int main(void) {
   test_pipeline_source_golden();
   test_scomp_e2e_golden();
   test_ir_validate();
+  test_pipeline_negative_matrix();
   test_absyn_nested_binary_expressions();
   test_absyn_stmtlist_multiple_statements();
   test_absyn_if_elsif_else_chain();

--- a/tests/test_pipeline_negative_matrix.c
+++ b/tests/test_pipeline_negative_matrix.c
@@ -1,0 +1,140 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "compiler_pipeline.h"
+#include "error.h"
+#include "ir.h"
+#include "semant.h"
+#include "test_assert.h"
+#include "test_helpers.h"
+
+typedef enum {
+  STAGE_PARSER,
+  STAGE_SEMANTIC,
+  STAGE_LOWER_IR_VALIDATE,
+  STAGE_EMITTER,
+} NEG_STAGE;
+
+typedef enum {
+  CASE_SOURCE,
+  CASE_BUILDER,
+} CASE_KIND;
+
+typedef int8_t (*builder_fn)(char **errdetail);
+
+typedef struct {
+  const char *name;
+  CASE_KIND source_or_builder;
+  const char *source;
+  builder_fn builder;
+  int8_t expected_code;
+  NEG_STAGE expected_stage;
+  const char *expected_substring;
+} NEG_CASE;
+
+static int8_t run_emit_case_invalid_label(char **errdetail) {
+  IR_Unit *unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = IR_OP_JUMP, .a = 42});
+  t_emit(unit, (IR_Inst){.op = IR_OP_HALT});
+
+  OUTPUT_t out = {0};
+  out.maxsize = 64;
+  out.bytecode = malloc(out.maxsize);
+  out.nextbyte = out.bytecode;
+
+  int8_t rc = t_emit_bytecode(unit, 0, 0, &out, errdetail);
+
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+  return rc;
+}
+
+static int8_t run_emit_case_unsupported_op(char **errdetail) {
+  IR_Unit *unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = (IR_Op)999});
+
+  OUTPUT_t out = {0};
+  out.maxsize = 64;
+  out.bytecode = malloc(out.maxsize);
+  out.nextbyte = out.bytecode;
+
+  int8_t rc = t_emit_bytecode(unit, 0, 0, &out, errdetail);
+
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+  return rc;
+}
+
+static int8_t run_ir_case_bad_local_index(char **errdetail) {
+  IR_Unit *unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = IR_OP_INC_LOCAL, .a = 3});
+  t_emit(unit, (IR_Inst){.op = IR_OP_HALT});
+
+  int8_t rc = ir_validate(unit, 1, errdetail);
+  ir_destroy_unit(unit);
+  return rc;
+}
+
+static int8_t run_ir_case_bad_arity(char **errdetail) {
+  IR_Unit *unit = t_new_unit();
+  t_emit(unit, (IR_Inst){.op = IR_OP_CALL, .a = -1, .b = 0});
+  t_emit(unit, (IR_Inst){.op = IR_OP_HALT});
+
+  int8_t rc = ir_validate(unit, 0, errdetail);
+  ir_destroy_unit(unit);
+  return rc;
+}
+
+void test_pipeline_negative_matrix(void) {
+  static const NEG_CASE cases[] = {
+      {"parser_unknown_char", CASE_SOURCE, "^;", NULL, ERR_COMP_UNKNOWNCHAR, STAGE_PARSER, "^"},
+      {"parser_malformed_item_syntax", CASE_SOURCE, "foo..bar;", NULL, ERR_COMP_SYNTAX, STAGE_PARSER, "syntax error"},
+      {"parser_unterminated_string", CASE_SOURCE, "\"unterminated;", NULL, ERR_COMP_UNKNOWNCHAR, STAGE_PARSER, "Unterminated string literal."},
+      {"parser_bad_if_endif_pairing", CASE_SOURCE, "endif;", NULL, ERR_COMP_SYNTAX, STAGE_PARSER, "syntax error"},
+
+      {"semantic_use_before_def", CASE_SOURCE, "@x;", NULL, ERR_COMP_LOCALBEFOREDEF, STAGE_SEMANTIC, "semant: @x"},
+      {"semantic_invalid_increment_target", CASE_SOURCE, "@x = 1; @y++;", NULL, ERR_COMP_LOCALBEFOREDEF, STAGE_SEMANTIC, "semant: @y"},
+
+      {"ir_validate_local_index_bounds", CASE_BUILDER, NULL, run_ir_case_bad_local_index, ERR_COMP_LOCALBEFOREDEF, STAGE_LOWER_IR_VALIDATE, "ir: Instruction 0 (INC_LOCAL) has out-of-range local index"},
+      {"ir_validate_arity_constraint", CASE_BUILDER, NULL, run_ir_case_bad_arity, ERR_COMP_TOOMANYARGS, STAGE_LOWER_IR_VALIDATE, "ir: Instruction 0 (CALL) has negative arity"},
+
+      {"emitter_invalid_label", CASE_BUILDER, NULL, run_emit_case_invalid_label, ERR_COMP_SYNTAX, STAGE_EMITTER, "emitbc: jump invalid label id"},
+      {"emitter_unsupported_op", CASE_BUILDER, NULL, run_emit_case_unsupported_op, ERR_COMP_SYNTAX, STAGE_EMITTER, "emitbc: unsupported IR op"},
+  };
+
+  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+    const NEG_CASE *tc = &cases[i];
+    char *errdetail = NULL;
+    int8_t rc = ERR_NOERROR;
+
+    if (tc->source_or_builder == CASE_SOURCE) {
+      OUTPUT_t *out = NULL;
+      rc = compile_source_to_bytecode(tc->source, strlen(tc->source), &out, &errdetail);
+      ASSERT_TRUE(out == NULL);
+    } else {
+      rc = tc->builder(&errdetail);
+    }
+
+    ASSERT_EQ_INT(tc->expected_code, rc);
+    ASSERT_NOT_NULL(errdetail);
+    ASSERT_TRUE(strstr(errdetail, tc->expected_substring) != NULL);
+
+    switch (tc->expected_stage) {
+      case STAGE_PARSER:
+        ASSERT_TRUE(strncmp(tc->name, "parser_", 7) == 0);
+        break;
+      case STAGE_SEMANTIC:
+        ASSERT_TRUE(strncmp(tc->name, "semantic_", 9) == 0);
+        break;
+      case STAGE_LOWER_IR_VALIDATE:
+        ASSERT_TRUE(strncmp(tc->name, "ir_validate_", 12) == 0);
+        break;
+      case STAGE_EMITTER:
+        ASSERT_TRUE(strncmp(tc->name, "emitter_", 8) == 0);
+        break;
+    }
+
+    free(errdetail);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a compact, table-driven suite to exercise negative compiler-pipeline scenarios with explicit stage targeting so parser, semantic, lowering/IR validation, and emitter failures can be distinguished.
- Make assertions deterministic by checking canonical error codes and a stable substring in the returned `errdetail` for each failure mode.
- Keep individual cases self-describing and easy to extend via a single test matrix structure.

### Description
- Add `tests/test_pipeline_negative_matrix.c` implementing a `NEG_CASE` table with fields `name`, `source_or_builder`, `source`, `builder`, `expected_code`, `expected_stage`, and `expected_substring` and helper builder functions for IR/emitter cases.
- Cover parser errors (unknown char, malformed item syntax, unterminated string, bad `if/endif` pairing), semantic errors (use-before-def, invalid increment target), IR validation errors (local index bounds, call arity), and emitter errors (invalid jump label, unsupported op). 
- Each case asserts both the canonical error code (e.g. `ERR_COMP_SYNTAX`, `ERR_COMP_LOCALBEFOREDEF`, `ERR_COMP_TOOMANYARGS`) and that `errdetail` contains a stable substring.
- Wire the suite into the shared runner by declaring and invoking `test_pipeline_negative_matrix()` in `tests/test_compiler.c` and adding the new test to `TEST_SOURCES` in the `Makefile`.

### Testing
- Ran `make test` which compiles the test runner and executes the suite, and the run completed successfully with the new negative matrix exercised as part of the test run.
- The build and tests passed after iterating on expected `errdetail` substrings to match the existing diagnostic messages (no failing automated tests remain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08265a17e4832eb3a723dede76de60)