### PR TITLE
core-compiler-gate: trigger on all push and pull_request events

### DIFF
--- a/.github/workflows/core-compiler-gate.yml
+++ b/.github/workflows/core-compiler-gate.yml
@@ -2,29 +2,7 @@ name: Core compiler gate
 
 on:
   pull_request:
-    paths:
-      - 'src/absyn.c'
-      - 'src/absyn.h'
-      - 'src/ir.c'
-      - 'src/ir.h'
-      - 'src/emitbc.c'
-      - 'src/emitbc.h'
-      - 'tests/**'
-      - 'Makefile'
-      - 'ci/gate_ir_absyn_emitbc.sh'
-      - '.github/workflows/core-compiler-gate.yml'
   push:
-    paths:
-      - 'src/absyn.c'
-      - 'src/absyn.h'
-      - 'src/ir.c'
-      - 'src/ir.h'
-      - 'src/emitbc.c'
-      - 'src/emitbc.h'
-      - 'tests/**'
-      - 'Makefile'
-      - 'ci/gate_ir_absyn_emitbc.sh'
-      - '.github/workflows/core-compiler-gate.yml'
 
 jobs:
   gate:


### PR DESCRIPTION
### Motivation
- Expand CI coverage so the `core-compiler-gate` workflow runs for every `push` and `pull_request` rather than only when specific source or test files change.

### Description
- Removed the `paths` filters under `on: pull_request` and `on: push` in `.github/workflows/core-compiler-gate.yml` so the workflow triggers on all pushes and PRs while keeping the existing job steps (`actions/checkout`, dependency install, and run `./ci/gate_ir_absyn_emitbc.sh`).

### Testing
- No automated tests were executed as part of this change; the workflow will be exercised by CI on subsequent pushes and pull requests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08bcf52534832eb9287a65a2466ba9)