### PR TITLE
Centralize libcall metadata and fix sys.compile arg count

### DIFF
--- a/src/libcall.c
+++ b/src/libcall.c
@@ -426,7 +426,7 @@ const LIBCALL_t libcalls[] = {
   {"sys",  "log",          1, 1, 1, lc_sys_log},
   {"sys",  "shutdown",     1, 2, 0, lc_sys_shutdown},
   {"sys",  "abort",        1, 3, 0, lc_sys_abort},
-  {"sys",  "compile",      1, 4, 0, lc_sys_compile},
+  {"sys",  "compile",      1, 4, 1, lc_sys_compile},
   {"task", "newgametask",  2, 0, 3, lc_task_newgametask},
   {"task", "killtask",     2, 1, 1, lc_task_killtask},
   {"net",  "input",        3, 0, 0, lc_net_input},
@@ -465,4 +465,3 @@ void *libcall_func(uint8_t lib, uint8_t call) {
   }
   return NULL;
 }
-

--- a/src/lower.c
+++ b/src/lower.c
@@ -11,42 +11,7 @@
 
 #include "compdiag.h"
 #include "error.h"
-
-typedef struct {
-  const char *lib;
-  const char *func;
-  uint8_t lib_index;
-  uint8_t func_index;
-  uint8_t args;
-} LOWER_LIBCALL;
-
-static const LOWER_LIBCALL k_libcalls[] = {
-  {"sys", "backup", 1, 0, 0},
-  {"sys", "log", 1, 1, 1},
-  {"sys", "shutdown", 1, 2, 0},
-  {"sys", "abort", 1, 3, 0},
-  {"task", "newgametask", 2, 0, 3},
-  {"task", "killtask", 2, 1, 1},
-  {"net", "input", 3, 0, 0},
-  {"net", "write", 3, 1, 2},
-  {"str", "capitalise", 4, 0, 1},
-  {"str", "upper", 4, 1, 1},
-  {"str", "lower", 4, 2, 1},
-  {NULL, NULL, 0, 0, 0},
-};
-
-static bool lower_lookup_libcall(const char *lib, const char *func,
-                                 uint8_t *lib_index, uint8_t *func_index, uint8_t *args) {
-  for (size_t i = 0; k_libcalls[i].lib != NULL; i++) {
-    if (strcmp(k_libcalls[i].lib, lib) == 0 && strcmp(k_libcalls[i].func, func) == 0) {
-      *lib_index = k_libcalls[i].lib_index;
-      *func_index = k_libcalls[i].func_index;
-      *args = k_libcalls[i].args;
-      return true;
-    }
-  }
-  return false;
-}
+#include "libcall.h"
 
 static void lower_set_error(LOWER_CTX *ctx, int8_t errnum, const char *detail) {
   if (!ctx) return;
@@ -323,7 +288,7 @@ static void lower_expr(LOWER_CTX *ctx, AS_NODE *node) {
 
       lower_arglist(ctx, (AS_NODE *)node->rhs, &argc);
       if (ctx->errnum != ERR_NOERROR) return;
-      if (!lower_lookup_libcall(libval->value.s, funcval->value.s, &lib_index, &call_index, &expected_args)) {
+      if (!libcall_lookup(libval->value.s, funcval->value.s, &lib_index, &call_index, &expected_args)) {
         lower_set_unsupported(ctx, node, "unknown libcall target");
         return;
       }


### PR DESCRIPTION
### Motivation

- Remove duplicated libcall metadata and lookup logic from the lowering module and reuse the single source of truth to avoid drift. 
- Correct the argument count for the `sys.compile` libcall which was previously incorrect.

### Description

- Removed the local `k_libcalls` table and `lower_lookup_libcall` function from `lower.c` and replaced them with a shared lookup by adding `#include "libcall.h"` and calling `libcall_lookup` from the lowering code. 
- Updated the global `libcalls` table in `src/libcall.c` to change the `sys.compile` entry's `args` field from `0` to `1`. 
- Minor cleanup of trailing/extra whitespace and dead code in the lowering implementation.

### Testing

- Built the project with `make`, which completed successfully. 
- Ran the automated unit test suite with `make test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a04e99058832e9197b3b7eea9b259)