### PR TITLE
Add ERR_RUNTIME_INVLIB and record unknown libcall details

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -23,4 +23,5 @@ void init_errmsg() {
   errmsg[ERR_RUNTIME_INVALIDARGS] = "Invalid arguments to library call.";
   errmsg[ERR_RUNTIME_NOSUCHITEM] = "Item does not exist.";
   errmsg[ERR_RUNTIME_TRUNCATED] = "Truncated bytecode.";
+  errmsg[ERR_RUNTIME_INVLIB] = "Invalid libcall.";
 }

--- a/src/error.h
+++ b/src/error.h
@@ -25,6 +25,7 @@
 #define ERR_RUNTIME_INVALIDARGS   21
 #define ERR_RUNTIME_NOSUCHITEM    22
 #define ERR_RUNTIME_TRUNCATED     23
+#define ERR_RUNTIME_INVLIB        24
 
 extern const char *errmsg[];
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -583,7 +583,12 @@ uint8_t *op_libcall(uint8_t *nextop, ITEM_t *item) {
   DISASS_LOG("Calling library %d, function %d.\n", lib, func);
   OP_t libcall = libcall_func(lib, func);
   if (!libcall) {
-    logerr("Library call not found.\n");
+    char detail[64];
+    snprintf(detail, sizeof(detail), "Unknown libcall %u:%u", lib, func);
+    logerr("%s.\n", detail);
+    set_error_item(ERR_RUNTIME_INVLIB, detail);
+    // Preserve the "libcalls return a value" contract even on failure.
+    push_stack(VM->stack, VALUE_NIL);
   } else {
     nextop = libcall(nextop, item);
   }

--- a/tests/core/test_libcall_registry.c
+++ b/tests/core/test_libcall_registry.c
@@ -69,6 +69,14 @@ void test_missing_libcall_is_null_and_interpret_deterministic(void) {
   VALUE_t v2 = interpret(code);
   ASSERT_EQ_INT(VALUE_nil, v1.type);
   ASSERT_EQ_INT(VALUE_nil, v2.type);
+  ITEM_t *err_item = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err_item);
+  ASSERT_EQ_INT(VALUE_int, err_item->value.type);
+  ASSERT_EQ_INT(ERR_RUNTIME_INVLIB, err_item->value.i);
+  ITEM_t *err_msg = find_item(config.itemroot, "error.msg");
+  ASSERT_NOT_NULL(err_msg);
+  ASSERT_EQ_INT(VALUE_str, err_msg->value.type);
+  ASSERT_TRUE(strstr(err_msg->value.s, "Unknown libcall 99:99") != NULL);
   ASSERT_EQ_INT(-1, config.vm->stack->current);
   ASSERT_EQ_INT(-1, config.vm->callstack->current);
 


### PR DESCRIPTION
### Motivation
- Make missing library-call failures reportable to the runtime state and provide a descriptive message while preserving the contract that libcalls always return a value.

### Description
- Add `ERR_RUNTIME_INVLIB` to `error.h` and an associated message in `error.c`.
- In `op_libcall` in `interpret.c`, build a detail string for missing libcalls, log it, call `set_error_item(ERR_RUNTIME_INVLIB, detail)`, and push `VALUE_NIL` to preserve the libcall return behavior.
- Update `tests/core/test_libcall_registry.c` to assert that an `error` item with the new code and an `error.msg` string containing the libcall detail are created when a libcall is missing.

### Testing
- Ran the core unit test `tests/core/test_libcall_registry.c` which includes `test_missing_libcall_is_null_and_interpret_deterministic` and `test_libcall_registry_self_check_invalid_entries`, and the tests passed.
- Ran the project's automated test suite (unit tests) after the change and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0fbae748832e8d31ba6aec7a5f96)