### PR TITLE
Optimize libcall lookup with keyed index and duplicate-name detection

### DIFF
--- a/src/libcall.c
+++ b/src/libcall.c
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdlib.h>
 
 #include "util.h"
 #include "error.h"
@@ -434,7 +435,31 @@ typedef struct {
   uint8_t lib_index;
   uint8_t call_index;
   uint8_t args;
+  char *lookup_key;
 } LIBCALL_NAME_ENTRY_t;
+
+static int libcall_name_entry_cmp(const void *a, const void *b) {
+  const LIBCALL_NAME_ENTRY_t *ea = (const LIBCALL_NAME_ENTRY_t *)a;
+  const LIBCALL_NAME_ENTRY_t *eb = (const LIBCALL_NAME_ENTRY_t *)b;
+  return strcmp(ea->lookup_key, eb->lookup_key);
+}
+
+static bool libcall_make_key(const char *libname, const char *callname,
+                             char **out_key) {
+  size_t liblen = strlen(libname);
+  size_t calllen = strlen(callname);
+  size_t keylen = liblen + 1 + calllen;
+  char *key = GROW_ARRAY(char, NULL, 0, keylen + 1);
+  if (!key) {
+    return false;
+  }
+  memcpy(key, libname, liblen);
+  key[liblen] = '\x1f';
+  memcpy(key + liblen + 1, callname, calllen);
+  key[keylen] = '\0';
+  *out_key = key;
+  return true;
+}
 
 static LIBCALL_REG_ENTRY_t *libcall_registry = NULL;
 static LIBCALL_NAME_ENTRY_t *libcall_name_registry = NULL;
@@ -511,6 +536,21 @@ bool libcall_init_registry(void) {
     libcall_name_registry[i].lib_index = lib_index;
     libcall_name_registry[i].call_index = call_index;
     libcall_name_registry[i].args = libcalls[i].args;
+    libcall_name_registry[i].lookup_key = NULL;
+    if (!libcall_make_key(libcalls[i].libname, libcalls[i].callname,
+                          &libcall_name_registry[i].lookup_key)) {
+      return false;
+    }
+  }
+
+  qsort(libcall_name_registry, count, sizeof(LIBCALL_NAME_ENTRY_t),
+        libcall_name_entry_cmp);
+
+  for (size_t i = 1; i < count; i++) {
+    if (strcmp(libcall_name_registry[i - 1].lookup_key,
+               libcall_name_registry[i].lookup_key) == 0) {
+      return false;
+    }
   }
 
   libcall_name_registry_count = count;
@@ -547,19 +587,37 @@ bool libcall_lookup(const char *libname, const char *callname,
     return false;
   }
 
-  for (size_t i = 0; i < libcall_name_registry_count; i++) {
-    if (strcmp(libcall_name_registry[i].libname, libname) != 0) {
-      continue;
-    }
-    if (strcmp(libcall_name_registry[i].callname, callname) == 0) {
-      *lib_index = libcall_name_registry[i].lib_index;
-      *call_index = libcall_name_registry[i].call_index;
-      *args = libcall_name_registry[i].args;
-      return true;
-    }
+  char *lookup_key = NULL;
+  if (!libcall_make_key(libname, callname, &lookup_key)) {
+    return false;
   }
 
-  return false;
+  LIBCALL_NAME_ENTRY_t needle = {.lookup_key = lookup_key};
+  LIBCALL_NAME_ENTRY_t *entry = bsearch(&needle, libcall_name_registry,
+      libcall_name_registry_count, sizeof(LIBCALL_NAME_ENTRY_t),
+      libcall_name_entry_cmp);
+  FREE_ARRAY(char, lookup_key, strlen(lookup_key) + 1);
+
+  if (!entry) {
+    return false;
+  }
+
+  *lib_index = entry->lib_index;
+  *call_index = entry->call_index;
+  *args = entry->args;
+  return true;
+}
+
+bool libcall_names_unique(const LIBCALL_t *calls) {
+  for (size_t i = 0; calls[i].libname != NULL; i++) {
+    for (size_t j = i + 1; calls[j].libname != NULL; j++) {
+      if (strcmp(calls[i].libname, calls[j].libname) == 0 &&
+          strcmp(calls[i].callname, calls[j].callname) == 0) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 void *libcall_func(uint8_t lib, uint8_t call) {

--- a/src/libcall.h
+++ b/src/libcall.h
@@ -25,4 +25,5 @@ bool libcall_lookup(const char *libname, const char *callname,
                     uint8_t *lib_index, uint8_t *call_index, uint8_t *args);
 bool libcall_init_registry(void);
 bool libcall_validate_registry(void);
+bool libcall_names_unique(const LIBCALL_t *calls);
 void *libcall_func(uint8_t lib, uint8_t call);

--- a/tests/core/test_libcall_registry.c
+++ b/tests/core/test_libcall_registry.c
@@ -16,3 +16,13 @@ void test_libcall_registry_roundtrip(void) {
   ASSERT_NOT_NULL(libcall_func(lib, call));
   ASSERT_TRUE(libcall_func(99, 99) == NULL);
 }
+
+void test_libcall_name_duplicate_detection(void) {
+  const LIBCALL_t dup_calls[] = {
+    {"sys", "log", 1, 1, 1, NULL},
+    {"sys", "log", 1, 9, 1, NULL},
+    {NULL, NULL, -1, -1, 0, NULL}
+  };
+
+  ASSERT_TRUE(!libcall_names_unique(dup_calls));
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -28,6 +28,7 @@ void test_fixture_policy_declared_goldens_exist(void);
 void test_find_item_cached_hit_and_negative_cache(void);
 void test_find_item_cached_invalidation_on_delete_and_reinsert(void);
 void test_libcall_registry_roundtrip(void);
+void test_libcall_name_duplicate_detection(void);
 
 /* Compiler component tests. */
 void test_emitbc_header(void);
@@ -109,6 +110,7 @@ static const test_case_t core_tests[] = {
     {"test_find_item_cached_hit_and_negative_cache", test_find_item_cached_hit_and_negative_cache},
     {"test_find_item_cached_invalidation_on_delete_and_reinsert", test_find_item_cached_invalidation_on_delete_and_reinsert},
     {"test_libcall_registry_roundtrip", test_libcall_registry_roundtrip},
+    {"test_libcall_name_duplicate_detection", test_libcall_name_duplicate_detection},
 };
 
 static const test_case_t compiler_tests[] = {


### PR DESCRIPTION
### Motivation
- Replace linear textual scan of `libcalls[]` with a compile-time-friendly keyed registry to speed and simplify name lookup. 
- Ensure duplicate textual names are detected early and fail fast during registry initialization. 

### Description
- Build textual keys of the form `libname + '\x1f' + callname` and store them on each name-entry, add `libcall_name_entry_cmp` and `libcall_make_key` helpers, and sort the name registry with `qsort` for binary lookup in `src/libcall.c`.
- Replace the full-scan lookup in `libcall_lookup` with a `bsearch` over the sorted name registry and return `lib_index`, `call_index`, and `args` from the found entry.
- Detect duplicate textual names after sorting and fail `libcall_init_registry` early if duplicates are found, and add a `libcall_names_unique` helper for unit tests.
- Add a declaration for `libcall_names_unique` to `src/libcall.h` and add a unit test `test_libcall_name_duplicate_detection` in `tests/core/test_libcall_registry.c`, and wire it into the shared test harness `tests/shared/test_compiler.c`.

### Testing
- Ran the test suite with `make test`; all tests completed successfully: `35 tests across 3 suites` and the new duplicate-detection test executed and passed. 
- Changes compiled as part of the default build and test targets (`gcc` toolchain used by `Makefile`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0953efc8832ebc0b4e8fd260129a)