### PR TITLE
Support optional leading dot for relative items with explicit AST node (N_RELITEM)

### DIFF
--- a/src/absyn.c
+++ b/src/absyn.c
@@ -174,6 +174,7 @@ void as_delete(AS_NODE *root) {
     case N_NTHNAME:
     case N_ROOTNAME:
     case N_ITEM:
+    case N_RELITEM:
     case N_NOT:
     case N_LIBCALL:
     case N_ARGLIST:
@@ -204,7 +205,7 @@ void as_delete(AS_NODE *root) {
 // Keep this in sync with ENUM_VALUE!
 const char *valname[] = { "V_INT", "V_STR", "V_LOCAL", "V_LAYER" };
 // And keep this in sync with ENUM_NODE!
-const char *nodename[] = { "N_VALUE", "N_ADD", "N_SUB", "N_MUL", "N_DIV", "N_INC", "N_DEC", "N_EQUAL", "N_NOTEQ", "N_OR", "N_AND", "N_LT", "N_LTEQ", "N_GT", "N_GTEQ", "N_DEREF", "N_EXISTS", "N_DELETE", "N_NTHNAME", "N_ROOTNAME", "N_ITEM", "N_NOT", "N_LIBCALL", "N_ARGLIST", "N_CODE", "N_CALL", "N_ASSITEM", "N_ASSLOCAL", "N_EXPRSTMT", "N_RETURN", "N_STMTLIST", "N_STMT", "N_WHILESTMT", "N_IFSTMT" };
+const char *nodename[] = { "N_VALUE", "N_ADD", "N_SUB", "N_MUL", "N_DIV", "N_INC", "N_DEC", "N_EQUAL", "N_NOTEQ", "N_OR", "N_AND", "N_LT", "N_LTEQ", "N_GT", "N_GTEQ", "N_DEREF", "N_EXISTS", "N_DELETE", "N_NTHNAME", "N_ROOTNAME", "N_ITEM", "N_RELITEM", "N_NOT", "N_LIBCALL", "N_ARGLIST", "N_CODE", "N_CALL", "N_ASSITEM", "N_ASSLOCAL", "N_EXPRSTMT", "N_RETURN", "N_STMTLIST", "N_STMT", "N_WHILESTMT", "N_IFSTMT" };
 
 void as_pretty_print(int tree_depth) {
   // Indent to make everything look all neat and professional
@@ -225,6 +226,11 @@ void as_reconstruct_value(AS_NODE *node) {
 
 void as_reconstruct_item(AS_NODE *root) {
   // Given an N_ITEM node, follow it to its end
+  if (root && root->nodetype == N_RELITEM) {
+    logmsg(".");
+    root = (AS_NODE*)root->lhs;
+  }
+
   AS_NODE *node = root->lhs;
   // An item node can only have children of type N_VALUE or N_DEREF
   if (node->nodetype == N_VALUE) {
@@ -362,7 +368,8 @@ static void as_walk_internal(AS_NODE *root, int tree_depth) {
       logmsg("Node type: %s\n", nodename[root->nodetype]);
       break;
     }
-    case N_ITEM: {
+    case N_ITEM:
+    case N_RELITEM: {
       logmsg("Item node: ");
       as_reconstruct_item(root);
       logmsg("\n");

--- a/src/absyn.h
+++ b/src/absyn.h
@@ -20,7 +20,7 @@ typedef struct AS_VALUE_s AS_VALUE;
 typedef enum { N_VALUE, N_ADD, N_SUB, N_MUL, N_DIV, N_INC, N_DEC,
                N_EQUAL, N_NOTEQ, N_OR, N_AND, N_LT, N_LTEQ, N_GT, N_GTEQ,
                N_DEREF, N_EXISTS, N_DELETE, N_NTHNAME, N_ROOTNAME, N_ITEM,
-               N_NOT, N_LIBCALL, N_ARGLIST, N_CODE, N_CALL, N_ASSITEM,
+               N_RELITEM, N_NOT, N_LIBCALL, N_ARGLIST, N_CODE, N_CALL, N_ASSITEM,
                N_ASSLOCAL, N_EXPRSTMT, N_RETURN, N_STMTLIST, N_STMT,
                N_WHILESTMT, N_IFSTMT
              } ENUM_NODE;

--- a/src/lower.c
+++ b/src/lower.c
@@ -124,7 +124,7 @@ static void lower_deref_payload(LOWER_CTX *ctx, AS_NODE *payload) {
     return;
   }
 
-  if (payload->nodetype == N_ITEM) {
+  if (payload->nodetype == N_ITEM || payload->nodetype == N_RELITEM) {
     lower_item(ctx, payload);
     return;
   }
@@ -134,9 +134,17 @@ static void lower_deref_payload(LOWER_CTX *ctx, AS_NODE *payload) {
 
 static void lower_item(LOWER_CTX *ctx, AS_NODE *item) {
   AS_NODE *cursor;
-  if (!item || item->nodetype != N_ITEM) {
+  if (!item || (item->nodetype != N_ITEM && item->nodetype != N_RELITEM)) {
     lower_set_unsupported(ctx, item, "expected item node");
     return;
+  }
+
+  if (item->nodetype == N_RELITEM) {
+    item = (AS_NODE *)item->lhs;
+    if (!item || item->nodetype != N_ITEM) {
+      lower_set_unsupported(ctx, item, "invalid relative item payload");
+      return;
+    }
   }
 
   ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_ITEM_BEGIN});
@@ -236,6 +244,7 @@ static void lower_expr(LOWER_CTX *ctx, AS_NODE *node) {
       return;
 
     case N_ITEM:
+    case N_RELITEM:
       lower_item(ctx, node);
       return;
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -249,6 +249,7 @@ item_assignment: expr { $$ = $1; }
         ;
 
 item:     first_layer subsequent_layers { $$ = as_new_node(N_ITEM, $1, $2); }
+        | TLAYERSEP first_layer subsequent_layers { $$ = as_new_node(N_RELITEM, as_new_node(N_ITEM, $2, $3), NULL); }
         ;
 
 first_layer: TLAYER { $$ = as_new_valnode(V_LAYER, $1); }


### PR DESCRIPTION
### Motivation
- Allow item syntax to start with an optional leading `TLAYERSEP` (a leading dot) before `first_layer` so expressions like `.bar` and `.[foo].bar` parse naturally.
- Represent the relative-item form explicitly in the AST instead of encoding it as an empty string layer so code that inspects/traverses items can distinguish relative items structurally.
- Ensure the AST walk/print and lowering logic accept the new form and that nested dereferences and deref-first-layer cases are handled consistently.

### Description
- Parser: updated `item` grammar in `src/parser.y` to accept `| TLAYERSEP first_layer subsequent_layers` and produce a new `N_RELITEM` node that wraps a normal `N_ITEM` payload (`N_RELITEM(as_new_node(N_ITEM, ...))`).
- AST: added `N_RELITEM` to `src/absyn.h` enum and updated `src/absyn.c` to include `N_RELITEM` in deletion traversal and nodename table, to print a leading dot when reconstructing `N_RELITEM`, and to treat `N_RELITEM` as an item node in the pretty-walk logic.
- Lowering: updated `src/lower.c` so `N_RELITEM` is accepted wherever `N_ITEM` is expected (including dereference payloads), unwraps the `N_RELITEM` to the enclosed `N_ITEM` for processing, and otherwise preserves the existing item lowering behavior.
- Kept representation consistent across nested dereferences so `.[[...]]` forms and deref-as-first-layer (`.[@x].foo`) produce item ASTs using the same representation.

### Testing
- Ran `make -j4` to rebuild the compiler, which completed successfully.
- Compiled sample sources using `./scomp` including `foo = .bar;`, `foo = .[foo].bar;` and `foo = .[.[foo].bar].baz;`, and compilation completed successfully for those cases.
- Verified dereference-first-layer and nested item-dereference cases parse and lower using the new `N_RELITEM` representation during the above compilations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11503811ec832ea59ffb69eab2bbdb)