### PR TITLE
Handle CR line endings and prevent infinite net-input scan

### DIFF
--- a/src/libcall.c
+++ b/src/libcall.c
@@ -202,7 +202,8 @@ uint8_t *lc_net_input(uint8_t *nextop, ITEM_t *item) {
   if (config.lastconn >= config.maxconns) {
     config.lastconn = 0;
   }
-  while (config.lastconn < config.maxconns) {
+  uint16_t scans = 0;
+  while (scans < config.maxconns) {
     VALUE_t val = {VALUE_int, {0}};
     // Find some activity.
     switch (line[config.lastconn].status) {
@@ -237,6 +238,10 @@ uint8_t *lc_net_input(uint8_t *nextop, ITEM_t *item) {
         return nextop;
       default:
         config.lastconn++;
+        if (config.lastconn >= config.maxconns) {
+          config.lastconn = 0;
+        }
+        scans++;
     }
   }
   // No activity found.

--- a/src/libcall.c
+++ b/src/libcall.c
@@ -202,8 +202,7 @@ uint8_t *lc_net_input(uint8_t *nextop, ITEM_t *item) {
   if (config.lastconn >= config.maxconns) {
     config.lastconn = 0;
   }
-  uint16_t scans = 0;
-  while (scans < config.maxconns) {
+  for (uint16_t scans = 0; scans < config.maxconns; scans++) {
     VALUE_t val = {VALUE_int, {0}};
     // Find some activity.
     switch (line[config.lastconn].status) {
@@ -241,7 +240,6 @@ uint8_t *lc_net_input(uint8_t *nextop, ITEM_t *item) {
         if (config.lastconn >= config.maxconns) {
           config.lastconn = 0;
         }
-        scans++;
     }
   }
   // No activity found.

--- a/src/network.c
+++ b/src/network.c
@@ -114,7 +114,7 @@ void append_input(LINE_t *line, const char *msg, const ssize_t len) {
     // No point in doing this if there is no connection.
     // If there is a newline in the input, we have received
     // a complete line of input.
-    if (memchr(msg, '\n', len)) {
+    if (memchr(msg, '\n', len) || memchr(msg, '\r', len)) {
       line->status = LINE_data;
     }
     while (line->inbuf->buf.len + len + 1 >= line->inbuf->length) {
@@ -134,19 +134,23 @@ char *get_input(LINE_t *line) {
   // input buffer, set the status to LINE_idle, otherwise leave it
   // unchanged.  The buffer allocated by this function will need to be
   // freed by the calling function when it is no longer needed.
-  // If there isn't a newline in the input buffer, explode messily.
-  char *eol = strchr(line->inbuf->buf.base, '\n');
+  // Find end-of-line marker (LF or CR).
+  char *eol = strpbrk(line->inbuf->buf.base, "\r\n");
+  if (!eol) {
+    // Defensive fallback: no terminator found despite LINE_data.
+    return strdup("");
+  }
   *eol = '\0';
   char *data = strdup(line->inbuf->buf.base);
   // Ok, we have the line of data, now take it out of the input buffer.
-  eol++;
+  while (*eol == '\r' || *eol == '\n') eol++;
   char *newbuffer = malloc(INBUF_LENGTH);
   strcpy(newbuffer, eol);
   free(line->inbuf->buf.base);
   line->inbuf->length = INBUF_LENGTH;
   line->inbuf->buf.base = newbuffer;
   line->inbuf->buf.len = strlen(newbuffer);
-  if (!strchr(line->inbuf->buf.base, '\n')) {
+  if (!strpbrk(line->inbuf->buf.base, "\r\n")) {
     line->status = LINE_idle;
   }
   return data;


### PR DESCRIPTION
### Motivation

- Ensure input terminated by carriage-return (`\r`) is treated as end-of-line so clients that send CR-only lines are processed correctly.
- Fix the fair queuing scan in `lc_net_input` to avoid potential infinite looping or missed connections when iterating `config.lastconn`.

### Description

- Changed `lc_net_input` loop to use a scan counter (`uint16_t scans`) and loop `while (scans < config.maxconns)` with explicit wrap of `config.lastconn` to ensure a bounded scan of connections.
- Updated `append_input` to treat `\r` as an end-of-line marker in addition to `\n` and set `LINE_data` accordingly.
- Rewrote `get_input` to search for either `\r` or `\n` using `strpbrk`, defensively return an empty string if no terminator is found, advance past all contiguous CR/LF bytes, and use `strpbrk` to detect remaining line terminators when deciding whether to set `LINE_idle`.

### Testing

- Built the project with `make`, which completed successfully.
- Ran the project test suite via `make test`, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089b6702ac832e9539234aa3eaba7a)