### PR TITLE
Add runtime tests for `sys.compile` libcall behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_emitbc_invariants.c $(TEST_DIR)/test_opcode_schema.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_pipeline_negative_matrix.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c $(TEST_DIR)/test_fixture_policy.c $(TEST_DIR)/test_compiler_context_failures.c $(TEST_DIR)/test_compiler_diag_pipeline.c $(TEST_DIR)/test_parser_input_api.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_emitbc_invariants.c $(TEST_DIR)/test_opcode_schema.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_pipeline_negative_matrix.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c $(TEST_DIR)/test_fixture_policy.c $(TEST_DIR)/test_compiler_context_failures.c $(TEST_DIR)/test_compiler_diag_pipeline.c $(TEST_DIR)/test_parser_input_api.c $(TEST_DIR)/test_sys_compile_libcall.c
 
 
 # Library of shared functions

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -33,6 +33,7 @@ void test_fixture_policy_declared_goldens_exist(void);
 void test_compiler_context_failures(void);
 void test_compiler_diag_pipeline(void);
 void test_parser_input_api(void);
+void test_sys_compile_libcall_runtime(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -112,5 +113,6 @@ int main(void) {
   run_test("test_compiler_context_failures", test_compiler_context_failures);
   run_test("test_compiler_diag_pipeline", test_compiler_diag_pipeline);
   run_test("test_parser_input_api", test_parser_input_api);
+  run_test("test_sys_compile_libcall_runtime", test_sys_compile_libcall_runtime);
   return 0;
 }

--- a/tests/test_sys_compile_libcall.c
+++ b/tests/test_sys_compile_libcall.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"
+#include "error.h"
+#include "item.h"
+#include "libcall.h"
+#include "memory.h"
+#include "test_assert.h"
+#include "value.h"
+#include "vm.h"
+
+CONFIG_t config;
+uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item);
+
+static VALUE_t vstr(const char *s) {
+  VALUE_t v = {VALUE_str, {.s = strdup(s)}};
+  return v;
+}
+
+static void setup_runtime(void) {
+  memset(&config, 0, sizeof(config));
+  init_errmsg();
+  config.itemroot = make_root_item("root");
+  ASSERT_NOT_NULL(config.itemroot);
+  config.vm = make_vm();
+  ASSERT_NOT_NULL(config.vm);
+}
+
+static void teardown_runtime(void) {
+  destroy_vm(config.vm);
+  destroy_item(config.itemroot);
+}
+
+static void assert_bool(VALUE_t v, int expected) {
+  ASSERT_EQ_INT(VALUE_bool, v.type);
+  ASSERT_EQ_INT(expected, v.i);
+}
+
+void test_sys_compile_libcall_runtime(void) {
+  setup_runtime();
+
+  push_stack(config.vm->stack, vstr("sys.log{\"ok\\n\"};"));
+  (void)lc_sys_compile(NULL, config.itemroot);
+  assert_bool(pop_stack(config.vm->stack), 1);
+
+  push_stack(config.vm->stack, vstr("sys.log{;"));
+  (void)lc_sys_compile(NULL, config.itemroot);
+  assert_bool(pop_stack(config.vm->stack), 0);
+  ITEM_t *err_item = find_item(config.itemroot, "error");
+  ITEM_t *msg_item = find_item(config.itemroot, "error.msg");
+  ASSERT_NOT_NULL(err_item);
+  ASSERT_NOT_NULL(msg_item);
+  ASSERT_EQ_INT(VALUE_int, err_item->value.type);
+  ASSERT_TRUE(err_item->value.i != ERR_NOERROR);
+  ASSERT_EQ_INT(VALUE_str, msg_item->value.type);
+  ASSERT_TRUE(msg_item->value.s != NULL && strlen(msg_item->value.s) > 0);
+
+  VALUE_t intarg = {VALUE_int, {.i = 42}};
+  push_stack(config.vm->stack, intarg);
+  (void)lc_sys_compile(NULL, config.itemroot);
+  assert_bool(pop_stack(config.vm->stack), 0);
+  err_item = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err_item);
+  ASSERT_EQ_INT(VALUE_int, err_item->value.type);
+  ASSERT_EQ_INT(ERR_RUNTIME_INVALIDARGS, err_item->value.i);
+
+  int32_t baseline = config.vm->stack->current;
+  for (int i = 0; i < 50; i++) {
+    push_stack(config.vm->stack, vstr("sys.log{\"x\\n\"};"));
+    (void)lc_sys_compile(NULL, config.itemroot);
+    assert_bool(pop_stack(config.vm->stack), 1);
+    ASSERT_EQ_INT(baseline, config.vm->stack->current);
+    ASSERT_TRUE(find_item(config.itemroot, "__sys_compile_tmp__") == NULL);
+    char tmpname[64];
+    snprintf(tmpname, sizeof(tmpname), "__sys_compile_tmp__%d", i + 1);
+    ASSERT_TRUE(find_item(config.itemroot, tmpname) == NULL);
+  }
+
+  teardown_runtime();
+}


### PR DESCRIPTION
### Motivation
- Add a runtime-level interpreter harness to validate `sys.compile` behavior across success, compile errors, invalid-argument handling, temporary artifact cleanup, and repeated-call stability.

### Description
- Add `tests/test_sys_compile_libcall.c` which sets up a `CONFIG_t`/VM harness and calls `lc_sys_compile` directly to assert `VALUE_TRUE` for valid source, `VALUE_FALSE` plus `error`/`error.msg` on compile failures, and `ERR_RUNTIME_INVALIDARGS` on non-string args.
- The test also checks that temporary compiled items (named `__sys_compile_tmp__*`) are removed after execution and that repeated invocations do not leak or conflict on temp naming and preserve the caller stack shape.
- Wire the test into the test runner by declaring and invoking `test_sys_compile_libcall_runtime` in `tests/test_compiler.c` and add the new source to `TEST_SOURCES` in the `Makefile` so it is built into `tests/test-compiler`.

### Testing
- Built the test runner using `make tests/test-compiler`, which compiled successfully.
- Ran the test binary with `./tests/test-compiler`, where the full suite executed and reached the new `test_sys_compile_libcall_runtime` test that failed on the temporary-item cleanup assertion, revealing a persistent temp-item cleanup issue in the current `sys.compile` implementation.
- The failure is reproducible in the test harness and indicates the test is exercising the intended behavior checks (test failure expected until `sys.compile` cleanup is fixed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0979e432cc832e91f65dd04accae6e)