### PR TITLE
Unify VM truthiness helpers across logical opcodes

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -217,10 +217,7 @@ uint8_t *op_jumpfalse(uint8_t *nextop, ITEM_t *item) {
   REQUIRE_BYTES(nextop, 2, "OP_JUMPFALSE");
   VALUE_t v1;
   v1 = pop_stack(VM->stack);
-  // "true" is a true bool value, or an int value != 0, or a string
-  // which is not empty.  Everything else is false.
-  if (((v1.type == VALUE_bool || v1.type == VALUE_int) && v1.i != 0)
-      || (v1.type == VALUE_str && v1.s[0] != '\0')) {
+  if (value_is_truthy(&v1)) {
     // A true value means that we don't branch.  Skip over
     // the next two bytes.
     DISASS_LOG("OP_JUMPFALSE: evaluates to true (no jump).\n");
@@ -463,44 +460,19 @@ uint8_t *op_greaterthanorequal(uint8_t *nextop, ITEM_t *item) {
 
 uint8_t *op_logicalnot(uint8_t *nextop, ITEM_t *item) {
   // Logically negate the value on top of the stack.
-  // Note that this operation CONVERTS the value on top of the stack to a
-  // VALUE_bool if it is not already.
-  switch (VM->stack->stack[VM->stack->current].type) {
-    case VALUE_bool:
-      VM->stack->stack[VM->stack->current].i =
-                                  !(VM->stack->stack[VM->stack->current].i);
-      break;
-    case VALUE_int:
-      // If the int value is nonzero, then false, else true.
-      VM->stack->stack[VM->stack->current].type = VALUE_bool;
-      if (VM->stack->stack[VM->stack->current].i) {
-        VM->stack->stack[VM->stack->current].i = 0;
-      } else {
-        VM->stack->stack[VM->stack->current].i = 1;
-      }
-      break;
-    case VALUE_nil:
-      // A logically-negated nil value is always true
-      VM->stack->stack[VM->stack->current].type = VALUE_bool;
-      VM->stack->stack[VM->stack->current].i = 1;
-      break;
-    case VALUE_str:
-      // A logically-negated string value is always false
-      // Tidy up the old string value
-      FREE_ARRAY(char, VM->stack->stack[VM->stack->current].s,
-                        strlen(VM->stack->stack[VM->stack->current].s) + 1);
-      VM->stack->stack[VM->stack->current].type = VALUE_bool;
-      VM->stack->stack[VM->stack->current].i = 0;
-      break;
-  }
+  VALUE_t *v = &VM->stack->stack[VM->stack->current];
+  value_to_bool_inplace(v);
+  v->i = !v->i;
   return nextop;
 }
 
 uint8_t *op_logicaland(uint8_t *nextop, ITEM_t *item) {
   // Pop two values from the stack, convert to bools
   // AND the result and push it.
-  VALUE_t v1 = convert_to_bool(pop_stack(VM->stack));
-  VALUE_t v2 = convert_to_bool(pop_stack(VM->stack));
+  VALUE_t v1 = pop_stack(VM->stack);
+  VALUE_t v2 = pop_stack(VM->stack);
+  value_to_bool_inplace(&v1);
+  value_to_bool_inplace(&v2);
   // v2 is guaranteed to be boolean now, whatever it was.
   v2.i = v1.i && v2.i; // Logical AND
   push_stack(VM->stack, v2);
@@ -510,8 +482,10 @@ uint8_t *op_logicaland(uint8_t *nextop, ITEM_t *item) {
 uint8_t *op_logicalor(uint8_t *nextop, ITEM_t *item) {
   // Pop two values from the stack, convert to bools
   // OR the result and push it.
-  VALUE_t v1 = convert_to_bool(pop_stack(VM->stack));
-  VALUE_t v2 = convert_to_bool(pop_stack(VM->stack));
+  VALUE_t v1 = pop_stack(VM->stack);
+  VALUE_t v2 = pop_stack(VM->stack);
+  value_to_bool_inplace(&v1);
+  value_to_bool_inplace(&v2);
   // v2 is guaranteed to be boolean now, whatever it was.
   v2.i = v1.i || v2.i; // Logical OR
   push_stack(VM->stack, v2);

--- a/src/value.c
+++ b/src/value.c
@@ -13,26 +13,32 @@ const VALUE_t VALUE_TRUE = {VALUE_bool, {1}};
 const VALUE_t VALUE_FALSE = {VALUE_bool, {0}};
 const VALUE_t VALUE_ZERO = {VALUE_int, {0}};
 
-VALUE_t convert_to_bool(VALUE_t from) {
-  // This function takes a VALUE of any type and returns a VALUE_bool
-  // which is sensibly true or false.
-  // NOTE: If from.type == VALUE_str, this function also frees from.s
-
-  switch (from.type) {
+int value_is_truthy(const VALUE_t *value) {
+  switch (value->type) {
     case VALUE_bool:
-      // This is already a bool.  Return it.
-      return from;
     case VALUE_int:
-      // Non-zero ints are true.
-      if (from.i == 0) return VALUE_FALSE; else return VALUE_TRUE;
+      return value->i != 0;
     case VALUE_str:
-      // All strings are true.
-      free(from.s);
-      return VALUE_TRUE;
+      return value->s[0] != '\0';
+    case VALUE_nil:
     default:
-      // If in doubt, it ain't true.
-      // Also applies to VALUE_nil.
-      return VALUE_FALSE;
+      return 0;
   }
 }
 
+void value_to_bool_inplace(VALUE_t *value) {
+  int truthy = value_is_truthy(value);
+
+  if (value->type == VALUE_str) {
+    free(value->s);
+  }
+
+  value->type = VALUE_bool;
+  value->i = truthy;
+}
+
+VALUE_t convert_to_bool(VALUE_t from) {
+  // Backward-compatible wrapper around in-place conversion.
+  value_to_bool_inplace(&from);
+  return from;
+}

--- a/src/value.h
+++ b/src/value.h
@@ -34,3 +34,16 @@ extern VALUE_t VALUE_FALSE;
   }
   
 VALUE_t convert_to_bool(VALUE_t from);
+
+// Truthiness contract for VM values:
+// - nil is false
+// - bool false/true preserve their value
+// - int 0 is false; any non-zero int is true
+// - string "" (empty) is false; any non-empty string is true
+//
+// Ownership contract:
+// - value_is_truthy() is read-only and never frees memory.
+// - value_to_bool_inplace() mutates in place to VALUE_bool and frees string
+//   storage if and only if the input value owns VALUE_str memory.
+int value_is_truthy(const VALUE_t *value);
+void value_to_bool_inplace(VALUE_t *value);


### PR DESCRIPTION
### Motivation
- Centralize and standardize truthiness/boolean conversion semantics for VM values to avoid drifting behavior across opcodes and to make ownership rules explicit.
- Prevent string ownership bugs (leaks or double-frees) when converting or mutating values during logical operations.

### Description
- Add a concise shared truthiness contract and two helpers in `src/value.h`: `value_is_truthy(const VALUE_t *)` and `value_to_bool_inplace(VALUE_t *)` with documented ownership behavior for strings.
- Implement `value_is_truthy` and `value_to_bool_inplace` in `src/value.c`, and make `convert_to_bool` a backward-compatible wrapper around the in-place helper.
- Refactor `src/interpret.c` to use the new helpers in `op_jumpfalse`, `op_logicalnot`, `op_logicaland`, and `op_logicalor`, preserving safe string cleanup and consistent truthiness semantics.

### Testing
- Ran the full test suite with `make test`, and the automated tests completed successfully.
- Interpreter semantic golden tests ran as part of the suite and passed without fixture changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a5127600832e9342f56a27a404c6)