### PR TITLE
Make VM explicit in callstack and interpreter to reduce global coupling

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -24,8 +24,8 @@
 // The configuration object, defined in sin.c
 extern CONFIG_t config;
 
-// Some shorthand
-#define VM config.vm
+static VM_t *current_vm = NULL;
+#define VM current_vm
 
 static OP_t opcode[256];
 
@@ -65,7 +65,7 @@ static inline int apply_comparison(CMP_MODE_t mode, int64_t left, int64_t right)
   return 0;
 }
 
-static inline int pop_compare_and_push_bool(CMP_MODE_t mode, const char *opcode_tag) {
+static inline int pop_compare_and_push_bool(VM_t *vm, CMP_MODE_t mode, const char *opcode_tag) {
   VALUE_t v1 = pop_stack(VM->stack);
   VALUE_t v2 = pop_stack(VM->stack);
   VALUE_t result;
@@ -407,32 +407,32 @@ uint8_t *op_negate(uint8_t *nextop, ITEM_t *item) {
 }
 
 uint8_t *op_equal(uint8_t *nextop, ITEM_t *item) {
-  pop_compare_and_push_bool(CMP_EQ, "OP_EQUAL");
+  pop_compare_and_push_bool(VM, CMP_EQ, "OP_EQUAL");
   return nextop;
 }
 
 uint8_t *op_notequal(uint8_t *nextop, ITEM_t *item) {
-  pop_compare_and_push_bool(CMP_NE, "OP_NOTEQUAL");
+  pop_compare_and_push_bool(VM, CMP_NE, "OP_NOTEQUAL");
   return nextop;
 }
 
 uint8_t *op_lessthan(uint8_t *nextop, ITEM_t *item) {
-  pop_compare_and_push_bool(CMP_LT, "OP_LESSTHAN");
+  pop_compare_and_push_bool(VM, CMP_LT, "OP_LESSTHAN");
   return nextop;
 }
 
 uint8_t *op_lessthanorequal(uint8_t *nextop, ITEM_t *item) {
-  pop_compare_and_push_bool(CMP_LTE, "OP_LTEQ");
+  pop_compare_and_push_bool(VM, CMP_LTE, "OP_LTEQ");
   return nextop;
 }
 
 uint8_t *op_greaterthan(uint8_t *nextop, ITEM_t *item) {
-  pop_compare_and_push_bool(CMP_GT, "OP_GREATERTHAN");
+  pop_compare_and_push_bool(VM, CMP_GT, "OP_GREATERTHAN");
   return nextop;
 }
 
 uint8_t *op_greaterthanorequal(uint8_t *nextop, ITEM_t *item) {
-  pop_compare_and_push_bool(CMP_GTE, "OP_GTEQ");
+  pop_compare_and_push_bool(VM, CMP_GTE, "OP_GTEQ");
   return nextop;
 }
 
@@ -778,12 +778,12 @@ uint8_t *op_fetchitem(uint8_t *nextop, ITEM_t *item) {
         // correctly adjusted to account for them at the top of the
         // current stack (they will be at the bottom of the frame for
         // the new item).
-        push_callstack(item, nextop, i->bytecode[1]);
+        push_callstack(VM, item, nextop, i->bytecode[1]);
         // Execute the item.
         ITEMDEBUG_LOG("Executing item %s\n", i->name);
         VALUE_t value = interpret(i);
         // Now go back to the status quo ante.
-        FRAME_t *prev_frame = pop_callstack();
+        FRAME_t *prev_frame = pop_callstack(VM);
         item = prev_frame->item;
         nextop = prev_frame->nextop;
         // Having restored the old state, push the result
@@ -1071,6 +1071,8 @@ void init_interpreter() {
 }
 
 VALUE_t interpret(ITEM_t *item) {
+  VM_t *vm = config.vm;
+  current_vm = vm;
   // Given some bytecode, interpret it until the HALT instruction is seen
   // NB: The HALT opcode (currently represented by the character 'h') does
   // not have an associated function.

--- a/src/vm.c
+++ b/src/vm.c
@@ -9,11 +9,6 @@
 #include "log.h"
 #include "vm.h"
 
-extern CONFIG_t config;
-
-// Some shorthand
-#define VM config.vm
-
 VM_t *make_vm() {
   // Create a shiny new VM ready for use.
   VM_t *newvm = NULL;
@@ -43,50 +38,54 @@ void destroy_callstack(CALLSTACK_t *stack) {
   FREE_ARRAY(CALLSTACK_t, stack, 1);
 }
 
-void push_callstack(ITEM_t *item, uint8_t *nextop, uint8_t args) {
+void push_callstack(VM_t *vm, ITEM_t *item, uint8_t *nextop, uint8_t args) {
   // Store the currently-executing item on the call stack.
   // If arguments are being passed to the next item, adjust the
   // stack for this item to take into account.
-  if (VM->callstack->current < VM->callstack->max) {
-    VM->callstack->current++;
-    VM->callstack->entry[VM->callstack->current].item = item;
-    VM->callstack->entry[VM->callstack->current].nextop = nextop;
-    VM->callstack->entry[VM->callstack->current].current_stack =
-                                                 VM->stack->current - args;
-    VM->callstack->entry[VM->callstack->current].current_base =
-                                                        VM->stack->base;
-    VM->callstack->entry[VM->callstack->current].current_locals =
-                                                        VM->stack->locals;
-    VM->callstack->entry[VM->callstack->current].current_params =
-                                                        VM->stack->params;
-    // The base is used when indexing into the stack in the current
-    // frame (eg for accessing local variables).
-    VM->stack->base = VM->stack->current + 1 - args;
+  if (vm->callstack->current < vm->callstack->max) {
+    vm->callstack->current++;
+    vm->callstack->entry[vm->callstack->current].item = item;
+    vm->callstack->entry[vm->callstack->current].nextop = nextop;
+    vm->callstack->entry[vm->callstack->current].current_stack =
+                                                 vm->stack->current - args;
+    vm->callstack->entry[vm->callstack->current].current_base =
+                                                        vm->stack->base;
+    vm->callstack->entry[vm->callstack->current].current_locals =
+                                                        vm->stack->locals;
+    vm->callstack->entry[vm->callstack->current].current_params =
+                                                        vm->stack->params;
+    // Invariant entering a called frame:
+    // - current/base/locals/params of the caller are captured in the frame.
+    // - base shifts to the first argument for callee local indexing.
+    vm->stack->base = vm->stack->current + 1 - args;
   } else {
     logerr("Callstack overflow.\n");
     raise(SIGUSR1);
   }
 }
 
-FRAME_t *pop_callstack() {
+FRAME_t *pop_callstack(VM_t *vm) {
   // Reset the VM to the previous stack:
   // Reset the value stack, then return a pointer to the frame
   // at the top of the callstack, so the interpreter can restore
   // its item and nextop.
-  if (VM->callstack->current >= 0) {
+  if (vm->callstack->current >= 0) {
     // First, reset the value stack to its previous state.
-    reset_stack_to(VM->stack,
-               VM->callstack->entry[VM->callstack->current].current_stack);
-    VM->stack->locals =
-                VM->callstack->entry[VM->callstack->current].current_locals;
-    VM->stack->params =
-                VM->callstack->entry[VM->callstack->current].current_params;
-    VM->stack->base =
-                VM->callstack->entry[VM->callstack->current].current_base;
+    reset_stack_to(vm->stack,
+               vm->callstack->entry[vm->callstack->current].current_stack);
+    vm->stack->locals =
+                vm->callstack->entry[vm->callstack->current].current_locals;
+    vm->stack->params =
+                vm->callstack->entry[vm->callstack->current].current_params;
+    vm->stack->base =
+                vm->callstack->entry[vm->callstack->current].current_base;
+    // Invariant returning to caller:
+    // - current/base/locals/params are restored from the captured frame.
+    // - value stack top matches pre-call state (minus call arguments).
     // Then decrement the callstack.
-    VM->callstack->current--;
+    vm->callstack->current--;
     // Finally return the old top of the callstack.
-    return &VM->callstack->entry[VM->callstack->current + 1];
+    return &vm->callstack->entry[vm->callstack->current + 1];
   }
   logerr("Callstack underflow.\n");
   raise(SIGUSR1);
@@ -98,4 +97,3 @@ int size_callstack(CALLSTACK_t *stack) {
   // An empty stack is size -1.
   return (stack->current + 1);
 }
-

--- a/src/vm.h
+++ b/src/vm.h
@@ -34,7 +34,6 @@ VM_t *make_vm();
 void destroy_vm(VM_t *vm);
 CALLSTACK_t *make_callstack();
 void destroy_callstack(CALLSTACK_t *stack);
-void push_callstack(ITEM_t *item, uint8_t *nextop, uint8_t args);
-FRAME_t *pop_callstack();
+void push_callstack(VM_t *vm, ITEM_t *item, uint8_t *nextop, uint8_t args);
+FRAME_t *pop_callstack(VM_t *vm);
 int size_callstack(CALLSTACK_t *stack);
-


### PR DESCRIPTION
### Motivation
- Reduce implicit global access to the VM (`config.vm` / `#define VM`) inside interpreter internals and callstack paths to improve clarity and decouple helpers from global state.
- Make call/return stack transitions and stack bookkeeping easier to reason about and document invariants for `stack->base/current/locals/params` across calls.

### Description
- Change callstack API in `src/vm.h` so `push_callstack` and `pop_callstack` take an explicit `VM_t *vm` parameter (`push_callstack(VM_t *vm, ITEM_t *item, uint8_t *nextop, uint8_t args)` and `FRAME_t *pop_callstack(VM_t *vm)`).
- Update `src/vm.c` implementation to use the passed-in `vm` pointer throughout and add comments documenting the invariants for entering and returning from frames describing how `stack->current/base/locals/params` are captured and restored.
- Refactor `src/interpret.c` internals to cache `VM_t *vm = config.vm` (exposed to helpers via a thin `current_vm` binding) and update internal helper calls (including callsites to `push_callstack`/`pop_callstack` and comparison helper signatures) to use the explicit VM context while preserving the external `interpret(ITEM_t *item)` API.
- Preserve runtime behavior while narrowing global dependency to a small boundary and updating call sites accordingly.

### Testing
- Built the project and ran the test suite with `make -j2 test` and the test harness completed successfully with the compiler and interpreter tests executing without failures.
- The repository binaries (`sin`, `scomp`, `sdiss`) and tests were produced during the build and the test run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098e0bb7d8832e861b25ce477da51e)