### PR TITLE
Harden interpreter against invalid/non-code items

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1074,6 +1074,24 @@ VALUE_t interpret(ITEM_t *item) {
   // Given some bytecode, interpret it until the HALT instruction is seen
   // NB: The HALT opcode (currently represented by the character 'h') does
   // not have an associated function.
+  if (!item) {
+    return VALUE_NIL;
+  }
+
+  // Interpreting a value item means returning a copy of its value.
+  // This can happen when the input item is configured as plain data.
+  if (item->type == ITEM_value) {
+    VALUE_t v = item->value;
+    if (v.type == VALUE_str && v.s) {
+      v.s = strdup(v.s);
+    }
+    return v;
+  }
+
+  if (!item->bytecode || item->bytecode_len < 3) {
+    logerr("Unable to interpret item '%s': invalid bytecode.\n", item->name);
+    return VALUE_NIL;
+  }
 
   // First set up the locals
   uint8_t numlocals = item->bytecode[0];
@@ -1089,12 +1107,16 @@ VALUE_t interpret(ITEM_t *item) {
   VM->stack->locals = numlocals;
   VM->stack->params = numparams;
   // The actual bytecode starts at the third byte.
-  uint8_t *op = item->bytecode + 2; 
-  while (*op != 'h') {
+  uint8_t *op = item->bytecode + 2;
+  uint8_t *end = item->bytecode + item->bytecode_len;
+  while (op < end && *op != 'h') {
     // We do it this way to avoid undefined behaviour between
     // two sequence points:
     uint8_t *nextop = op + 1;
     op = opcode[*op](nextop, item);
+  }
+  if (op >= end) {
+    logerr("Reached end of bytecode for item '%s' without HALT.\n", item->name);
   }
 
   // Item is now free to be replaced or deleted


### PR DESCRIPTION
### Motivation
- The interpreter could read past valid bytecode (or be invoked on non-code items) and dispatch random bytes as opcodes, leading to undefined behaviour and segfaults when running the echo server.  

### Description
- Added an early null check in `interpret()` to return `VALUE_NIL` for a null `item`.  
- If `item->type == ITEM_value`, return a copy of the item's value immediately instead of treating it as bytecode.  
- Validate `item->bytecode` and `item->bytecode_len` and log an error and return `VALUE_NIL` when the bytecode is invalid or too short.  
- Bound the interpreter loop with an `end` pointer derived from `item->bytecode_len` to avoid out-of-bounds opcode dispatch and log an explicit error if execution reaches the end without encountering the HALT opcode.  

### Testing
- Built the project with `make -j4` and the build completed successfully.  
- Ran the load step with `./sin -b -oexamples/echo-load.obj` which completed successfully.  
- Launched the boot step with `./sin -oexamples/echo-boot.obj` under a timeout and confirmed there is no segfault; instead the interpreter logs the end-of-bytecode condition when HALT is missing and the process continues (exits only due to the enforced timeout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0895d0bb20832eb42ba0cf520d9aff)