### PR TITLE
Add interpreter bytecode bounds checks and frame bytecode metadata

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -19,6 +19,7 @@ void init_errmsg() {
   errmsg[ERR_RUNTIME_SIGUSR1] = "Restarting due to SIGUSR1.";
   errmsg[ERR_RUNTIME_INVALIDARGS] = "Invalid arguments to library call.";
   errmsg[ERR_RUNTIME_NOSUCHITEM] = "Item does not exist.";
+  errmsg[ERR_RUNTIME_TRUNCATED] = "Truncated bytecode.";
   errmsg[ERR_COMP_TOOMANYPARAMS] = "Too many parameters in item definition.";
   errmsg[ERR_COMP_TOOMANYARGS] = "Too many arguments passed to item.";
 }

--- a/src/error.h
+++ b/src/error.h
@@ -24,6 +24,7 @@
 #define ERR_RUNTIME_SIGUSR1       20
 #define ERR_RUNTIME_INVALIDARGS   21
 #define ERR_RUNTIME_NOSUCHITEM    22
+#define ERR_RUNTIME_TRUNCATED     23
 
 extern const char *errmsg[];
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -35,7 +35,7 @@ static inline bool require_bytes(uint8_t *nextop, size_t bytes, const char *opna
     char detail[128];
     snprintf(detail, sizeof(detail), "%s truncated bytecode read (%zu bytes)", opname, bytes);
     logerr("%s.\n", detail);
-    set_error_item(ERR_COMP_UNKNOWN, detail);
+    set_error_item(ERR_RUNTIME_TRUNCATED, detail);
     return false;
   }
   return true;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -26,6 +26,23 @@ extern CONFIG_t config;
 
 static VM_t *current_vm = NULL;
 #define VM current_vm
+static uint8_t *current_frame_start = NULL;
+static uint8_t *current_frame_end = NULL;
+
+static inline bool require_bytes(uint8_t *nextop, size_t bytes, const char *opname) {
+  if (!current_frame_start || !current_frame_end) return true;
+  if (nextop > current_frame_end || (size_t)(current_frame_end - nextop) < bytes) {
+    char detail[128];
+    snprintf(detail, sizeof(detail), "%s truncated bytecode read (%zu bytes)", opname, bytes);
+    logerr("%s.\n", detail);
+    set_error_item(ERR_COMP_UNKNOWN, detail);
+    return false;
+  }
+  return true;
+}
+
+#define REQUIRE_BYTES(nextop, n, opname) \
+  do { if (!require_bytes((nextop), (n), (opname))) return NULL; } while (0)
 
 static OP_t opcode[256];
 
@@ -143,6 +160,7 @@ uint8_t *op_undefined(uint8_t *nextop, ITEM_t *item) {
 uint8_t *op_pushint(uint8_t *nextop, ITEM_t *item) {
   // Push an int64 onto the stack.
   // Read the next 8 bytes and make an VALUE_t
+  REQUIRE_BYTES(nextop, 8, "OP_PUSHINT");
   VALUE_t v;
   v.type = VALUE_int;
   v.i = *(int64_t*)nextop;
@@ -180,6 +198,7 @@ uint8_t *op_declocal(uint8_t *nextop, ITEM_t *item) {
 uint8_t *op_jump(uint8_t *nextop, ITEM_t *item) {
   // Unconditional jump.  Interpret the next two bytes as a
   // SIGNED int, and then modify the bytecode pointer by that amount.
+  REQUIRE_BYTES(nextop, 2, "OP_JUMP");
   int16_t offset;
   memcpy(&offset, nextop, 2);
   DISASS_LOG("OP_JUMP: offset is  %d.\n", offset);
@@ -192,6 +211,7 @@ uint8_t *op_jumpfalse(uint8_t *nextop, ITEM_t *item) {
   // by that amount.  Alternatively, if true, simply skip the next
   // two bytes and go on to the next instruction.
 
+  REQUIRE_BYTES(nextop, 2, "OP_JUMPFALSE");
   VALUE_t v1;
   v1 = pop_stack(VM->stack);
   // "true" is a true bool value, or an int value != 0, or a string
@@ -264,10 +284,12 @@ uint8_t *op_pushstr(uint8_t *nextop, ITEM_t *item) {
   // Push a string literal onto the stack.
   VALUE_t v;
   v.type = VALUE_str;
+  REQUIRE_BYTES(nextop, 2, "OP_PUSHSTR length");
   uint16_t len;
   // Get the length
   memcpy(&len, nextop, 2);
   nextop += 2;
+  REQUIRE_BYTES(nextop, len, "OP_PUSHSTR payload");
   v.s = GROW_ARRAY(char, NULL, 0, len+1);
   memcpy(v.s, nextop, len);
   v.s[len] = 0;
@@ -737,6 +759,7 @@ uint8_t *op_fetchitem(uint8_t *nextop, ITEM_t *item) {
   // If the item does not exist, nil is pushed onto the stack.
 
   // First, let's get the number of arguments passed to this item
+  REQUIRE_BYTES(nextop, 2, "OP_FETCHITEM arg-count");
   uint16_t arg_count;
   memcpy(&arg_count, nextop, 2);
   nextop += 2;
@@ -778,7 +801,7 @@ uint8_t *op_fetchitem(uint8_t *nextop, ITEM_t *item) {
         // correctly adjusted to account for them at the top of the
         // current stack (they will be at the bottom of the frame for
         // the new item).
-        push_callstack(VM, item, nextop, i->bytecode[1]);
+        push_callstack(VM, item, nextop, i->bytecode[1], current_frame_start, current_frame_end);
         // Execute the item.
         ITEMDEBUG_LOG("Executing item %s\n", i->name);
         VALUE_t value = interpret(i);
@@ -786,6 +809,8 @@ uint8_t *op_fetchitem(uint8_t *nextop, ITEM_t *item) {
         FRAME_t *prev_frame = pop_callstack(VM);
         item = prev_frame->item;
         nextop = prev_frame->nextop;
+        current_frame_start = prev_frame->bytecode_start;
+        current_frame_end = prev_frame->bytecode_end;
         // Having restored the old state, push the result
         // of the executed item.
         push_stack(VM->stack, value);
@@ -823,19 +848,27 @@ uint8_t *assembleitem_helper(uint8_t *nextop, ITEM_t *item) {
   STRBUILDER_t sb;
   sb_init(&sb, 130);
 
-  while (*nextop != 'E' && !invalid) {
+  while (!invalid) {
+    REQUIRE_BYTES(nextop, 1, "OP_ASSEMBLEITEM layer");
+    if (*nextop == 'E') {
+      break;
+    }
     switch (*nextop++) {
       case 'L': {
         // Simple layer
+        REQUIRE_BYTES(nextop, 1, "OP_ASSEMBLEITEM layer length");
         int s = *nextop++; // Length of layer name
+        REQUIRE_BYTES(nextop, s, "OP_ASSEMBLEITEM layer bytes");
         sb_append_substr(&sb, (char *)nextop, (uint32_t)s);
         nextop += s;
         break;
       }
       case 'D': {
         // Deref layer - either a V (localvar) or another I (item)
+        REQUIRE_BYTES(nextop, 1, "OP_ASSEMBLEITEM deref type");
         switch (*nextop++) {
           case 'V': {
+            REQUIRE_BYTES(nextop, 1, "OP_ASSEMBLEITEM local index");
             int idx = *nextop++ + VM->stack->base; // Local variable index
             switch (VM->stack->stack[idx].type) {
               case VALUE_str: {
@@ -866,6 +899,10 @@ uint8_t *assembleitem_helper(uint8_t *nextop, ITEM_t *item) {
             // This is a bit more complicated.  We need to dereference an
             // item, then evaluate it, and use the result as the layer name.
             nextop = assembleitem_helper(nextop, item);
+            if (!nextop) {
+              invalid = true;
+              break;
+            }
             VALUE_t layername = pop_stack(VM->stack);
             if (layername.type == VALUE_str) {
               //  This is basically the same as op_fetchitem
@@ -936,7 +973,7 @@ uint8_t *assembleitem_helper(uint8_t *nextop, ITEM_t *item) {
     push_stack(VM->stack, name);
     ITEMDEBUG_LOG("Item assembled: %s\n", sb.buf);
   }
-
+  REQUIRE_BYTES(nextop, 1, "OP_ASSEMBLEITEM terminator");
   return nextop + 1;
 }
 
@@ -1073,6 +1110,8 @@ void init_interpreter() {
 VALUE_t interpret(ITEM_t *item) {
   VM_t *vm = config.vm;
   current_vm = vm;
+  set_item(config.itemroot, "error", VALUE_NIL);
+  set_item(config.itemroot, "error.msg", VALUE_NIL);
   // Given some bytecode, interpret it until the HALT instruction is seen
   // NB: The HALT opcode (currently represented by the character 'h') does
   // not have an associated function.
@@ -1093,6 +1132,8 @@ VALUE_t interpret(ITEM_t *item) {
 
   // The actual bytecode starts at the third byte.
   uint8_t *op = item->bytecode + 2;
+  current_frame_start = op;
+  current_frame_end = item->bytecode + item->bytecode_len;
 
 #if defined(__GNUC__) || defined(__clang__)
   // On compilers that support labels-as-values, use computed-goto dispatch.
@@ -1109,7 +1150,7 @@ VALUE_t interpret(ITEM_t *item) {
   };
 
 #define DISPATCH() do { if (*op == 'h') goto op_halt_label; goto *jump_table[*op]; } while (0)
-#define OPCASE(label_name, fn)   label_name: {     uint8_t *nextop = op + 1;     op = fn(nextop, item);     DISPATCH();   }
+#define OPCASE(label_name, fn)   label_name: {     uint8_t *nextop = op + 1;     op = fn(nextop, item);     if (!op) goto op_error_label; DISPATCH();   }
 
   DISPATCH();
 #define OPCASE_ENTRY(opcode_byte, handler_fn) OPCASE(handler_fn##_label, handler_fn)
@@ -1118,6 +1159,7 @@ VALUE_t interpret(ITEM_t *item) {
   OPCASE(op_undefined_label, op_undefined)
 
 op_halt_label:
+  goto op_done_label;
 #undef OPCASE
 #undef DISPATCH
 #else
@@ -1127,11 +1169,22 @@ op_halt_label:
     // two sequence points:
     uint8_t *nextop = op + 1;
     op = opcode[*op](nextop, item);
+    if (!op) {
+      goto op_error_label;
+    }
   }
 #endif
+op_error_label:
+op_done_label:
 
   // Item is now free to be replaced or deleted
   item->inuse = false;
+  current_frame_start = NULL;
+  current_frame_end = NULL;
+
+  if (!op) {
+    return VALUE_NIL;
+  }
 
   if (size_stack(VM->stack) > 0) {
     return pop_stack(VM->stack);

--- a/src/vm.c
+++ b/src/vm.c
@@ -38,7 +38,8 @@ void destroy_callstack(CALLSTACK_t *stack) {
   FREE_ARRAY(CALLSTACK_t, stack, 1);
 }
 
-void push_callstack(VM_t *vm, ITEM_t *item, uint8_t *nextop, uint8_t args) {
+void push_callstack(VM_t *vm, ITEM_t *item, uint8_t *nextop, uint8_t args,
+                    uint8_t *bytecode_start, uint8_t *bytecode_end) {
   // Store the currently-executing item on the call stack.
   // If arguments are being passed to the next item, adjust the
   // stack for this item to take into account.
@@ -46,6 +47,8 @@ void push_callstack(VM_t *vm, ITEM_t *item, uint8_t *nextop, uint8_t args) {
     vm->callstack->current++;
     vm->callstack->entry[vm->callstack->current].item = item;
     vm->callstack->entry[vm->callstack->current].nextop = nextop;
+    vm->callstack->entry[vm->callstack->current].bytecode_start = bytecode_start;
+    vm->callstack->entry[vm->callstack->current].bytecode_end = bytecode_end;
     vm->callstack->entry[vm->callstack->current].current_stack =
                                                  vm->stack->current - args;
     vm->callstack->entry[vm->callstack->current].current_base =

--- a/src/vm.h
+++ b/src/vm.h
@@ -12,6 +12,8 @@
 typedef struct {
   ITEM_t *item;
   uint8_t *nextop;
+  uint8_t *bytecode_start;
+  uint8_t *bytecode_end;
   int32_t current_stack;
   int32_t current_base;
   uint8_t current_locals;
@@ -34,6 +36,6 @@ VM_t *make_vm();
 void destroy_vm(VM_t *vm);
 CALLSTACK_t *make_callstack();
 void destroy_callstack(CALLSTACK_t *stack);
-void push_callstack(VM_t *vm, ITEM_t *item, uint8_t *nextop, uint8_t args);
+void push_callstack(VM_t *vm, ITEM_t *item, uint8_t *nextop, uint8_t args, uint8_t *bytecode_start, uint8_t *bytecode_end);
 FRAME_t *pop_callstack(VM_t *vm);
 int size_callstack(CALLSTACK_t *stack);


### PR DESCRIPTION
### Motivation
- Prevent out-of-bounds/truncated bytecode reads in the interpreter by tracking per-frame bytecode bounds and adding centralized checks before variable-width reads.
- Centralize the check logic to keep the fast-path opcode handlers maintainable and avoid duplicated per-op error handling.
- Ensure truncated-read failures produce a proper execution error item and unwind cleanly instead of crashing.

### Description
- Added bytecode boundary metadata to call frames by extending `FRAME_t` with `bytecode_start` and `bytecode_end`, and threaded these through `push_callstack(...)` so saved frames preserve caller bounds (`src/vm.h`, `src/vm.c`).
- Implemented `require_bytes(...)` and `REQUIRE_BYTES(...)` in `src/interpret.c` to validate available bytes before variable-width reads and to set an execution error via `set_error_item(...)` on failure.
- Applied `REQUIRE_BYTES(...)` before multi-byte/variable reads in opcode handlers and parsers, including `op_pushint`, `op_pushstr` (length + payload), `op_jump` / `op_jumpfalse`, `op_fetchitem` arg-count decode, and recursive item parsing in `assembleitem_helper`.
- Adjusted interpreter dispatch so opcode handlers may return `NULL` on bounds-failure, the interpreter treats that as a clean execution error path and returns `VALUE_NIL`, and frame bounds are restored after nested `interpret()` calls.

### Testing
- Built the project successfully with `make -j2` (compile succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0997e85c30832e870291f6ecac3ea6)