### PR TITLE
Refactor libcall dispatch to return OP_t and add regression for missing libcall

### DIFF
--- a/src/libcall.c
+++ b/src/libcall.c
@@ -484,6 +484,23 @@ const LIBCALL_t libcalls[] = {
   {NULL,   NULL,          -1, -1, 0, NULL}  // End marker
 };
 
+#define LIBCALL_FUNC_SIGNATURE_GUARD(name) \
+  _Static_assert(__builtin_types_compatible_p(__typeof__(&(name)), OP_t), \
+                 "libcall function must match OP_t signature")
+
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_sys_backup);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_sys_log);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_sys_shutdown);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_sys_abort);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_sys_compile);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_task_newgametask);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_task_killtask);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_net_input);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_net_write);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_str_capitalise);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_str_upper);
+LIBCALL_FUNC_SIGNATURE_GUARD(lc_str_lower);
+
 static size_t libcall_registry_index(uint8_t lib_index, uint8_t call_index) {
   return ((size_t)lib_index * libcall_registry_width) + (size_t)call_index;
 }
@@ -620,7 +637,7 @@ bool libcall_names_unique(const LIBCALL_t *calls) {
   return true;
 }
 
-void *libcall_func(uint8_t lib, uint8_t call) {
+OP_t libcall_func(uint8_t lib, uint8_t call) {
   if (!libcall_init_registry()) {
     return NULL;
   }

--- a/src/libcall.h
+++ b/src/libcall.h
@@ -26,4 +26,4 @@ bool libcall_lookup(const char *libname, const char *callname,
 bool libcall_init_registry(void);
 bool libcall_validate_registry(void);
 bool libcall_names_unique(const LIBCALL_t *calls);
-void *libcall_func(uint8_t lib, uint8_t call);
+OP_t libcall_func(uint8_t lib, uint8_t call);

--- a/tests/core/test_libcall_registry.c
+++ b/tests/core/test_libcall_registry.c
@@ -1,5 +1,15 @@
+#include <string.h>
+#include <stdlib.h>
+
 #include "libcall.h"
+#include "config.h"
+#include "error.h"
+#include "interpret.h"
+#include "item.h"
 #include "test_assert.h"
+#include "vm.h"
+
+extern CONFIG_t config;
 
 void test_libcall_registry_roundtrip(void) {
   ASSERT_TRUE(libcall_init_registry());
@@ -25,4 +35,38 @@ void test_libcall_name_duplicate_detection(void) {
   };
 
   ASSERT_TRUE(!libcall_names_unique(dup_calls));
+}
+
+void test_missing_libcall_is_null_and_interpret_deterministic(void) {
+  ASSERT_TRUE(libcall_func(99, 99) == NULL);
+
+  memset(&config, 0, sizeof(config));
+  init_errmsg();
+  config.itemroot = make_root_item("root");
+  ASSERT_NOT_NULL(config.itemroot);
+  config.vm = make_vm();
+  ASSERT_NOT_NULL(config.vm);
+
+  uint8_t template_bytecode[] = {
+    0x00, 0x00,
+    'A', 99, 99,
+    'h'
+  };
+  uint8_t *bytecode = malloc(sizeof(template_bytecode));
+  ASSERT_NOT_NULL(bytecode);
+  memcpy(bytecode, template_bytecode, sizeof(template_bytecode));
+
+  ITEM_t *code = insert_code_item(config.itemroot, "test.missinglibcall",
+                                  sizeof(template_bytecode), bytecode);
+  ASSERT_NOT_NULL(code);
+
+  VALUE_t v1 = interpret(code);
+  VALUE_t v2 = interpret(code);
+  ASSERT_EQ_INT(VALUE_nil, v1.type);
+  ASSERT_EQ_INT(VALUE_nil, v2.type);
+  ASSERT_EQ_INT(-1, config.vm->stack->current);
+  ASSERT_EQ_INT(-1, config.vm->callstack->current);
+
+  destroy_vm(config.vm);
+  destroy_item(config.itemroot);
 }

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -29,6 +29,7 @@ void test_find_item_cached_hit_and_negative_cache(void);
 void test_find_item_cached_invalidation_on_delete_and_reinsert(void);
 void test_libcall_registry_roundtrip(void);
 void test_libcall_name_duplicate_detection(void);
+void test_missing_libcall_is_null_and_interpret_deterministic(void);
 
 /* Compiler component tests. */
 void test_emitbc_header(void);
@@ -111,6 +112,7 @@ static const test_case_t core_tests[] = {
     {"test_find_item_cached_invalidation_on_delete_and_reinsert", test_find_item_cached_invalidation_on_delete_and_reinsert},
     {"test_libcall_registry_roundtrip", test_libcall_registry_roundtrip},
     {"test_libcall_name_duplicate_detection", test_libcall_name_duplicate_detection},
+    {"test_missing_libcall_is_null_and_interpret_deterministic", test_missing_libcall_is_null_and_interpret_deterministic},
 };
 
 static const test_case_t compiler_tests[] = {


### PR DESCRIPTION
### Motivation
- Remove the use of an untyped `void *` in the libcall dispatch boundary and enforce the actual opcode-function signature (`OP_t`) across the registry. 
- Fail fast at compile time if any registered libcall handler does not match the interpreter `OP_t` signature. 
- Add a regression to ensure a missing libcall lookup yields `NULL` and the interpreter behaves deterministically when such a call is executed.

### Description
- Change the libcall lookup API in `src/libcall.h` from `void *libcall_func(uint8_t lib, uint8_t call);` to `OP_t libcall_func(uint8_t lib, uint8_t call);` so the lookup returns a typed opcode function pointer. 
- Update the implementation signature in `src/libcall.c` to return `OP_t` and keep the same `NULL` semantics for invalid lookups. 
- Add a compile-time guard macro using `_Static_assert` + `__builtin_types_compatible_p` (`LIBCALL_FUNC_SIGNATURE_GUARD`) in `src/libcall.c` to verify each `libcalls[]` entry's handler matches `OP_t`. 
- Add `test_missing_libcall_is_null_and_interpret_deterministic` in `tests/core/test_libcall_registry.c` and register it in `tests/shared/test_compiler.c`; the test asserts `libcall_func(99,99) == NULL`, runs a short bytecode sequence that invokes a missing libcall twice, and verifies the interpreter returns `VALUE_nil` both times and leaves VM stack/callstack stable. 

### Testing
- Built and ran the test harness with `make test`; the test run completed and reported all tests across the suites (core/compiler/interpreter) passing. 
- Existing libcall registry tests remain in place and the new regression test was executed as part of the harness. 
- The change includes compile-time verification that every registered libcall handler matches the `OP_t` signature via the added `_Static_assert` checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0d222984832ea615a20630e71c1b)