### PR TITLE
Add initialized libcall registry for direct O(1) dispatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ TEST_CORE_SOURCES := \
 	$(TEST_DIR)/core/test_ir_validate.c \
 	$(TEST_DIR)/core/test_opcode_schema.c \
 	$(TEST_DIR)/core/test_parser_input_api.c \
-	$(TEST_DIR)/core/test_item_cache.c
+	$(TEST_DIR)/core/test_item_cache.c \
+	$(TEST_DIR)/core/test_libcall_registry.c
 TEST_COMPILER_SOURCES := \
 	$(TEST_DIR)/compiler/test_emitbc_header.c \
 	$(TEST_DIR)/compiler/test_emitbc_opcode_map.c \
@@ -36,7 +37,8 @@ TEST_COMPILER_SOURCES := \
 	$(TEST_DIR)/compiler/test_sdiss_fixtures.c \
 	$(TEST_DIR)/compiler/test_compiler_context_failures.c \
 	$(TEST_DIR)/compiler/test_compiler_diag_pipeline.c \
-	$(TEST_DIR)/compiler/test_sys_compile_libcall.c
+	$(TEST_DIR)/compiler/test_sys_compile_libcall.c \
+	$(TEST_DIR)/compiler/test_libcall_lookup_precomputed.c
 TEST_INTERPRETER_SOURCES := \
 	$(TEST_DIR)/interpreter/test_interpret_semantics_golden.c
 TEST_SOURCES := $(TEST_SHARED_SOURCES) $(TEST_CORE_SOURCES) $(TEST_COMPILER_SOURCES) $(TEST_INTERPRETER_SOURCES)

--- a/src/libcall.c
+++ b/src/libcall.c
@@ -421,6 +421,28 @@ uint8_t *lc_str_lower(uint8_t *nextop, ITEM_t *item) {
   return nextop;
 }
 
+
+typedef struct {
+  OP_t func;
+  uint8_t args;
+  bool present;
+} LIBCALL_REG_ENTRY_t;
+
+typedef struct {
+  const char *libname;
+  const char *callname;
+  uint8_t lib_index;
+  uint8_t call_index;
+  uint8_t args;
+} LIBCALL_NAME_ENTRY_t;
+
+static LIBCALL_REG_ENTRY_t *libcall_registry = NULL;
+static LIBCALL_NAME_ENTRY_t *libcall_name_registry = NULL;
+static size_t libcall_registry_width = 0;
+static size_t libcall_registry_height = 0;
+static size_t libcall_name_registry_count = 0;
+static bool libcall_registry_ready = false;
+
 const LIBCALL_t libcalls[] = {
   {"sys",  "backup",       1, 0, 0, lc_sys_backup},
   {"sys",  "log",          1, 1, 1, lc_sys_log},
@@ -437,31 +459,117 @@ const LIBCALL_t libcalls[] = {
   {NULL,   NULL,          -1, -1, 0, NULL}  // End marker
 };
 
-bool libcall_lookup(const char *libname, const char *callname,
-                   uint8_t *lib_index, uint8_t *call_index, uint8_t *args) {
-  // Finds a library call.  Returns true if found, with lib_index and
-  // call_index being updated to the correct indices.
-  for (int i = 0; libcalls[i].libname != NULL; i++) {
-    if (strcmp(libcalls[i].libname, libname) == 0 &&
-        strcmp(libcalls[i].callname, callname) == 0) {
-      *lib_index = libcalls[i].lib_index;
-      *call_index = libcalls[i].call_index;
-      *args = libcalls[i].args;
-      return true;  // Found
+static size_t libcall_registry_index(uint8_t lib_index, uint8_t call_index) {
+  return ((size_t)lib_index * libcall_registry_width) + (size_t)call_index;
+}
+
+bool libcall_init_registry(void) {
+  if (libcall_registry_ready) {
+    return true;
+  }
+
+  int8_t max_lib_index = -1;
+  int8_t max_call_index = -1;
+  size_t count = 0;
+  for (size_t i = 0; libcalls[i].libname != NULL; i++) {
+    if (libcalls[i].lib_index < 0 || libcalls[i].call_index < 0) {
+      return false;
+    }
+    if (libcalls[i].lib_index > max_lib_index) {
+      max_lib_index = libcalls[i].lib_index;
+    }
+    if (libcalls[i].call_index > max_call_index) {
+      max_call_index = libcalls[i].call_index;
+    }
+    count++;
+  }
+
+  libcall_registry_height = (size_t)max_lib_index + 1;
+  libcall_registry_width = (size_t)max_call_index + 1;
+  size_t dense_count = libcall_registry_height * libcall_registry_width;
+
+  libcall_registry = GROW_ARRAY(LIBCALL_REG_ENTRY_t, NULL, 0, dense_count);
+  libcall_name_registry = GROW_ARRAY(LIBCALL_NAME_ENTRY_t, NULL, 0, count);
+  if (!libcall_registry || !libcall_name_registry) {
+    return false;
+  }
+  memset(libcall_registry, 0, sizeof(LIBCALL_REG_ENTRY_t) * dense_count);
+
+  for (size_t i = 0; i < count; i++) {
+    uint8_t lib_index = (uint8_t)libcalls[i].lib_index;
+    uint8_t call_index = (uint8_t)libcalls[i].call_index;
+    size_t dense_index = libcall_registry_index(lib_index, call_index);
+    if (libcall_registry[dense_index].present) {
+      return false;
+    }
+    libcall_registry[dense_index].func = libcalls[i].func;
+    libcall_registry[dense_index].args = libcalls[i].args;
+    libcall_registry[dense_index].present = true;
+
+    libcall_name_registry[i].libname = libcalls[i].libname;
+    libcall_name_registry[i].callname = libcalls[i].callname;
+    libcall_name_registry[i].lib_index = lib_index;
+    libcall_name_registry[i].call_index = call_index;
+    libcall_name_registry[i].args = libcalls[i].args;
+  }
+
+  libcall_name_registry_count = count;
+  libcall_registry_ready = true;
+  return true;
+}
+
+bool libcall_validate_registry(void) {
+  if (!libcall_init_registry()) {
+    return false;
+  }
+
+  for (size_t i = 0; libcalls[i].libname != NULL; i++) {
+    uint8_t lib_index = (uint8_t)libcalls[i].lib_index;
+    uint8_t call_index = (uint8_t)libcalls[i].call_index;
+    if (lib_index >= libcall_registry_height || call_index >= libcall_registry_width) {
+      return false;
+    }
+    size_t dense_index = libcall_registry_index(lib_index, call_index);
+    if (!libcall_registry[dense_index].present) {
+      return false;
+    }
+    if (libcall_registry[dense_index].func != libcalls[i].func ||
+        libcall_registry[dense_index].args != libcalls[i].args) {
+      return false;
     }
   }
-  return false;  // Not found
+  return true;
+}
+
+bool libcall_lookup(const char *libname, const char *callname,
+                   uint8_t *lib_index, uint8_t *call_index, uint8_t *args) {
+  if (!libcall_init_registry()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < libcall_name_registry_count; i++) {
+    if (strcmp(libcall_name_registry[i].libname, libname) != 0) {
+      continue;
+    }
+    if (strcmp(libcall_name_registry[i].callname, callname) == 0) {
+      *lib_index = libcall_name_registry[i].lib_index;
+      *call_index = libcall_name_registry[i].call_index;
+      *args = libcall_name_registry[i].args;
+      return true;
+    }
+  }
+
+  return false;
 }
 
 void *libcall_func(uint8_t lib, uint8_t call) {
-  // Given a library and call index, try to find it in the
-  // libcall table.  Return a pointer to its function if
-  // found, otherwise return NULL.
-  for (int i = 0; libcalls[i].libname != NULL; i++) {
-    if (libcalls[i].lib_index == lib &&
-        libcalls[i].call_index == call) {
-      return libcalls[i].func;
-    }
+  if (!libcall_init_registry()) {
+    return NULL;
   }
-  return NULL;
+  if (lib >= libcall_registry_height || call >= libcall_registry_width) {
+    return NULL;
+  }
+
+  LIBCALL_REG_ENTRY_t entry = libcall_registry[libcall_registry_index(lib, call)];
+  return entry.present ? entry.func : NULL;
 }

--- a/src/libcall.h
+++ b/src/libcall.h
@@ -23,5 +23,6 @@ typedef struct {
 
 bool libcall_lookup(const char *libname, const char *callname,
                     uint8_t *lib_index, uint8_t *call_index, uint8_t *args);
+bool libcall_init_registry(void);
+bool libcall_validate_registry(void);
 void *libcall_func(uint8_t lib, uint8_t call);
-

--- a/tests/compiler/test_libcall_lookup_precomputed.c
+++ b/tests/compiler/test_libcall_lookup_precomputed.c
@@ -1,0 +1,15 @@
+#include "libcall.h"
+#include "test_assert.h"
+
+void test_libcall_lookup_precomputed(void) {
+  uint8_t lib = 0;
+  uint8_t call = 0;
+  uint8_t args = 0;
+
+  ASSERT_TRUE(libcall_lookup("task", "newgametask", &lib, &call, &args));
+  ASSERT_EQ_INT(2, lib);
+  ASSERT_EQ_INT(0, call);
+  ASSERT_EQ_INT(3, args);
+
+  ASSERT_TRUE(!libcall_lookup("missing", "missing", &lib, &call, &args));
+}

--- a/tests/core/test_libcall_registry.c
+++ b/tests/core/test_libcall_registry.c
@@ -1,0 +1,18 @@
+#include "libcall.h"
+#include "test_assert.h"
+
+void test_libcall_registry_roundtrip(void) {
+  ASSERT_TRUE(libcall_init_registry());
+  ASSERT_TRUE(libcall_validate_registry());
+
+  uint8_t lib = 0;
+  uint8_t call = 0;
+  uint8_t args = 0;
+  ASSERT_TRUE(libcall_lookup("sys", "log", &lib, &call, &args));
+  ASSERT_EQ_INT(1, lib);
+  ASSERT_EQ_INT(1, call);
+  ASSERT_EQ_INT(1, args);
+
+  ASSERT_NOT_NULL(libcall_func(lib, call));
+  ASSERT_TRUE(libcall_func(99, 99) == NULL);
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -27,6 +27,7 @@ void test_parser_input_api(void);
 void test_fixture_policy_declared_goldens_exist(void);
 void test_find_item_cached_hit_and_negative_cache(void);
 void test_find_item_cached_invalidation_on_delete_and_reinsert(void);
+void test_libcall_registry_roundtrip(void);
 
 /* Compiler component tests. */
 void test_emitbc_header(void);
@@ -45,6 +46,7 @@ void test_sdiss_reads_compiler_operand_widths(void);
 void test_compiler_context_failures(void);
 void test_compiler_diag_pipeline(void);
 void test_sys_compile_libcall_runtime(void);
+void test_libcall_lookup_precomputed(void);
 
 /* Interpreter component tests. */
 void test_interpret_semantics_golden(void);
@@ -106,6 +108,7 @@ static const test_case_t core_tests[] = {
     {"test_fixture_policy_declared_goldens_exist", test_fixture_policy_declared_goldens_exist},
     {"test_find_item_cached_hit_and_negative_cache", test_find_item_cached_hit_and_negative_cache},
     {"test_find_item_cached_invalidation_on_delete_and_reinsert", test_find_item_cached_invalidation_on_delete_and_reinsert},
+    {"test_libcall_registry_roundtrip", test_libcall_registry_roundtrip},
 };
 
 static const test_case_t compiler_tests[] = {
@@ -125,6 +128,7 @@ static const test_case_t compiler_tests[] = {
     {"test_compiler_context_failures", test_compiler_context_failures},
     {"test_compiler_diag_pipeline", test_compiler_diag_pipeline},
     {"test_sys_compile_libcall_runtime", test_sys_compile_libcall_runtime},
+    {"test_libcall_lookup_precomputed", test_libcall_lookup_precomputed},
 };
 
 static const test_case_t interpreter_tests[] = {


### PR DESCRIPTION
### Motivation
- Replace linear scans over `LIBCALL_t libcalls[]` with a dense dispatch table to enable O(1) lookup by `(lib_index, call_index)` and catch duplicate index assignments early. 
- Preserve `libcalls[]` as the single source of truth while precomputing runtime structures to speed dispatch and enable name-based lookups.

### Description
- Add an in-memory registry and name table plus two new APIs `libcall_init_registry()` and `libcall_validate_registry()` that build and cross-validate the dense tables from `libcalls[]` and reject duplicate `(lib_index, call_index)` pairs, with lazy initialization on first use. 
- Introduce `LIBCALL_REG_ENTRY_t` and `LIBCALL_NAME_ENTRY_t` tables and size/ready state in `src/libcall.c` and compute flattened indices with `libcall_registry_index()` for direct dispatch. 
- Change `libcall_func(uint8_t lib, uint8_t call)` to perform bounds checks and return the function pointer via a dense table lookup instead of scanning `libcalls[]`. 
- Change `libcall_lookup(const char *libname, const char *callname, ...)` to consult the precomputed name table built at init instead of scanning `libcalls[]`. 
- Keep `libcalls[]` intact as the canonical declaration and add `libcall_validate_registry()` to cross-check registry contents against it. 
- Add tests `tests/core/test_libcall_registry.c` and `tests/compiler/test_libcall_lookup_precomputed.c`, and wire them into the shared test harness and `Makefile` so they run under `make test`.

### Testing
- Ran the full test harness with `make test`, which executed the core, compiler and interpreter suites and reported all tests completed: `34 tests across 3 suites` (success). 
- New tests `test_libcall_registry_roundtrip` and `test_libcall_lookup_precomputed` were included and exercised registry initialization, validation, name lookup, and out-of-range behavior (passing). 
- Build and test flow was validated end-to-end, including linking the shared library and running the test runner binary (`tests/test-compiler`) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e072d14dc832ea133415b10ee940a)