### PR TITLE
Refactor golden tests to use centralized helper utilities

### DIFF
--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "compiler_pipeline.h"
+#include "error.h"
 #include "test_assert.h"
 
 // Tests intentionally allocate heap buffers/strings (e.g. strdup/realloc)
@@ -56,6 +58,8 @@ uint8_t hex_nibble(char c) {
 }
 
 uint8_t *load_hex_fixture(const char *path, size_t *out_len) {
+  ASSERT_NOT_NULL(path);
+  ASSERT_NOT_NULL(out_len);
   FILE *f = fopen(path, "rb");
   if (!f) {
     char alt[512];
@@ -95,4 +99,100 @@ uint8_t *load_hex_fixture(const char *path, size_t *out_len) {
   fclose(f);
   *out_len = len;
   return buf;
+}
+
+void assert_bytes_equal_with_diag(const uint8_t *expected, size_t expected_len,
+                                  const uint8_t *actual, size_t actual_len,
+                                  const char *context) {
+  const char *ctx = context ? context : "byte-compare";
+  if (expected_len != actual_len) {
+    TEST_FAILF("%s length mismatch: expected len=%zu actual len=%zu first differing byte offset=0",
+               ctx, expected_len, actual_len);
+  }
+
+  for (size_t i = 0; i < expected_len; i++) {
+    if (expected[i] != actual[i]) {
+      TEST_FAILF("%s byte mismatch: expected len=%zu actual len=%zu first differing byte offset=%zu (expected=0x%02x actual=0x%02x)",
+                 ctx, expected_len, actual_len, i, expected[i], actual[i]);
+    }
+  }
+}
+
+void assert_file_bytes_equal(const char *expected_path, const char *actual_path,
+                             const char *context) {
+  FILE *expected_f = fopen(expected_path, "rb");
+  ASSERT_NOT_NULL(expected_f);
+  FILE *actual_f = fopen(actual_path, "rb");
+  ASSERT_NOT_NULL(actual_f);
+
+  ASSERT_EQ_INT(0, fseek(expected_f, 0, SEEK_END));
+  long expected_n = ftell(expected_f);
+  ASSERT_TRUE(expected_n >= 0);
+  ASSERT_EQ_INT(0, fseek(expected_f, 0, SEEK_SET));
+
+  ASSERT_EQ_INT(0, fseek(actual_f, 0, SEEK_END));
+  long actual_n = ftell(actual_f);
+  ASSERT_TRUE(actual_n >= 0);
+  ASSERT_EQ_INT(0, fseek(actual_f, 0, SEEK_SET));
+
+  size_t expected_len = (size_t)expected_n;
+  size_t actual_len = (size_t)actual_n;
+  uint8_t *expected = malloc(expected_len ? expected_len : 1);
+  uint8_t *actual = malloc(actual_len ? actual_len : 1);
+  ASSERT_NOT_NULL(expected);
+  ASSERT_NOT_NULL(actual);
+
+  ASSERT_EQ_INT((int)expected_len, (int)fread(expected, 1, expected_len, expected_f));
+  ASSERT_EQ_INT((int)actual_len, (int)fread(actual, 1, actual_len, actual_f));
+  fclose(expected_f);
+  fclose(actual_f);
+
+  assert_bytes_equal_with_diag(expected, expected_len, actual, actual_len, context);
+  free(expected);
+  free(actual);
+}
+
+void compile_source_and_assert_hex(const char *source, const char *fixture_path) {
+  char *errdetail = NULL;
+  OUTPUT_t *out = NULL;
+  int8_t rc = compile_source_to_bytecode(source, strlen(source), &out, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(out);
+
+  size_t expected_len = 0;
+  uint8_t *expected = load_hex_fixture(fixture_path, &expected_len);
+  size_t actual_len = (size_t)(out->nextbyte - out->bytecode);
+  assert_bytes_equal_with_diag(expected, expected_len, out->bytecode, actual_len, fixture_path);
+
+  free(expected);
+  free(out->bytecode);
+  free(out);
+}
+
+int run_command_and_capture(const char *cmd, char **captured_output) {
+  ASSERT_NOT_NULL(cmd);
+  ASSERT_NOT_NULL(captured_output);
+  *captured_output = NULL;
+
+  FILE *pipe = popen(cmd, "r");
+  ASSERT_NOT_NULL(pipe);
+
+  size_t cap = 256;
+  size_t len = 0;
+  char *buf = malloc(cap);
+  ASSERT_NOT_NULL(buf);
+
+  int c;
+  while ((c = fgetc(pipe)) != EOF) {
+    if (len + 1 >= cap) {
+      cap *= 2;
+      buf = realloc(buf, cap);
+      ASSERT_NOT_NULL(buf);
+    }
+    buf[len++] = (char)c;
+  }
+  buf[len] = '\0';
+  *captured_output = buf;
+  return pclose(pipe);
 }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -21,3 +21,11 @@ int8_t t_emit_bytecode(IR_Unit *unit, uint8_t local_count, uint8_t param_count,
 
 uint8_t hex_nibble(char c);
 uint8_t *load_hex_fixture(const char *path, size_t *out_len);
+
+void assert_bytes_equal_with_diag(const uint8_t *expected, size_t expected_len,
+                                  const uint8_t *actual, size_t actual_len,
+                                  const char *context);
+void assert_file_bytes_equal(const char *expected_path, const char *actual_path,
+                             const char *context);
+void compile_source_and_assert_hex(const char *source, const char *fixture_path);
+int run_command_and_capture(const char *cmd, char **captured_output);

--- a/tests/test_parser_examples_obj_golden.c
+++ b/tests/test_parser_examples_obj_golden.c
@@ -1,9 +1,8 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "test_assert.h"
+#include "test_helpers.h"
 
 typedef struct {
   const char *name;
@@ -12,48 +11,17 @@ typedef struct {
   const char *out_path;
 } ParserObjGoldenCase;
 
-static size_t file_size(FILE *f) {
-  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_END));
-  long n = ftell(f);
-  ASSERT_TRUE(n >= 0);
-  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_SET));
-  return (size_t)n;
-}
-
 static void run_case(const ParserObjGoldenCase *tc) {
   char cmd[512];
   int rc = snprintf(cmd, sizeof(cmd), "./scomp %s %s", tc->src_path, tc->out_path);
   ASSERT_TRUE(rc > 0 && (size_t)rc < sizeof(cmd));
 
-  rc = system(cmd);
+  char *output = NULL;
+  rc = run_command_and_capture(cmd, &output);
+  free(output);
   ASSERT_EQ_INT(0, rc);
 
-  FILE *expected_f = fopen(tc->obj_path, "rb");
-  ASSERT_NOT_NULL(expected_f);
-
-  FILE *actual_f = fopen(tc->out_path, "rb");
-  ASSERT_NOT_NULL(actual_f);
-
-  size_t expected_len = file_size(expected_f);
-  size_t actual_len = file_size(actual_f);
-  ASSERT_EQ_INT((int)expected_len, (int)actual_len);
-
-  uint8_t *expected = malloc(expected_len);
-  uint8_t *actual = malloc(actual_len);
-  ASSERT_NOT_NULL(expected);
-  ASSERT_NOT_NULL(actual);
-
-  size_t expected_read = fread(expected, 1, expected_len, expected_f);
-  size_t actual_read = fread(actual, 1, actual_len, actual_f);
-  ASSERT_EQ_INT((int)expected_len, (int)expected_read);
-  ASSERT_EQ_INT((int)actual_len, (int)actual_read);
-
-  ASSERT_EQ_INT(0, memcmp(expected, actual, expected_len));
-
-  fclose(expected_f);
-  fclose(actual_f);
-  free(expected);
-  free(actual);
+  assert_file_bytes_equal(tc->obj_path, tc->out_path, tc->name);
   remove(tc->out_path);
 }
 

--- a/tests/test_pipeline_golden.c
+++ b/tests/test_pipeline_golden.c
@@ -47,11 +47,10 @@ static void run_case(const GoldenCase *tc) {
   ASSERT_EQ_INT(ERR_NOERROR, rc);
   ASSERT_TRUE(errdetail == NULL);
 
+  size_t actual_len = (size_t)(out.nextbyte - out.bytecode);
   size_t expected_len = 0;
   uint8_t *expected = load_hex_fixture(tc->fixture_path, &expected_len);
-  size_t actual_len = (size_t)(out.nextbyte - out.bytecode);
-  ASSERT_EQ_INT((int)expected_len, (int)actual_len);
-  ASSERT_EQ_INT(0, memcmp(expected, out.bytecode, expected_len));
+  assert_bytes_equal_with_diag(expected, expected_len, out.bytecode, actual_len, tc->name);
 
   free(expected);
   free(out.bytecode);

--- a/tests/test_pipeline_source_golden.c
+++ b/tests/test_pipeline_source_golden.c
@@ -15,22 +15,8 @@ typedef struct {
 } SourceGoldenCase;
 
 static void run_source_case(const SourceGoldenCase *tc) {
-  char *errdetail = NULL;
-  OUTPUT_t *out = NULL;
-  int8_t rc = compile_source_to_bytecode(tc->source, strlen(tc->source), &out, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-  ASSERT_NOT_NULL(out);
-
-  size_t expected_len = 0;
-  uint8_t *expected = load_hex_fixture(tc->fixture_path, &expected_len);
-  size_t actual_len = (size_t)(out->nextbyte - out->bytecode);
-  ASSERT_EQ_INT((int)expected_len, (int)actual_len);
-  ASSERT_EQ_INT(0, memcmp(expected, out->bytecode, expected_len));
-
-  free(expected);
-  free(out->bytecode);
-  free(out);
+  (void)tc->name;
+  compile_source_and_assert_hex(tc->source, tc->fixture_path);
 }
 
 static void test_source_pipeline_negative_cases(void) {
@@ -79,8 +65,7 @@ static void test_source_exprstmt_libcall_no_pop(void) {
       0x68,
   };
   size_t n = (size_t)(out->nextbyte - out->bytecode);
-  ASSERT_EQ_INT((int)sizeof(expected), (int)n);
-  ASSERT_EQ_INT(0, memcmp(expected, out->bytecode, n));
+  assert_bytes_equal_with_diag(expected, sizeof(expected), out->bytecode, n, "exprstmt_libcall_no_pop");
 
   free(out->bytecode);
   free(out);
@@ -106,8 +91,7 @@ static void test_source_item_with_numeric_layer(void) {
       'h',
   };
   size_t n = (size_t)(out->nextbyte - out->bytecode);
-  ASSERT_EQ_INT((int)sizeof(expected), (int)n);
-  ASSERT_EQ_INT(0, memcmp(expected, out->bytecode, n));
+  assert_bytes_equal_with_diag(expected, sizeof(expected), out->bytecode, n, "item_with_numeric_layer");
 
   free(out->bytecode);
   free(out);

--- a/tests/test_scomp_e2e_golden.c
+++ b/tests/test_scomp_e2e_golden.c
@@ -10,20 +10,5 @@ void test_scomp_e2e_golden(void) {
   const char *source = "42;";
   const char *hex_fixture = "tests/fixtures/int_literal.hex";
 
-  char *errdetail = NULL;
-  OUTPUT_t *out = NULL;
-  int8_t rc = compile_source_to_bytecode(source, strlen(source), &out, &errdetail);
-  ASSERT_EQ_INT(ERR_NOERROR, rc);
-  ASSERT_TRUE(errdetail == NULL);
-  ASSERT_NOT_NULL(out);
-
-  size_t expected_len = 0;
-  uint8_t *expected = load_hex_fixture(hex_fixture, &expected_len);
-  size_t actual_len = (size_t)(out->nextbyte - out->bytecode);
-  ASSERT_EQ_INT((int)expected_len, (int)actual_len);
-  ASSERT_EQ_INT(0, memcmp(expected, out->bytecode, expected_len));
-
-  free(expected);
-  free(out->bytecode);
-  free(out);
+  compile_source_and_assert_hex(source, hex_fixture);
 }


### PR DESCRIPTION
### Motivation
- Remove duplicated byte-comparison and file-handling logic across golden tests and standardize failure diagnostics including expected length, actual length, and first differing byte offset. 
- Centralize fixture path handling so `load_hex_fixture` remains the single place that implements relative/alternate path fallbacks. 

### Description
- Added test helpers in `tests/test_helpers.h` and implemented them in `tests/test_helpers.c`: `assert_bytes_equal_with_diag`, `assert_file_bytes_equal`, `compile_source_and_assert_hex`, and `run_command_and_capture`. 
- Replaced bespoke comparison logic in `tests/test_pipeline_golden.c`, `tests/test_pipeline_source_golden.c`, `tests/test_parser_examples_obj_golden.c`, and `tests/test_scomp_e2e_golden.c` to call the new helpers. 
- Kept and asserted the existing `load_hex_fixture` fallback behavior for fixture path resolution and routed hex-based assertions through `compile_source_and_assert_hex`. 

### Testing
- Ran `make test` and the test binary executed the updated test suite successfully. 
- Golden comparison behavior for compiled bytecode and object-file outputs was validated via the new helpers during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08292a513c832eba80b43e0815320f)