### PR TITLE
Add CompilerContext ownership to scomp pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_emitbc_invariants.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_pipeline_negative_matrix.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c $(TEST_DIR)/test_fixture_policy.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_emitbc_invariants.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_pipeline_negative_matrix.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c $(TEST_DIR)/test_fixture_policy.c $(TEST_DIR)/test_compiler_context_failures.c
 
 
 # Library of shared functions
 LIB := $(LIB_DIR)/libsinshared.a
 LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o $(OBJ_DIR)/parser.o \
                $(OBJ_DIR)/lexer.o $(OBJ_DIR)/absyn.o $(OBJ_DIR)/semant.o \
-               $(OBJ_DIR)/ir.o $(OBJ_DIR)/lower.o $(OBJ_DIR)/compiler_pipeline.o $(OBJ_DIR)/emitbc.o \
+               $(OBJ_DIR)/ir.o $(OBJ_DIR)/lower.o $(OBJ_DIR)/compiler_context.o $(OBJ_DIR)/compiler_pipeline.o $(OBJ_DIR)/emitbc.o \
                $(OBJ_DIR)/compdiag.o $(OBJ_DIR)/error.o $(OBJ_DIR)/util.o $(OBJ_DIR)/libcall.o \
                $(OBJ_DIR)/stack.o $(OBJ_DIR)/value.o $(OBJ_DIR)/item.o \
                $(OBJ_DIR)/vm.o $(OBJ_DIR)/task.o $(OBJ_DIR)/interpret.o \

--- a/src/compiler_context.c
+++ b/src/compiler_context.c
@@ -1,0 +1,60 @@
+#include "compiler_context.h"
+
+#include <string.h>
+
+#include "memory.h"
+
+void compiler_context_init(CompilerContext *ctx, const char *source, size_t source_len) {
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->source = source;
+  ctx->source_len = source_len;
+}
+
+void compiler_context_reset(CompilerContext *ctx) {
+  if (!ctx) {
+    return;
+  }
+
+  if (ctx->ast_root) {
+    as_delete(ctx->ast_root);
+    ctx->ast_root = NULL;
+  }
+  if (ctx->sem_ctx) {
+    sem_delete_ctx(ctx->sem_ctx);
+    ctx->sem_ctx = NULL;
+  }
+  if (ctx->ir_unit) {
+    ir_destroy_unit(ctx->ir_unit);
+    ctx->ir_unit = NULL;
+  }
+  if (ctx->bytecode_out) {
+    if (ctx->bytecode_out->bytecode) {
+      FREE_ARRAY(unsigned char, ctx->bytecode_out->bytecode, ctx->bytecode_out->maxsize);
+    }
+    FREE_ARRAY(OUTPUT_t, ctx->bytecode_out, 1);
+    ctx->bytecode_out = NULL;
+  }
+  if (ctx->diagnostic) {
+    FREE_ARRAY(char, ctx->diagnostic, 1);
+    ctx->diagnostic = NULL;
+  }
+}
+
+void compiler_context_destroy(CompilerContext *ctx) {
+  compiler_context_reset(ctx);
+  if (ctx) {
+    memset(ctx, 0, sizeof(*ctx));
+  }
+}
+
+int8_t compiler_context_prepare_bytecode_output(CompilerContext *ctx, size_t initial_size) {
+  if (!ctx || initial_size == 0) {
+    return -1;
+  }
+
+  ctx->bytecode_out = GROW_ARRAY(OUTPUT_t, NULL, 0, 1);
+  ctx->bytecode_out->maxsize = initial_size;
+  ctx->bytecode_out->bytecode = GROW_ARRAY(unsigned char, NULL, 0, ctx->bytecode_out->maxsize);
+  ctx->bytecode_out->nextbyte = ctx->bytecode_out->bytecode;
+  return 0;
+}

--- a/src/compiler_context.h
+++ b/src/compiler_context.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "absyn.h"
+#include "emitbc.h"
+#include "ir.h"
+#include "semant.h"
+
+typedef struct {
+  const char *source;
+  size_t source_len;
+
+  AS_NODE *ast_root;
+  SEM_CTX *sem_ctx;
+  IR_Unit *ir_unit;
+  OUTPUT_t *bytecode_out;
+
+  char *diagnostic;
+} CompilerContext;
+
+void compiler_context_init(CompilerContext *ctx, const char *source, size_t source_len);
+void compiler_context_reset(CompilerContext *ctx);
+void compiler_context_destroy(CompilerContext *ctx);
+
+int8_t compiler_context_prepare_bytecode_output(CompilerContext *ctx, size_t initial_size);

--- a/src/compiler_pipeline.c
+++ b/src/compiler_pipeline.c
@@ -1,42 +1,14 @@
 #include "compiler_pipeline.h"
 
-#include "absyn.h"
+#include "compiler_context.h"
 #include "error.h"
-#include "ir.h"
 #include "lower.h"
-#include "memory.h"
 #include "parser.h"
-#include "semant.h"
-
-typedef struct {
-  AS_NODE *absyn;
-  SEM_CTX *sem;
-  IR_Unit *ir;
-  OUTPUT_t *out;
-} CompileObjects;
-
-static void cleanup_compile_objects(CompileObjects *objs) {
-  if (objs->absyn) {
-    as_delete(objs->absyn);
-  }
-  if (objs->sem) {
-    sem_delete_ctx(objs->sem);
-  }
-  if (objs->ir) {
-    ir_destroy_unit(objs->ir);
-  }
-  if (objs->out) {
-    if (objs->out->bytecode) {
-      FREE_ARRAY(unsigned char, objs->out->bytecode, objs->out->maxsize);
-    }
-    FREE_ARRAY(OUTPUT_t, objs->out, 1);
-  }
-}
 
 int8_t compile_source_to_bytecode_with_params(const char *source, size_t len,
                                               const char **params, size_t param_count,
                                               OUTPUT_t **out, char **errdetail) {
-  CompileObjects objs = {0};
+  CompilerContext ctx;
   int8_t rc = ERR_NOERROR;
 
   if (!source || !out) {
@@ -44,55 +16,53 @@ int8_t compile_source_to_bytecode_with_params(const char *source, size_t len,
   }
 
   *out = NULL;
+  compiler_context_init(&ctx, source, len);
 
-  objs.out = GROW_ARRAY(OUTPUT_t, NULL, 0, 1);
-  objs.out->maxsize = 1024;
-  objs.out->bytecode = GROW_ARRAY(unsigned char, NULL, 0, objs.out->maxsize);
-  objs.out->nextbyte = objs.out->bytecode;
-
-  objs.sem = sem_create_ctx();
-
-  rc = parse_source((char *)source, (int)len, &objs.absyn, errdetail);
-  if (rc != ERR_NOERROR) {
-    goto fail;
+  if (compiler_context_prepare_bytecode_output(&ctx, 1024) != 0) {
+    rc = ERR_COMP_SYNTAX;
+    goto done;
   }
 
-  sem_seed_params(objs.sem, params, param_count);
-
-  rc = sem_check_locals(objs.absyn, errdetail, objs.sem);
+  ctx.sem_ctx = sem_create_ctx();
+  rc = parse_source((char *)ctx.source, (int)ctx.source_len, &ctx.ast_root, errdetail);
   if (rc != ERR_NOERROR) {
-    goto fail;
+    goto done;
   }
 
-  rc = lower_ast_to_ir(objs.absyn, objs.sem, &objs.ir, errdetail);
+  sem_seed_params(ctx.sem_ctx, params, param_count);
+
+  rc = sem_check_locals(ctx.ast_root, errdetail, ctx.sem_ctx);
   if (rc != ERR_NOERROR) {
-    goto fail;
+    goto done;
   }
 
-  rc = ir_validate(objs.ir, objs.sem->count, errdetail);
+  rc = lower_ast_to_ir(ctx.ast_root, ctx.sem_ctx, &ctx.ir_unit, errdetail);
   if (rc != ERR_NOERROR) {
-    goto fail;
+    goto done;
+  }
+
+  rc = ir_validate(ctx.ir_unit, ctx.sem_ctx->count, errdetail);
+  if (rc != ERR_NOERROR) {
+    goto done;
   }
 
   uint8_t emitted_param_count = 0;
-  for (uint32_t i = 0; i < objs.sem->count; i++) {
-    if (objs.sem->locals[i].param) {
+  for (uint32_t i = 0; i < ctx.sem_ctx->count; i++) {
+    if (ctx.sem_ctx->locals[i].param) {
       emitted_param_count++;
     }
   }
 
-  rc = emit_bytecode(objs.ir, (uint8_t)objs.sem->count, emitted_param_count, objs.out, errdetail);
+  rc = emit_bytecode(ctx.ir_unit, (uint8_t)ctx.sem_ctx->count, emitted_param_count, ctx.bytecode_out, errdetail);
   if (rc != ERR_NOERROR) {
-    goto fail;
+    goto done;
   }
 
-  *out = objs.out;
-  objs.out = NULL;
-  cleanup_compile_objects(&objs);
-  return ERR_NOERROR;
+  *out = ctx.bytecode_out;
+  ctx.bytecode_out = NULL;
 
-fail:
-  cleanup_compile_objects(&objs);
+done:
+  compiler_context_destroy(&ctx);
   return rc;
 }
 

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -28,6 +28,7 @@ void test_sdiss_fixture_basic(void);
 void test_parser_examples_obj_golden(void);
 void test_interpret_semantics_golden(void);
 void test_fixture_policy_declared_goldens_exist(void);
+void test_compiler_context_failures(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -102,5 +103,6 @@ int main(void) {
   run_test("test_parser_examples_obj_golden", test_parser_examples_obj_golden);
   run_test("test_interpret_semantics_golden", test_interpret_semantics_golden);
   run_test("test_fixture_policy_declared_goldens_exist", test_fixture_policy_declared_goldens_exist);
+  run_test("test_compiler_context_failures", test_compiler_context_failures);
   return 0;
 }

--- a/tests/test_compiler_context_failures.c
+++ b/tests/test_compiler_context_failures.c
@@ -1,0 +1,88 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "compiler_context.h"
+#include "error.h"
+#include "ir.h"
+#include "lower.h"
+#include "parser.h"
+#include "semant.h"
+#include "test_assert.h"
+
+static void test_context_parse_failure_cleanup(void) {
+  CompilerContext ctx;
+  char *errdetail = NULL;
+  compiler_context_init(&ctx, "^;", 2);
+  ASSERT_EQ_INT(0, compiler_context_prepare_bytecode_output(&ctx, 64));
+  ctx.sem_ctx = sem_create_ctx();
+
+  int8_t rc = parse_source((char *)ctx.source, (int)ctx.source_len, &ctx.ast_root, &errdetail);
+  ASSERT_TRUE(rc != ERR_NOERROR);
+  ASSERT_NOT_NULL(errdetail);
+
+  free(errdetail);
+  compiler_context_destroy(&ctx);
+}
+
+static void test_context_semant_failure_cleanup(void) {
+  CompilerContext ctx;
+  char *errdetail = NULL;
+  const char *src = "@x;";
+  compiler_context_init(&ctx, src, strlen(src));
+  ASSERT_EQ_INT(0, compiler_context_prepare_bytecode_output(&ctx, 64));
+  ctx.sem_ctx = sem_create_ctx();
+
+  ASSERT_EQ_INT(ERR_NOERROR,
+                parse_source((char *)ctx.source, (int)ctx.source_len, &ctx.ast_root, &errdetail));
+  int8_t rc = sem_check_locals(ctx.ast_root, &errdetail, ctx.sem_ctx);
+  ASSERT_TRUE(rc != ERR_NOERROR);
+  ASSERT_NOT_NULL(errdetail);
+
+  free(errdetail);
+  compiler_context_destroy(&ctx);
+}
+
+static void test_context_lower_failure_cleanup(void) {
+  CompilerContext ctx;
+  char *errdetail = NULL;
+  const char *src = "@x;";
+  compiler_context_init(&ctx, src, strlen(src));
+  ASSERT_EQ_INT(0, compiler_context_prepare_bytecode_output(&ctx, 64));
+  ctx.sem_ctx = sem_create_ctx();
+
+  ASSERT_EQ_INT(ERR_NOERROR,
+                parse_source((char *)ctx.source, (int)ctx.source_len, &ctx.ast_root, &errdetail));
+
+  int8_t rc = lower_ast_to_ir(ctx.ast_root, ctx.sem_ctx, &ctx.ir_unit, &errdetail);
+  ASSERT_TRUE(rc != ERR_NOERROR);
+  ASSERT_NOT_NULL(errdetail);
+
+  free(errdetail);
+  compiler_context_destroy(&ctx);
+}
+
+static void test_context_emit_failure_cleanup(void) {
+  CompilerContext ctx;
+  char *errdetail = NULL;
+  compiler_context_init(&ctx, NULL, 0);
+  ASSERT_EQ_INT(0, compiler_context_prepare_bytecode_output(&ctx, 64));
+
+  ctx.ir_unit = ir_create_unit();
+  ASSERT_NOT_NULL(ctx.ir_unit);
+  ir_emit(ctx.ir_unit, (IR_Inst){.op = IR_OP_JUMP, .a = 999});
+  ir_emit(ctx.ir_unit, (IR_Inst){.op = IR_OP_HALT});
+
+  int8_t rc = emit_bytecode(ctx.ir_unit, 0, 0, ctx.bytecode_out, &errdetail);
+  ASSERT_TRUE(rc != ERR_NOERROR);
+  ASSERT_NOT_NULL(errdetail);
+
+  free(errdetail);
+  compiler_context_destroy(&ctx);
+}
+
+void test_compiler_context_failures(void) {
+  test_context_parse_failure_cleanup();
+  test_context_semant_failure_cleanup();
+  test_context_lower_failure_cleanup();
+  test_context_emit_failure_cleanup();
+}


### PR DESCRIPTION
### Motivation
- Centralize ownership of per-compilation artifacts so the scomp pipeline has a single owner for phase outputs and a single teardown path. 
- Eliminate repeated ad-hoc free/goto-fail blocks and reduce the risk of leaks/double-frees on early-exit paths.

### Description
- Introduce `CompilerContext` in `src/compiler_context.h` / `src/compiler_context.c` that holds source metadata, AST root, `SEM_CTX`, `IR_Unit`, `OUTPUT_t` bytecode buffer, and a diagnostic slot, and provide lifecycle APIs `compiler_context_init`, `compiler_context_reset`, `compiler_context_destroy`, and `compiler_context_prepare_bytecode_output`.
- Refactor `compile_source_to_bytecode_with_params` (in `src/compiler_pipeline.c`) to allocate and register all phase outputs through `CompilerContext`, transfer final ownership of the output buffer to the caller, and use a single structured teardown via `compiler_context_destroy`.
- Add a regression test `tests/test_compiler_context_failures.c` that exercises parse/semantic/lower/emit failure cleanup using the context-backed workflow and wire it into the test harness by updating `tests/test_compiler.c` and `Makefile`.
- Update build wiring in the `Makefile` to compile the new `compiler_context.o` and include the new test source.

### Testing
- Ran the project test-suite with `make test -j4` (build + tests/test-compiler) and the test run completed successfully with the new failure-regression tests included. 
- New test `tests/test_compiler_context_failures.c` exercised parse, semantic, lower, and emit failure paths and passed in the automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0855b47650832ebbba46b68ae1bba0)