### PR TITLE
Introduce failure-aware allocation helpers and propagate allocation errors with tests

### DIFF
--- a/src/absyn.c
+++ b/src/absyn.c
@@ -75,18 +75,24 @@ AS_NODE *as_new_stmtlist_node(void) {
   return as_new_node(N_STMTLIST, as_new_stmtlist(), NULL);
 }
 
-AS_NODE *as_stmtlist_append(AS_NODE *stmtlist_node, AS_NODE *stmt) {
+bool as_stmtlist_append_checked(AS_NODE *stmtlist_node, AS_NODE *stmt) {
   if (!stmtlist_node || stmtlist_node->nodetype != N_STMTLIST || !stmt) {
-    return stmtlist_node;
+    return true;
   }
   AS_STMTLIST *stmtlist = (AS_STMTLIST *)stmtlist_node->lhs;
   if (stmtlist->count == stmtlist->capacity) {
-    int oldcap = stmtlist->capacity;
-    stmtlist->capacity = stmtlist->capacity == 0 ? 4 : stmtlist->capacity * 2;
-    stmtlist->stmts = GROW_ARRAY(AS_NODE*, stmtlist->stmts, oldcap,
-                                                          stmtlist->capacity);
+    size_t oldcap = stmtlist->capacity;
+    size_t newcap = 0;
+    if (!alloc_grow_capacity(oldcap, oldcap + 1, &newcap)) return false;
+    if (!alloc_grow_array((void **)&stmtlist->stmts, oldcap, newcap, sizeof(AS_NODE*))) return false;
+    stmtlist->capacity = (uint32_t)newcap;
   }
   stmtlist->stmts[stmtlist->count++] = stmt;
+  return true;
+}
+
+AS_NODE *as_stmtlist_append(AS_NODE *stmtlist_node, AS_NODE *stmt) {
+  (void)as_stmtlist_append_checked(stmtlist_node, stmt);
   return stmtlist_node;
 }
 

--- a/src/absyn.h
+++ b/src/absyn.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 typedef enum { V_INT, V_STR, V_LOCAL, V_LAYER } ENUM_VALUE;
 struct AS_VALUE_s {
@@ -50,9 +51,9 @@ AS_NODE *as_new_valnode(ENUM_VALUE valtype, char *sval);
 AS_STMTLIST *as_new_stmtlist(void);
 AS_NODE *as_new_stmtlist_node(void);
 AS_NODE *as_stmtlist_append(AS_NODE *stmtlist_node, AS_NODE *stmt);
+bool as_stmtlist_append_checked(AS_NODE *stmtlist_node, AS_NODE *stmt);
 AS_NODE *as_new_node(ENUM_NODE nodetype, void *lhs, void *rhs);
 AS_IF *as_new_if(AS_NODE *condition, AS_NODE *then, AS_IF *elsif);
 void as_delete(AS_NODE *root);
 void as_delete_if(AS_IF *asif);
 void as_walk(AS_NODE *root);
-

--- a/src/compiler_context.c
+++ b/src/compiler_context.c
@@ -52,9 +52,9 @@ int8_t compiler_context_prepare_bytecode_output(CompilerContext *ctx, size_t ini
     return -1;
   }
 
-  ctx->bytecode_out = GROW_ARRAY(OUTPUT_t, NULL, 0, 1);
+  if (!alloc_grow_array((void **)&ctx->bytecode_out, 0, 1, sizeof(OUTPUT_t))) return -1;
   ctx->bytecode_out->maxsize = initial_size;
-  ctx->bytecode_out->bytecode = GROW_ARRAY(unsigned char, NULL, 0, ctx->bytecode_out->maxsize);
+  if (!alloc_grow_array((void **)&ctx->bytecode_out->bytecode, 0, ctx->bytecode_out->maxsize, sizeof(unsigned char))) return -1;
   ctx->bytecode_out->nextbyte = ctx->bytecode_out->bytecode;
   return 0;
 }

--- a/src/emitbc.c
+++ b/src/emitbc.c
@@ -30,13 +30,16 @@ typedef struct {
 
 static int bw_ensure(BC_Writer *w, size_t extra) {
   if (w->failed) return 0;
-  size_t needed = w->used + extra;
+  size_t needed = 0;
+  if (alloc_add_overflow(w->used, extra, &needed)) { w->failed = 1; return 0; }
   if (needed <= w->out->maxsize) return 1;
   size_t oldcap = w->out->maxsize;
-  size_t newcap = GROW_CAPACITY(oldcap);
-  while (newcap < needed) newcap = GROW_CAPACITY(newcap);
-  w->out->bytecode = GROW_ARRAY(unsigned char, w->out->bytecode, oldcap, newcap);
-  if (!w->out->bytecode) {
+  size_t newcap = 0;
+  if (!alloc_grow_capacity(oldcap, needed, &newcap)) {
+    w->failed = 1;
+    return 0;
+  }
+  if (!alloc_grow_array((void **)&w->out->bytecode, oldcap, newcap, sizeof(unsigned char))) {
     w->failed = 1;
     return 0;
   }
@@ -126,7 +129,13 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
     return errnum;
   }
 
-  size_t *pos = GROW_ARRAY(size_t, NULL, 0, ir->function.count > 0 ? ir->function.count : 1);
+  size_t pos_count = ir->function.count > 0 ? ir->function.count : 1;
+  size_t *pos = NULL;
+  if (!alloc_grow_array((void **)&pos, 0, pos_count, sizeof(size_t))) {
+    int8_t errnum = ERR_NOERROR;
+    compdiag_set_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "out of memory allocating position map");
+    return errnum;
+  }
   size_t pc = 2;
   for (size_t i = 0; i < ir->function.count; i++) {
     const IR_Inst *in = &ir->function.code[i];

--- a/src/ir.c
+++ b/src/ir.c
@@ -13,34 +13,28 @@
 #include "ir.h"
 #include "memory.h"
 
-static void ensure_inst_capacity(IR_Function* function, size_t needed) {
+static bool ensure_inst_capacity(IR_Function* function, size_t needed) {
   if (function->capacity >= needed) {
-    return;
+    return true;
   }
-
   size_t oldcap = function->capacity;
-  size_t newcap = GROW_CAPACITY(oldcap);
-  while (newcap < needed) {
-    newcap = GROW_CAPACITY(newcap);
-  }
-
-  function->code = GROW_ARRAY(IR_Inst, function->code, oldcap, newcap);
+  size_t newcap = 0;
+  if (!alloc_grow_capacity(oldcap, needed, &newcap)) return false;
+  if (!alloc_grow_array((void **)&function->code, oldcap, newcap, sizeof(IR_Inst))) return false;
   function->capacity = newcap;
+  return true;
 }
 
-static void ensure_label_capacity(IR_LabelTable* labels, size_t needed) {
+static bool ensure_label_capacity(IR_LabelTable* labels, size_t needed) {
   if (labels->capacity >= needed) {
-    return;
+    return true;
   }
-
   size_t oldcap = labels->capacity;
-  size_t newcap = GROW_CAPACITY(oldcap);
-  while (newcap < needed) {
-    newcap = GROW_CAPACITY(newcap);
-  }
-
-  labels->entries = GROW_ARRAY(IR_Label, labels->entries, oldcap, newcap);
+  size_t newcap = 0;
+  if (!alloc_grow_capacity(oldcap, needed, &newcap)) return false;
+  if (!alloc_grow_array((void **)&labels->entries, oldcap, newcap, sizeof(IR_Label))) return false;
   labels->capacity = newcap;
+  return true;
 }
 
 IR_Unit* ir_create_unit(void) {
@@ -65,7 +59,7 @@ void ir_destroy_unit(IR_Unit* unit) {
 
 size_t ir_emit(IR_Unit* unit, IR_Inst inst) {
   size_t idx = unit->function.count;
-  ensure_inst_capacity(&unit->function, idx + 1);
+  if (!ensure_inst_capacity(&unit->function, idx + 1)) return SIZE_MAX;
   unit->function.code[idx] = inst;
   unit->function.count++;
   return idx;
@@ -73,7 +67,7 @@ size_t ir_emit(IR_Unit* unit, IR_Inst inst) {
 
 int32_t ir_new_label(IR_Unit* unit) {
   size_t idx = unit->labels.count;
-  ensure_label_capacity(&unit->labels, idx + 1);
+  if (!ensure_label_capacity(&unit->labels, idx + 1)) return -1;
 
   IR_Label* label = &unit->labels.entries[idx];
   label->id = (int32_t)idx;
@@ -96,18 +90,19 @@ bool ir_bind_label(IR_Unit* unit, int32_t label_id) {
   return true;
 }
 
-static void ensure_embedded_capacity(IR_EmbeddedCodeTable* table, size_t needed) {
-  if (table->capacity >= needed) return;
+static bool ensure_embedded_capacity(IR_EmbeddedCodeTable* table, size_t needed) {
+  if (table->capacity >= needed) return true;
   size_t oldcap = table->capacity;
-  size_t newcap = GROW_CAPACITY(oldcap);
-  while (newcap < needed) newcap = GROW_CAPACITY(newcap);
-  table->entries = GROW_ARRAY(IR_EmbeddedCodePayload, table->entries, oldcap, newcap);
+  size_t newcap = 0;
+  if (!alloc_grow_capacity(oldcap, needed, &newcap)) return false;
+  if (!alloc_grow_array((void **)&table->entries, oldcap, newcap, sizeof(IR_EmbeddedCodePayload))) return false;
   table->capacity = newcap;
+  return true;
 }
 
 int32_t ir_add_embedded_code_payload(IR_Unit* unit, IR_EmbeddedCodePayload payload) {
   size_t idx = unit->embedded_code.count;
-  ensure_embedded_capacity(&unit->embedded_code, idx + 1);
+  if (!ensure_embedded_capacity(&unit->embedded_code, idx + 1)) return -1;
   unit->embedded_code.entries[idx] = payload;
   unit->embedded_code.count++;
   return (int32_t)idx;

--- a/src/memory.c
+++ b/src/memory.c
@@ -3,9 +3,47 @@
 // Licensed under the MIT License - see LICENSE file for details.
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "memory.h"
-#include "log.h"
+
+static long g_alloc_counter = 0;
+static long g_fail_after = -1;
+
+bool alloc_mul_overflow(size_t a, size_t b, size_t *out) {
+  if (a != 0 && b > SIZE_MAX / a) return true;
+  if (out) *out = a * b;
+  return false;
+}
+
+bool alloc_add_overflow(size_t a, size_t b, size_t *out) {
+  if (a > SIZE_MAX - b) return true;
+  if (out) *out = a + b;
+  return false;
+}
+
+bool alloc_grow_capacity(size_t oldcap, size_t needed, size_t *newcap) {
+  size_t cap = oldcap < 8 ? 8 : oldcap;
+  while (cap < needed) {
+    if (cap > SIZE_MAX / 2) return false;
+    cap *= 2;
+  }
+  if (newcap) *newcap = cap;
+  return true;
+}
+
+bool alloc_grow_array(void **ptr, size_t oldcap, size_t newcap, size_t elem_size) {
+  size_t oldbytes = 0, newbytes = 0;
+  void *res;
+  if (alloc_mul_overflow(oldcap, elem_size, &oldbytes)) return false;
+  if (alloc_mul_overflow(newcap, elem_size, &newbytes)) return false;
+  res = reallocate(*ptr, oldbytes, newbytes);
+  if (!res && newbytes != 0) return false;
+  *ptr = res;
+  return true;
+}
+
+void alloc_test_fail_after(long nth_allocation) { g_fail_after = nth_allocation; g_alloc_counter = 0; }
 
 void* reallocate(void* ptr, size_t oldcount, size_t newcount) {
   // This function handles all memory allocation, reallocation, and release.
@@ -21,13 +59,12 @@ void* reallocate(void* ptr, size_t oldcount, size_t newcount) {
     return NULL;
   }
 
+  g_alloc_counter++;
+  if (g_fail_after >= 0 && g_alloc_counter >= g_fail_after) return NULL;
+
   void *res;
   if (ptr) {
     res = realloc(ptr, newcount);
-    if (res == NULL) {
-      logerr("Unable to allocate memory.  This is bad.");
-      exit(EXIT_FAILURE);
-    }
   } else {
     res = calloc(1, newcount); // zero all bytes
   }

--- a/src/memory.h
+++ b/src/memory.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 
 // This macro makes numbers bigger.  It is used to double the size of an
@@ -22,3 +23,8 @@
 
 void* reallocate(void* pointer, size_t oldSize, size_t newSize);
 
+bool alloc_mul_overflow(size_t a, size_t b, size_t *out);
+bool alloc_add_overflow(size_t a, size_t b, size_t *out);
+bool alloc_grow_capacity(size_t oldcap, size_t needed, size_t *newcap);
+bool alloc_grow_array(void **ptr, size_t oldcap, size_t newcap, size_t elem_size);
+void alloc_test_fail_after(long nth_allocation);

--- a/src/parser.y
+++ b/src/parser.y
@@ -71,6 +71,7 @@ int8_t parse_source(char *source, int sourcelen, AS_NODE **absyn, char **errdeta
   SCANNER_STATE_t scanner_state;
   scanner_state.errnum = ERR_NOERROR;
   scanner_state.errdetail = NULL;
+  scanner_state.absyn = NULL;
   FILE *in = fmemopen(source, sourcelen, "r");
   yyset_in(in, sc);
 
@@ -81,7 +82,10 @@ int8_t parse_source(char *source, int sourcelen, AS_NODE **absyn, char **errdeta
   yylex_destroy(sc);
 
   if (failed) {
-    scanner_state.absyn = NULL;
+    if (scanner_state.absyn != NULL) {
+      as_delete(scanner_state.absyn);
+      scanner_state.absyn = NULL;
+    }
     *errdetail = scanner_state.errdetail;
     return scanner_state.errnum;
   } else {
@@ -138,7 +142,15 @@ input:  stmtlist { state->absyn = $1; }
         ;
 
 stmtlist: /* Nothing */ { $$ = as_new_stmtlist_node(); }
-        | stmtlist stmtsemi { $$ = as_stmtlist_append($1, $2); }
+        | stmtlist stmtsemi {
+            if (!as_stmtlist_append_checked($1, $2)) {
+              $$ = NULL;
+              state->errnum = ERR_COMP_SYNTAX;
+              state->errdetail = strdup("parser: out of memory growing statement list");
+              YYERROR;
+            }
+            $$ = $1;
+          }
         ;
 
 stmtsemi: stmt TSEMI { $$ = $1; }
@@ -242,4 +254,3 @@ deref_content: item { $$ = $1; }
         | TLOCAL { $$ = as_new_valnode(V_LOCAL, $1); }
         ;
 %%
-

--- a/tests/test_compiler_context_failures.c
+++ b/tests/test_compiler_context_failures.c
@@ -1,10 +1,12 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "compiler_context.h"
 #include "error.h"
 #include "ir.h"
 #include "lower.h"
+#include "memory.h"
 #include "parser.h"
 #include "semant.h"
 #include "test_assert.h"
@@ -85,4 +87,49 @@ void test_compiler_context_failures(void) {
   test_context_semant_failure_cleanup();
   test_context_lower_failure_cleanup();
   test_context_emit_failure_cleanup();
+
+  alloc_test_fail_after(-1);
+  {
+    AS_NODE *list = as_new_stmtlist_node();
+    ASSERT_NOT_NULL(list);
+    for (int i = 0; i < 8; i++) {
+      char buf[8];
+      snprintf(buf, sizeof(buf), "%d", i);
+      ASSERT_TRUE(as_stmtlist_append_checked(list, as_new_valnode(V_INT, strdup(buf))));
+    }
+    AS_NODE *stmt2 = as_new_valnode(V_INT, strdup("9"));
+    alloc_test_fail_after(1);
+    ASSERT_TRUE(!as_stmtlist_append_checked(list, stmt2));
+    as_delete(stmt2);
+    as_delete(list);
+  }
+  alloc_test_fail_after(-1);
+
+  alloc_test_fail_after(1);
+  {
+    IR_Unit *u = ir_create_unit();
+    if (u) {
+      ASSERT_EQ_INT((int)SIZE_MAX, (int)ir_emit(u, (IR_Inst){.op=IR_OP_HALT}));
+      ir_destroy_unit(u);
+    }
+  }
+  alloc_test_fail_after(-1);
+
+  alloc_test_fail_after(3);
+  {
+    OUTPUT_t out = {0};
+    out.maxsize = 1;
+    out.bytecode = malloc(1);
+    out.nextbyte = out.bytecode;
+    IR_Unit *u = ir_create_unit();
+    ASSERT_NOT_NULL(u);
+    ir_emit(u, (IR_Inst){.op=IR_OP_PUSH_INT,.imm=1});
+    char *err = NULL;
+    int8_t rc = emit_bytecode(u, 0, 0, &out, &err);
+    ASSERT_TRUE(rc != ERR_NOERROR);
+    if (err) free(err);
+    ir_destroy_unit(u);
+    free(out.bytecode);
+  }
+  alloc_test_fail_after(-1);
 }


### PR DESCRIPTION
### Motivation

- Replace unchecked growth macros and immediate aborts on allocation failure with explicit, failure-aware allocation helpers to support robust error handling and testable OOM behavior.
- Ensure parser and AST helpers properly clean up on parse/allocation failure instead of leaking or returning partial state.
- Make IR/bytecode emit paths propagate allocation failures instead of proceeding with invalid state.

### Description

- Add safe allocation utilities and failure-injection support in `memory.c`/`memory.h` including `alloc_mul_overflow`, `alloc_add_overflow`, `alloc_grow_capacity`, `alloc_grow_array`, and `alloc_test_fail_after`, and update `reallocate` to honor the failure-injection counter.
- Replace direct `GROW_ARRAY`/`GROW_CAPACITY` usages with the new helpers across modules (`absyn.c`, `ir.c`, `emitbc.c`, `compiler_context.c`) and make capacity-ensure helpers return `bool` so callers can detect failures; convert growth calls to `alloc_grow_array` and `alloc_grow_capacity` and propagate errors.
- Add a checked statement-list append API `as_stmtlist_append_checked` that returns failure on OOM and make `as_stmtlist_append` a wrapper; update the parser (`parser.y`) to use the checked append, free the partial AST on parse failure, and set an appropriate parse error detail.
- Improve `emitbc.c` to detect integer overflow when computing needed buffer size and to grow the output buffer using the new allocation APIs while setting a failure flag on allocation error.
- Update headers to expose the new allocation APIs and include `<stdbool.h>` where needed.
- Add allocation-failure unit tests and expand `tests/test_compiler_context_failures.c` to exercise OOM scenarios for statement list growth, `ir_emit`, and `emit_bytecode` using `alloc_test_fail_after`.

### Testing

- Ran the unit test targeted at compiler context failure scenarios via the test harness, including the updated `tests/test_compiler_context_failures.c`, and the tests covering parse/semant/lower/emit failure cleanup and the new allocation-failure injections, and they passed.
- Exercise of OOM behavior for `as_stmtlist_append_checked`, `ir_emit` (returns `SIZE_MAX` on failure), and `emit_bytecode` (returns error) was validated by the added tests.
- No automated test failures observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0859c4e488832e8741f71e0a2aafb8)