### PR TITLE
Fix sdiss decoding for compiler-emitted CALL/LIBCALL operands

### DIFF
--- a/src/sdiss.c
+++ b/src/sdiss.c
@@ -232,9 +232,11 @@ static uint8_t *h_dec_local(uint8_t *p, uint8_t *e, decode_context_t c) {
 }
 static uint8_t *h_libcall(uint8_t *p, uint8_t *e, decode_context_t c) {
   (void) c;
+  uint8_t argc;
   uint8_t id;
+  if (read_u8(&p, e, &argc, "LIBCALL arg count") != PARSE_OK) return p;
   if (read_u8(&p, e, &id, "LIBCALL id") != PARSE_OK) return p;
-  logmsg("LIBCALL ID %u\n", id);
+  logmsg("LIBCALL ARGC %u ID %u\n", argc, id);
   return p;
 }
 static uint8_t *h_jump(uint8_t *p, uint8_t *e, decode_context_t c) {
@@ -290,9 +292,9 @@ static uint8_t *h_f(uint8_t *p, uint8_t *e, decode_context_t c) {
     logmsg("ITEM DEREF\n");
     return p;
   }
-  uint8_t argc;
-  if (read_u8(&p, e, &argc, "CALL arg count") != PARSE_OK) return p;
-  logmsg("CALL ARGC %u\n", argc);
+  int16_t argc;
+  if (read_i16(&p, e, &argc, "CALL arg count") != PARSE_OK) return p;
+  logmsg("CALL ARGC %d\n", argc);
   return p;
 }
 static uint8_t *h_I(uint8_t *p, uint8_t *e, decode_context_t c) {

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -26,6 +26,7 @@ void test_sem_check_locals_reusable_context(void);
 void test_sem_duplicate_local_keeps_original_index(void);
 void test_sem_code_params_are_treated_as_defined_locals(void);
 void test_sdiss_fixture_basic(void);
+void test_sdiss_reads_compiler_operand_widths(void);
 void test_parser_examples_obj_golden(void);
 void test_interpret_semantics_golden(void);
 void test_fixture_policy_declared_goldens_exist(void);
@@ -104,6 +105,7 @@ int main(void) {
   run_test("test_sem_duplicate_local_keeps_original_index", test_sem_duplicate_local_keeps_original_index);
   run_test("test_sem_code_params_are_treated_as_defined_locals", test_sem_code_params_are_treated_as_defined_locals);
   run_test("test_sdiss_fixture_basic", test_sdiss_fixture_basic);
+  run_test("test_sdiss_reads_compiler_operand_widths", test_sdiss_reads_compiler_operand_widths);
   run_test("test_parser_examples_obj_golden", test_parser_examples_obj_golden);
   run_test("test_interpret_semantics_golden", test_interpret_semantics_golden);
   run_test("test_fixture_policy_declared_goldens_exist", test_fixture_policy_declared_goldens_exist);

--- a/tests/test_sdiss_fixtures.c
+++ b/tests/test_sdiss_fixtures.c
@@ -50,3 +50,31 @@ void test_sdiss_fixture_basic(void) {
   }
   free(expected);
 }
+
+void test_sdiss_reads_compiler_operand_widths(void) {
+  const uint8_t bytes[] = {
+      0x00, 0x00, /* locals/params */
+      'A', 0x02, 0x03, /* LIBCALL argc=2 id=3 */
+      'F', 0x02, 0x00, /* CALL argc=2 */
+      'h'};
+
+  const char *tmp_path = "tests/fixtures/sdiss/operand-widths.bin";
+  FILE *out = fopen(tmp_path, "wb");
+  ASSERT_NOT_NULL(out);
+  ASSERT_EQ_INT((int)sizeof(bytes), (int)fwrite(bytes, 1, sizeof(bytes), out));
+  fclose(out);
+
+  FILE *pipe = popen("./sdiss --no-header -o tests/fixtures/sdiss/operand-widths.bin 2>&1", "r");
+  ASSERT_NOT_NULL(pipe);
+  char output[4096];
+  size_t total = fread(output, 1, sizeof(output) - 1, pipe);
+  output[total] = '\0';
+  int rc = pclose(pipe);
+  ASSERT_TRUE(rc != -1);
+  ASSERT_TRUE(WIFEXITED(rc));
+  ASSERT_EQ_INT(0, WEXITSTATUS(rc));
+
+  ASSERT_TRUE(strstr(output, "LIBCALL ARGC 2 ID 3") != NULL);
+  ASSERT_TRUE(strstr(output, "CALL ARGC 2") != NULL);
+  ASSERT_TRUE(strstr(output, "unknown=0") != NULL);
+}


### PR DESCRIPTION
### Motivation
- Ensure `sdiss` can correctly disassemble bytecode produced by the current compiler by aligning operand widths/ordering with `emitbc` output. 
- Prevent mis-decoding of `LIBCALL` and statement-level `CALL` instructions which caused incorrect or truncated disassembly output.

### Description
- Update `sdiss` `h_libcall` handler to read two `u8` operands (`argc`, `id`) and print both using `logmsg` to match compiler emission. 
- Update `sdiss` `h_f` (statement-level `CALL`) handler to read a 16-bit argument count with `read_i16` and print it, matching the 2-byte encoding emitted by the compiler. 
- Add a regression test `test_sdiss_reads_compiler_operand_widths` in `tests/test_sdiss_fixtures.c` that writes a minimal compiler-shaped bytecode stream containing `LIBCALL`, `CALL`, and `HALT` and asserts the expected decoded strings. 
- Register the new test in the test harness (`tests/test_compiler.c`) so it runs with the rest of the automated tests.

### Testing
- Ran the full test suite via `make test` which built `sdiss` and the test runner and executed the harness. 
- The new regression test `test_sdiss_reads_compiler_operand_widths` executed as part of the harness. 
- All automated tests completed successfully (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a086969de14832eb26c677efbfbdd64)