### PR TITLE
Add item lookup cache with invalidation and tests; use cached lookup in interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIB_DIR := lib
 # Test runner
 TEST_DIR := tests
 TEST_BIN := $(TEST_DIR)/test-compiler
-TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_emitbc_invariants.c $(TEST_DIR)/test_opcode_schema.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_pipeline_negative_matrix.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c $(TEST_DIR)/test_fixture_policy.c $(TEST_DIR)/test_compiler_context_failures.c $(TEST_DIR)/test_compiler_diag_pipeline.c $(TEST_DIR)/test_parser_input_api.c $(TEST_DIR)/test_sys_compile_libcall.c
+TEST_SOURCES := $(TEST_DIR)/test_compiler.c $(TEST_DIR)/test_helpers.c $(TEST_DIR)/test_emitbc_header.c $(TEST_DIR)/test_emitbc_opcode_map.c $(TEST_DIR)/test_emitbc_jumps.c $(TEST_DIR)/test_emitbc_invariants.c $(TEST_DIR)/test_opcode_schema.c $(TEST_DIR)/test_pipeline_golden.c $(TEST_DIR)/test_pipeline_source_golden.c $(TEST_DIR)/test_ir_validate.c $(TEST_DIR)/test_pipeline_negative_matrix.c $(TEST_DIR)/test_absyn_lifecycle.c $(TEST_DIR)/test_semant.c $(TEST_DIR)/test_sdiss_fixtures.c $(TEST_DIR)/test_parser_examples_obj_golden.c $(TEST_DIR)/test_interpret_semantics_golden.c $(TEST_DIR)/test_fixture_policy.c $(TEST_DIR)/test_compiler_context_failures.c $(TEST_DIR)/test_compiler_diag_pipeline.c $(TEST_DIR)/test_parser_input_api.c $(TEST_DIR)/test_sys_compile_libcall.c $(TEST_DIR)/test_item_cache.c
 
 
 # Library of shared functions

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -769,7 +769,7 @@ uint8_t *op_fetchitem(uint8_t *nextop, ITEM_t *item) {
 
   // First check to see if there is a valid item to look up
   if (itemname.type == VALUE_str) {
-    ITEM_t *i = find_item(config.itemroot, itemname.s);
+    ITEM_t *i = find_item_cached(config.itemroot, itemname.s, NULL);
     if (i) {
       ITEMDEBUG_LOG("Fetched item %s (called with %d arguments).\n", itemname.s, arg_count);
       // Just push the item value onto the stack.

--- a/src/item.c
+++ b/src/item.c
@@ -15,6 +15,63 @@
 #include "log.h"
 #include "item.h"
 
+static uint64_t itemstore_generation = 1;
+#define FETCHITEM_CACHE_SIZE 64
+typedef struct {
+  bool valid;
+  bool found;
+  char key[MAX_ITEM_NAME];
+  ITEM_t *item;
+} FETCHITEM_CACHE_ENTRY_t;
+
+static FETCHITEM_CACHE_ENTRY_t fetchitem_cache[FETCHITEM_CACHE_SIZE];
+static uint64_t fetchitem_cache_hits = 0;
+static uint64_t fetchitem_cache_misses = 0;
+
+static void invalidate_fetchitem_cache(void) {
+  memset(fetchitem_cache, 0, sizeof(fetchitem_cache));
+}
+
+static inline void bump_itemstore_generation(void) {
+  itemstore_generation++;
+  invalidate_fetchitem_cache();
+}
+
+uint64_t get_itemstore_generation(void) {
+  return itemstore_generation;
+}
+
+static uint32_t fetchitem_cache_hash(const char *key) {
+  return murmur3_32(key, strlen(key), 0x5EED1234u);
+}
+
+ITEM_t *find_item_cached(ITEM_t *root, const char *item_name, bool *found) {
+  uint32_t index = fetchitem_cache_hash(item_name) % FETCHITEM_CACHE_SIZE;
+  FETCHITEM_CACHE_ENTRY_t *entry = &fetchitem_cache[index];
+
+  if (entry->valid && strcmp(entry->key, item_name) == 0) {
+    fetchitem_cache_hits++;
+    if (found) *found = entry->found;
+    DISASS_LOG("itemcache hit: %s (hits=%llu misses=%llu)\n", item_name,
+               (unsigned long long)fetchitem_cache_hits,
+               (unsigned long long)fetchitem_cache_misses);
+    return entry->item;
+  }
+
+  fetchitem_cache_misses++;
+  ITEM_t *item = find_item(root, item_name);
+  entry->valid = true;
+  entry->item = item;
+  entry->found = (item != NULL);
+  strncpy(entry->key, item_name, MAX_ITEM_NAME - 1);
+  entry->key[MAX_ITEM_NAME - 1] = '\0';
+  if (found) *found = entry->found;
+  DISASS_LOG("itemcache miss: %s (hits=%llu misses=%llu)\n", item_name,
+             (unsigned long long)fetchitem_cache_hits,
+             (unsigned long long)fetchitem_cache_misses);
+  return item;
+}
+
 // The configuration object, defined in sin.c
 extern CONFIG_t config;
 
@@ -428,6 +485,7 @@ ITEM_t *insert_item(ITEM_t *root, const char *item_name, VALUE_t value) {
     current_pos = next_dot + 1;
   }
   // Return a pointer to the last-created item
+  bump_itemstore_generation();
   return current_item;
 }
 
@@ -478,6 +536,7 @@ ITEM_t *insert_code_item(ITEM_t *root, const char *item_name, uint32_t len,
     current_pos = next_dot + 1;
   }
   // Return a pointer to the last-created item
+  bump_itemstore_generation();
   return current_item;
 }
 
@@ -543,6 +602,7 @@ void delete_item(ITEM_t *root, const char *item_name) {
     }
     // Now we have isolated this item, delete it and all its children.
     destroy_item(item);
+    bump_itemstore_generation();
     ITEMDEBUG_LOG("Item %s has been deleted, along with all of its children.\n",
                                                                  item_name);
   }
@@ -837,4 +897,3 @@ void set_error_item(const int errnum, const char *errdetail) {
   }
   set_item(config.itemroot, "error.msg", emsg);
 }
-

--- a/src/item.h
+++ b/src/item.h
@@ -91,6 +91,7 @@ ITEM_t *insert_item(ITEM_t *root, const char *item_name, VALUE_t value);
 ITEM_t *insert_code_item(ITEM_t *root, const char *item_name, uint32_t len,
                                                         uint8_t *bytecode);
 ITEM_t *find_item(ITEM_t *root, const char *item_name);
+ITEM_t *find_item_cached(ITEM_t *root, const char *item_name, bool *found);
 ITEM_t *find_item_by_index(ITEM_t *parent, const size_t index);
 void delete_item(ITEM_t *root, const char *item_name);
 void set_item(ITEM_t *root, const char *item_name, VALUE_t value);
@@ -100,6 +101,7 @@ bool save_itemsource(ITEM_t *item, char *source);
 void save_itemstore(const char *filename, ITEM_t *root); 
 ITEM_t *load_itemstore(const char *filename); 
 void dump_item(ITEM_t *item, char *item_name, bool isroot);
+uint64_t get_itemstore_generation(void);
 
 // Other item-related API functions
 bool is_valid_layer(const char *str);

--- a/tests/test_compiler.c
+++ b/tests/test_compiler.c
@@ -34,6 +34,8 @@ void test_compiler_context_failures(void);
 void test_compiler_diag_pipeline(void);
 void test_parser_input_api(void);
 void test_sys_compile_libcall_runtime(void);
+void test_find_item_cached_hit_and_negative_cache(void);
+void test_find_item_cached_invalidation_on_delete_and_reinsert(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -114,5 +116,7 @@ int main(void) {
   run_test("test_compiler_diag_pipeline", test_compiler_diag_pipeline);
   run_test("test_parser_input_api", test_parser_input_api);
   run_test("test_sys_compile_libcall_runtime", test_sys_compile_libcall_runtime);
+  run_test("test_find_item_cached_hit_and_negative_cache", test_find_item_cached_hit_and_negative_cache);
+  run_test("test_find_item_cached_invalidation_on_delete_and_reinsert", test_find_item_cached_invalidation_on_delete_and_reinsert);
   return 0;
 }

--- a/tests/test_item_cache.c
+++ b/tests/test_item_cache.c
@@ -1,0 +1,63 @@
+#include <stdbool.h>
+#include <string.h>
+
+#include "item.h"
+#include "test_assert.h"
+
+void test_find_item_cached_hit_and_negative_cache(void) {
+  ITEM_t *root = make_root_item("root");
+  ASSERT_NOT_NULL(root);
+
+  VALUE_t value = {.type = VALUE_int, .i = 42};
+  ITEM_t *inserted = insert_item(root, "alpha.beta", value);
+  ASSERT_NOT_NULL(inserted);
+
+  bool found = false;
+  ITEM_t *cached = find_item_cached(root, "alpha.beta", &found);
+  ASSERT_NOT_NULL(cached);
+  ASSERT_TRUE(found);
+  ASSERT_EQ_INT(VALUE_int, cached->value.type);
+  ASSERT_EQ_INT(42, cached->value.i);
+
+  found = true;
+  ITEM_t *missing = find_item_cached(root, "alpha.gamma", &found);
+  ASSERT_TRUE(missing == NULL);
+  ASSERT_TRUE(!found);
+
+  found = false;
+  missing = find_item_cached(root, "alpha.gamma", &found);
+  ASSERT_TRUE(missing == NULL);
+  ASSERT_TRUE(!found);
+
+  destroy_item(root);
+}
+
+void test_find_item_cached_invalidation_on_delete_and_reinsert(void) {
+  ITEM_t *root = make_root_item("root");
+  ASSERT_NOT_NULL(root);
+
+  VALUE_t value = {.type = VALUE_int, .i = 7};
+  ITEM_t *first = insert_item(root, "cache.target", value);
+  ASSERT_NOT_NULL(first);
+
+  ITEM_t *cached_before = find_item_cached(root, "cache.target", NULL);
+  ASSERT_NOT_NULL(cached_before);
+  ASSERT_TRUE(cached_before == first);
+
+  delete_item(root, "cache.target");
+  ITEM_t *after_delete = find_item_cached(root, "cache.target", NULL);
+  ASSERT_TRUE(after_delete == NULL);
+
+  uint64_t gen_after_delete = get_itemstore_generation();
+  VALUE_t value2 = {.type = VALUE_int, .i = 99};
+  ITEM_t *second = insert_item(root, "cache.target", value2);
+  ASSERT_NOT_NULL(second);
+  ASSERT_TRUE(get_itemstore_generation() > gen_after_delete);
+
+  ITEM_t *after_reinsert = find_item_cached(root, "cache.target", NULL);
+  ASSERT_NOT_NULL(after_reinsert);
+  ASSERT_TRUE(after_reinsert == second || after_reinsert == first);
+  ASSERT_EQ_INT(99, after_reinsert->value.i);
+
+  destroy_item(root);
+}


### PR DESCRIPTION
### Motivation

- Reduce repeated expensive item lookups during execution by adding a small in-memory cache for `find_item` used by `OP_FETCHITEM`.

### Description

- Introduce a fixed-size fetch-item cache and helper `find_item_cached` with hit/miss logging and a `get_itemstore_generation` counter to track mutations.
- Invalidate the cache on mutations by calling `bump_itemstore_generation` from `insert_item`, `insert_code_item`, and `delete_item` and by clearing the cache with `invalidate_fetchitem_cache`.
- Replace direct `find_item` usage in the interpreter (`op_fetchitem`) with `find_item_cached` and export `find_item_cached` and `get_itemstore_generation` in `item.h`.
- Add unit tests in `tests/test_item_cache.c` and wire them into the test runner via `tests/test_compiler.c` and `Makefile` updates.

### Testing

- Compiled the project and executed the test runner via the existing test binary `tests/test-compiler` which includes the new cache tests.
- All automated tests, including `test_find_item_cached_hit_and_negative_cache` and `test_find_item_cached_invalidation_on_delete_and_reinsert`, succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099c5da5e8832e95cf250b801514d1)