### PR TITLE
Add fixture policy doc and enforcement test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_emitbc_invariants.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_scomp_e2e_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_pipeline_negative_matrix.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_emitbc_invariants.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_scomp_e2e_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_pipeline_negative_matrix.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c $(TEST_DIR)/test_fixture_policy.c
 
 
 # Library of shared functions

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,55 @@
+# Fixture policy
+
+This directory and related `examples/` artifacts define golden fixtures used by compiler and interpreter tests.
+
+## Golden fixture classes
+
+1. **Source fixtures** (`*.src`)
+   - Purpose: canonical Sin source programs used by golden tests.
+   - Source of truth: the `.src` file contents.
+   - Regeneration: author/edit directly; no generator.
+
+2. **Bytecode hex fixtures** (`*.hex`)
+   - Purpose: expected bytecode snapshots for compile pipeline tests.
+   - Source of truth: compiler output from the associated source/program builder case.
+   - Regeneration: `make regen-fixtures`.
+
+3. **Object fixtures** (`*.obj`)
+   - Purpose: expected object files for parser/e2e/interpreter goldens.
+   - Source of truth: `./scomp` output from the paired `.src` source.
+   - Regeneration examples:
+     - `./scomp -i examples/chat-boot.src -o examples/chat-boot.obj`
+     - `./scomp -i examples/chat-load.src -o examples/chat-load.obj`
+     - `./scomp -i examples/echo-boot.src -o examples/echo-boot.obj`
+     - `./scomp -i examples/echo-load.src -o examples/echo-load.obj`
+
+4. **Interpreter output fixtures** (`*.expected.txt`)
+   - Purpose: expected stdout/stderr/exit contracts for runtime behavior.
+   - Source of truth: `./sin` output for the paired object fixture, normalized to test format.
+   - Regeneration example:
+     - `./sin -f examples/echo-boot.obj > tests/fixtures/interpret/echo-boot.expected.txt`
+
+## Naming conventions
+
+- Use lowercase kebab-case fixture stems (for example: `echo-load`, `chat-boot`, `int_literal`).
+- Keep fixture names aligned across classes when they represent the same program.
+- Use suffixes by class:
+  - source: `.src`
+  - bytecode snapshot: `.hex`
+  - object snapshot: `.obj`
+  - interpreter expectation: `.expected.txt`
+
+## Required comments for case tables
+
+When adding a fixture entry to any golden case table in `tests/*.c`, include a short inline comment that documents:
+
+- `SOT:` source-of-truth artifact (file or builder function)
+- `regen:` exact regeneration command (or `manual` for hand-authored source fixtures)
+
+Example:
+
+```c
+{"echo_load", "examples/echo-load.src", "examples/echo-load.obj"}, /* SOT: examples/echo-load.src | regen: ./scomp -i examples/echo-load.src -o examples/echo-load.obj */
+```
+
+The enforcement test (`tests/test_fixture_policy.c`) validates fixture-file existence and validates comment metadata format for the fixture policy table.

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -26,6 +26,7 @@ void test_sem_duplicate_local_keeps_original_index(void);
 void test_sdiss_fixture_basic(void);
 void test_parser_examples_obj_golden(void);
 void test_interpret_semantics_golden(void);
+void test_fixture_policy_declared_goldens_exist(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -92,5 +93,6 @@ int main(void) {
   test_sdiss_fixture_basic();
   test_parser_examples_obj_golden();
   test_interpret_semantics_golden();
+  test_fixture_policy_declared_goldens_exist();
   return 0;
 }

--- a/tests/test_fixture_policy.c
+++ b/tests/test_fixture_policy.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "test_assert.h"
+
+typedef struct {
+  const char *name;
+  const char *path;
+  const char *comment;
+} FixtureEntry;
+
+static void assert_fixture_entry(const char *class_name, const FixtureEntry *entry) {
+  FILE *f = fopen(entry->path, "rb");
+  ASSERT_NOT_NULL(f);
+  fclose(f);
+
+  ASSERT_TRUE(strncmp(entry->comment, "SOT:", 4) == 0);
+  ASSERT_TRUE(strstr(entry->comment, "| regen:") != NULL);
+
+  (void)class_name;
+}
+
+void test_fixture_policy_declared_goldens_exist(void) {
+  static const FixtureEntry source_fixtures[] = {
+      {"chat_boot_src", "examples/chat-boot.src", "SOT: examples/chat-boot.src | regen: authored source fixture"},
+      {"chat_load_src", "examples/chat-load.src", "SOT: examples/chat-load.src | regen: authored source fixture"},
+      {"echo_boot_src", "examples/echo-boot.src", "SOT: examples/echo-boot.src | regen: authored source fixture"},
+      {"echo_load_src", "examples/echo-load.src", "SOT: examples/echo-load.src | regen: authored source fixture"},
+      {"int_literal_src", "tests/fixtures/int_literal.src", "SOT: tests/fixtures/int_literal.src | regen: authored source fixture"},
+  };
+
+  static const FixtureEntry bytecode_hex_fixtures[] = {
+      {"int_literal_hex", "tests/fixtures/int_literal.hex", "SOT: pipeline output for tests/fixtures/int_literal.src | regen: make regen-fixtures"},
+      {"string_literal_hex", "tests/fixtures/string_literal.hex", "SOT: AST builder in tests/test_pipeline_golden.c | regen: make regen-fixtures"},
+      {"locals_store_load_hex", "tests/fixtures/locals_store_load.hex", "SOT: pipeline/source golden tables | regen: make regen-fixtures"},
+      {"arithmetic_add_hex", "tests/fixtures/arithmetic_add.hex", "SOT: pipeline/source golden tables | regen: make regen-fixtures"},
+      {"boolean_compare_hex", "tests/fixtures/boolean_compare.hex", "SOT: AST builder in tests/test_pipeline_golden.c | regen: make regen-fixtures"},
+      {"simple_if_hex", "tests/fixtures/simple_if.hex", "SOT: AST builder in tests/test_pipeline_golden.c | regen: make regen-fixtures"},
+      {"if_elsif_else_hex", "tests/fixtures/if_elsif_else.hex", "SOT: inline source in tests/test_pipeline_source_golden.c | regen: make regen-fixtures"},
+      {"locals_inc_hex", "tests/fixtures/locals_inc.hex", "SOT: inline source in tests/test_pipeline_source_golden.c | regen: make regen-fixtures"},
+      {"locals_dec_hex", "tests/fixtures/locals_dec.hex", "SOT: inline source in tests/test_pipeline_source_golden.c | regen: make regen-fixtures"},
+      {"sdiss_basic_hex", "tests/fixtures/sdiss/basic.hex", "SOT: hand-authored disassembly sample | regen: manual update plus expected sync"},
+  };
+
+  static const FixtureEntry object_fixtures[] = {
+      {"chat_boot_obj", "examples/chat-boot.obj", "SOT: compiler output from examples/chat-boot.src | regen: ./scomp -i examples/chat-boot.src -o examples/chat-boot.obj"},
+      {"chat_load_obj", "examples/chat-load.obj", "SOT: compiler output from examples/chat-load.src | regen: ./scomp -i examples/chat-load.src -o examples/chat-load.obj"},
+      {"echo_boot_obj", "examples/echo-boot.obj", "SOT: compiler output from examples/echo-boot.src | regen: ./scomp -i examples/echo-boot.src -o examples/echo-boot.obj"},
+      {"echo_load_obj", "examples/echo-load.obj", "SOT: compiler output from examples/echo-load.src | regen: ./scomp -i examples/echo-load.src -o examples/echo-load.obj"},
+  };
+
+  static const FixtureEntry interpret_output_fixtures[] = {
+      {"chat_boot_expected", "tests/fixtures/interpret/chat-boot.expected.txt", "SOT: runtime output contract for chat-boot | regen: ./sin -f examples/chat-boot.obj > tests/fixtures/interpret/chat-boot.expected.txt"},
+      {"chat_load_expected", "tests/fixtures/interpret/chat-load.expected.txt", "SOT: runtime output contract for chat-load | regen: ./sin -f examples/chat-load.obj > tests/fixtures/interpret/chat-load.expected.txt"},
+      {"echo_boot_expected", "tests/fixtures/interpret/echo-boot.expected.txt", "SOT: runtime output contract for echo-boot | regen: ./sin -f examples/echo-boot.obj > tests/fixtures/interpret/echo-boot.expected.txt"},
+      {"echo_load_expected", "tests/fixtures/interpret/echo-load.expected.txt", "SOT: runtime output contract for echo-load | regen: ./sin -f examples/echo-load.obj > tests/fixtures/interpret/echo-load.expected.txt"},
+      {"sdiss_basic_expected", "tests/fixtures/sdiss/basic.expected.txt", "SOT: sdiss stdout for tests/fixtures/sdiss/basic.hex | regen: ./sdiss --no-header -o tests/fixtures/sdiss/basic.bin"},
+  };
+
+  for (size_t i = 0; i < sizeof(source_fixtures) / sizeof(source_fixtures[0]); i++) {
+    assert_fixture_entry("source", &source_fixtures[i]);
+  }
+  for (size_t i = 0; i < sizeof(bytecode_hex_fixtures) / sizeof(bytecode_hex_fixtures[0]); i++) {
+    assert_fixture_entry("bytecode_hex", &bytecode_hex_fixtures[i]);
+  }
+  for (size_t i = 0; i < sizeof(object_fixtures) / sizeof(object_fixtures[0]); i++) {
+    assert_fixture_entry("object", &object_fixtures[i]);
+  }
+  for (size_t i = 0; i < sizeof(interpret_output_fixtures) / sizeof(interpret_output_fixtures[0]); i++) {
+    assert_fixture_entry("interpret_output", &interpret_output_fixtures[i]);
+  }
+}


### PR DESCRIPTION
### Motivation

- Ensure golden fixtures used by compiler/interpreter tests are discoverable, documented with a clear source-of-truth (SOT) and regeneration command, and kept in sync with automated checks.
- Provide lightweight enforcement to prevent regressions from missing or undocumented fixtures in golden test tables.

### Description

- Add `tests/fixtures/README.md` which documents the four golden fixture classes (source, bytecode hex, object, interpreter output), their source-of-truth guidance, regeneration commands, naming conventions, and required `SOT`/`regen` comment format.
- Add `tests/test_fixture_policy.c`, which declares fixture tables for each class and verifies that each declared fixture file exists and that the inline comment metadata begins with `SOT:` and contains `| regen:`.
- Wire the new test into the test runner by adding the declaration/invocation to `tests/test_compiler.c` and adding `tests/test_fixture_policy.c` to `Makefile` test sources.
- Document example regeneration commands such as `make regen-fixtures`, `./scomp -i <src> -o <obj>`, `./sin -f <obj> > <expected.txt>`, and `./sdiss --no-header -o <bin>` in the README.

### Testing

- Ran `make test` which compiled the tools and test runner and executed `tests/test-compiler`; the run completed successfully (tests passed).
- The new enforcement test `test_fixture_policy_declared_goldens_exist` executed as part of the test runner and validated the declared fixture entries and their metadata format.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082c658e80832eb5752b480a2b78b6)