### PR TITLE
Refactor parser OBJ golden test to compile in-process

### DIFF
--- a/tests/test_parser_examples_obj_golden.c
+++ b/tests/test_parser_examples_obj_golden.c
@@ -1,6 +1,10 @@
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
+#include "compiler_pipeline.h"
+#include "error.h"
 #include "test_assert.h"
 #include "test_helpers.h"
 
@@ -11,17 +15,54 @@ typedef struct {
   const char *out_path;
 } ParserObjGoldenCase;
 
+static char *load_file_text(const char *path, size_t *out_len) {
+  FILE *f = fopen(path, "rb");
+  ASSERT_NOT_NULL(f);
+
+  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_END));
+  long n = ftell(f);
+  ASSERT_TRUE(n >= 0);
+  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_SET));
+
+  size_t len = (size_t)n;
+  char *buf = malloc(len + 1);
+  ASSERT_NOT_NULL(buf);
+  ASSERT_EQ_INT((int)len, (int)fread(buf, 1, len, f));
+  ASSERT_EQ_INT(0, fclose(f));
+  buf[len] = '\0';
+  *out_len = len;
+  return buf;
+}
+
+static void write_output_file(const char *path, const OUTPUT_t *out) {
+  ASSERT_NOT_NULL(path);
+  ASSERT_NOT_NULL(out);
+  ASSERT_NOT_NULL(out->bytecode);
+
+  size_t out_len = (size_t)(out->nextbyte - out->bytecode);
+  FILE *f = fopen(path, "wb");
+  ASSERT_NOT_NULL(f);
+  ASSERT_EQ_INT((int)out_len, (int)fwrite(out->bytecode, 1, out_len, f));
+  ASSERT_EQ_INT(0, fclose(f));
+}
+
 static void run_case(const ParserObjGoldenCase *tc) {
-  char cmd[512];
-  int rc = snprintf(cmd, sizeof(cmd), "./scomp %s %s", tc->src_path, tc->out_path);
-  ASSERT_TRUE(rc > 0 && (size_t)rc < sizeof(cmd));
+  size_t src_len = 0;
+  char *source = load_file_text(tc->src_path, &src_len);
 
-  char *output = NULL;
-  rc = run_command_and_capture(cmd, &output);
-  free(output);
-  ASSERT_EQ_INT(0, rc);
+  char *errdetail = NULL;
+  OUTPUT_t *out = NULL;
+  int8_t rc = compile_source_to_bytecode(source, src_len, &out, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(out);
 
+  write_output_file(tc->out_path, out);
   assert_file_bytes_equal(tc->obj_path, tc->out_path, tc->name);
+
+  free(source);
+  free(out->bytecode);
+  free(out);
   remove(tc->out_path);
 }
 


### PR DESCRIPTION
### Motivation
- Remove fragile raw `system()`/`popen()` invocation in the golden test to avoid shelling out to `./scomp` and improve test isolation.
- Use existing in-process compile API so tests can directly access produced bytecode for deterministic file-level comparisons.
- Preserve the “examples are golden” guarantee by still comparing generated outputs against `examples/*.obj` fixtures.

### Description
- Rewrote `tests/test_parser_examples_obj_golden.c` to read example source files with a new `load_file_text` helper and call `compile_source_to_bytecode` in-process. 
- Added `write_output_file` helper to persist the `OUTPUT_t` bytecode to a generated `.obj` file for comparison.
- Removed the previous `./scomp` invocation and `run_command_and_capture` usage, and replaced it with direct assertions that `compile_source_to_bytecode` returns `ERR_NOERROR`, that `errdetail == NULL`, and that `out` is non-NULL before comparing artifacts.
- Kept the golden comparison using `assert_file_bytes_equal(tc->obj_path, tc->out_path, tc->name)` and clean up generated files after each case.

### Testing
- Ran `make test` and the unified `tests/test-compiler` run completed successfully, including `test_parser_examples_obj_golden`.
- All tests in the test suite passed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082a2663e4832e95c1d144917e55a5)