### PR TITLE
Refactor repetitive libcall argument validation and cleanup paths

### DIFF
--- a/src/libcall.c
+++ b/src/libcall.c
@@ -29,6 +29,31 @@ extern LINE_t *line;
 // Some shorthand
 #define VM config.vm
 
+// Popped VALUE_t ownership rules in this file:
+// - Callers own popped values and must free any owned string payload exactly once.
+// - FREE_STR(v) is the canonical cleanup helper; it is a safe no-op for non-string values.
+static inline bool lc_value_is_type(VALUE_t v, VALUE_e type) {
+  return v.type == type;
+}
+
+static inline uint8_t *lc_invalid_args_return(uint8_t *nextop, VALUE_t ret) {
+  set_error_item(ERR_RUNTIME_INVALIDARGS, NULL);
+  push_stack(VM->stack, ret);
+  return nextop;
+}
+
+static inline void lc_cleanup_values(VALUE_t *values, size_t count) {
+  for (size_t i = 0; i < count; i++) {
+    FREE_STR(values[i]);
+  }
+}
+
+static inline void lc_cleanup_cstr(char *s) {
+  if (s) {
+    FREE_ARRAY(char, s, strlen(s) + 1);
+  }
+}
+
 uint8_t *lc_sys_backup(uint8_t *nextop, ITEM_t *item) {
   // Create a backup of the itemstore.
   // All of the following is a long-winded way to get a backup filename.
@@ -100,12 +125,10 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
   // This call takes one parameter, expected to be a string.
   VALUE_t val = pop_stack(VM->stack);
 
-  if (val.type != VALUE_str) {
+  if (!lc_value_is_type(val, VALUE_str)) {
     logmsg("Sys.compile called with non-string value.\n");
     FREE_STR(val);
-    set_error_item(ERR_RUNTIME_INVALIDARGS, NULL);
-    push_stack(VM->stack, VALUE_FALSE);
-    return nextop;
+    return lc_invalid_args_return(nextop, VALUE_FALSE);
   }
 
   int8_t result = 0;
@@ -120,16 +143,14 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
   if (result != 0 || !out || !out->bytecode) {
     // Compile failed; release owned errdetail/out/val.s exactly once.
     set_error_item(result != 0 ? result : ERR_COMP_UNKNOWN, errdetail);
-    if (errdetail) {
-      FREE_ARRAY(char, errdetail, strlen(errdetail) + 1);
-    }
+    lc_cleanup_cstr(errdetail);
     if (out) {
       if (out->bytecode) {
         FREE_ARRAY(unsigned char, out->bytecode, out->maxsize);
       }
       FREE_ARRAY(OUTPUT_t, out, 1);
     }
-    FREE_ARRAY(char, val.s, strlen(val.s) + 1);
+    lc_cleanup_cstr(val.s);
     push_stack(VM->stack, VALUE_FALSE);
     return nextop;
   }
@@ -141,7 +162,7 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
         "Sys.compile temporary item name generation failed.");
     FREE_ARRAY(unsigned char, out->bytecode, out->maxsize);
     FREE_ARRAY(OUTPUT_t, out, 1);
-    FREE_ARRAY(char, val.s, strlen(val.s) + 1);
+    lc_cleanup_cstr(val.s);
     push_stack(VM->stack, VALUE_FALSE);
     return nextop;
   }
@@ -160,7 +181,7 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
     set_error_item(ERR_COMP_INUSE, NULL);
     FREE_ARRAY(unsigned char, out->bytecode, out->maxsize);
     FREE_ARRAY(OUTPUT_t, out, 1);
-    FREE_ARRAY(char, val.s, strlen(val.s) + 1);
+    lc_cleanup_cstr(val.s);
     push_stack(VM->stack, VALUE_FALSE);
     return nextop;
   }
@@ -179,7 +200,7 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
   set_item(config.itemroot, "error.msg", VALUE_NIL);
 
   FREE_ARRAY(OUTPUT_t, out, 1); // bytecode ownership moved into inserted item
-  FREE_ARRAY(char, val.s, strlen(val.s) + 1);
+  lc_cleanup_cstr(val.s);
 
   push_stack(VM->stack, VALUE_TRUE);
   return nextop;
@@ -224,16 +245,14 @@ uint8_t *lc_task_newgametask(uint8_t *nextop, ITEM_t *item) {
   VALUE_t repeatin = pop_stack(VM->stack);
   VALUE_t startin = pop_stack(VM->stack);
   VALUE_t itemname = pop_stack(VM->stack);
-  if (repeatin.type != VALUE_int || startin.type != VALUE_int
-                               || itemname.type != VALUE_str) {
+  if (!lc_value_is_type(repeatin, VALUE_int)
+   || !lc_value_is_type(startin, VALUE_int)
+   || !lc_value_is_type(itemname, VALUE_str)) {
     // Invalid parameters.  Clean them up, set the error item,
     // and return.
-    FREE_STR(repeatin);
-    FREE_STR(startin);
-    FREE_STR(itemname);
-    set_error_item(ERR_RUNTIME_INVALIDARGS, NULL);
-    push_stack(VM->stack, VALUE_NIL);
-    return nextop;
+    VALUE_t popped[] = {repeatin, startin, itemname};
+    lc_cleanup_values(popped, 3);
+    return lc_invalid_args_return(nextop, VALUE_NIL);
   }
   ITEM_t *taskitem = find_item(config.itemroot, itemname.s);
   if (!taskitem) {
@@ -268,12 +287,10 @@ uint8_t *lc_task_killtask(uint8_t *nextop, ITEM_t *item) {
   // Given a task id, kill it.
   // First validate the argument
   VALUE_t taskid = pop_stack(VM->stack);
-  if (taskid.type != VALUE_int) {
+  if (!lc_value_is_type(taskid, VALUE_int)) {
     // taskid may only own heap memory when it is a string; FREE_STR is a safe no-op otherwise.
     FREE_STR(taskid);
-    set_error_item(ERR_RUNTIME_INVALIDARGS, NULL);
-    push_stack(VM->stack, VALUE_NIL);
-    return nextop;
+    return lc_invalid_args_return(nextop, VALUE_NIL);
   }
 
   // Does this task even exist?
@@ -345,12 +362,10 @@ uint8_t *lc_net_write(uint8_t *nextop, ITEM_t *item) {
   VALUE_t out = pop_stack(VM->stack);
   VALUE_t linenum = pop_stack(VM->stack);
 
-  if (linenum.type != VALUE_int || linenum.i < 0 
+  if (!lc_value_is_type(linenum, VALUE_int) || linenum.i < 0 
                                         || linenum.i >= config.maxconns) {
     FREE_STR(out);
-    set_error_item(ERR_RUNTIME_INVALIDARGS, NULL);
-    push_stack(VM->stack, VALUE_NIL);
-    return nextop;
+    return lc_invalid_args_return(nextop, VALUE_NIL);
   } else {
     switch(out.type) {
       case VALUE_str:

--- a/tests/core/test_libcall_registry.c
+++ b/tests/core/test_libcall_registry.c
@@ -10,7 +10,33 @@
 #include "vm.h"
 #include "memory.h"
 
+#include "network.h"
+
+uint8_t *lc_task_newgametask(uint8_t *nextop, ITEM_t *item);
+uint8_t *lc_task_killtask(uint8_t *nextop, ITEM_t *item);
+uint8_t *lc_net_write(uint8_t *nextop, ITEM_t *item);
+
+extern LINE_t *line;
 extern CONFIG_t config;
+
+static void setup_libcall_runtime(void) {
+  memset(&config, 0, sizeof(config));
+  init_errmsg();
+  config.itemroot = make_root_item("root");
+  ASSERT_NOT_NULL(config.itemroot);
+  config.vm = make_vm();
+  ASSERT_NOT_NULL(config.vm);
+}
+
+static void teardown_libcall_runtime(void) {
+  if (line) {
+    free(line);
+    line = NULL;
+  }
+  destroy_vm(config.vm);
+  destroy_item(config.itemroot);
+}
+
 
 static uint8_t *test_noop_libcall(uint8_t *nextop, ITEM_t *item) {
   (void)item;
@@ -115,4 +141,46 @@ void test_libcall_registry_self_check_invalid_entries(void) {
 
   const LIBCALL_t gap_lib[] = {{"sys","a",1,0,0,test_noop_libcall},{"net","b",3,0,0,test_noop_libcall},{NULL,NULL,-1,-1,0,NULL}};
   ASSERT_TRUE(!libcall_registry_self_check(gap_lib, false));
+}
+
+void test_libcall_invalid_arg_branches_return_contracts(void) {
+  setup_libcall_runtime();
+
+  VALUE_t bad_name = {VALUE_int, {.i = 7}};
+  VALUE_t start = {VALUE_int, {.i = 1}};
+  VALUE_t repeat = {VALUE_int, {.i = 1}};
+  push_stack(config.vm->stack, bad_name);
+  push_stack(config.vm->stack, start);
+  push_stack(config.vm->stack, repeat);
+  (void)lc_task_newgametask(NULL, config.itemroot);
+  VALUE_t ret = pop_stack(config.vm->stack);
+  ASSERT_EQ_INT(VALUE_nil, ret.type);
+  ITEM_t *err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(ERR_RUNTIME_INVALIDARGS, err->value.i);
+
+  VALUE_t bad_taskid = {VALUE_str, {.s = strdup("x")}};
+  push_stack(config.vm->stack, bad_taskid);
+  (void)lc_task_killtask(NULL, config.itemroot);
+  ret = pop_stack(config.vm->stack);
+  ASSERT_EQ_INT(VALUE_nil, ret.type);
+  err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(ERR_RUNTIME_INVALIDARGS, err->value.i);
+
+  config.maxconns = 1;
+  line = calloc((size_t)config.maxconns, sizeof(LINE_t));
+  ASSERT_NOT_NULL(line);
+  VALUE_t bad_line = {VALUE_int, {.i = -1}};
+  VALUE_t out = {VALUE_str, {.s = strdup("hello")}};
+  push_stack(config.vm->stack, bad_line);
+  push_stack(config.vm->stack, out);
+  (void)lc_net_write(NULL, config.itemroot);
+  ret = pop_stack(config.vm->stack);
+  ASSERT_EQ_INT(VALUE_nil, ret.type);
+  err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(ERR_RUNTIME_INVALIDARGS, err->value.i);
+
+  teardown_libcall_runtime();
 }

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -32,6 +32,7 @@ void test_libcall_registry_init_failure_has_no_partial_state(void);
 void test_libcall_name_duplicate_detection(void);
 void test_missing_libcall_is_null_and_interpret_deterministic(void);
 void test_libcall_registry_self_check_invalid_entries(void);
+void test_libcall_invalid_arg_branches_return_contracts(void);
 void test_relative_item_leading_dot_parse_accepts_deref_chain(void);
 void test_relative_item_leading_dot_nested_relative_deref_layers(void);
 void test_relative_item_leading_dot_nested_deref_nil_or_empty_leading_allowed(void);
@@ -125,6 +126,7 @@ static const test_case_t core_tests[] = {
     {"test_libcall_name_duplicate_detection", test_libcall_name_duplicate_detection},
     {"test_missing_libcall_is_null_and_interpret_deterministic", test_missing_libcall_is_null_and_interpret_deterministic},
     {"test_libcall_registry_self_check_invalid_entries", test_libcall_registry_self_check_invalid_entries},
+    {"test_libcall_invalid_arg_branches_return_contracts", test_libcall_invalid_arg_branches_return_contracts},
     {"test_relative_item_leading_dot_parse_accepts_deref_chain", test_relative_item_leading_dot_parse_accepts_deref_chain},
     {"test_relative_item_leading_dot_nested_relative_deref_layers", test_relative_item_leading_dot_nested_relative_deref_layers},
     {"test_relative_item_leading_dot_nested_deref_nil_or_empty_leading_allowed", test_relative_item_leading_dot_nested_deref_nil_or_empty_leading_allowed},


### PR DESCRIPTION
### Motivation
- Reduce duplicated argument validation and cleanup logic across libcalls by centralizing common patterns into small helpers. 
- Make ownership rules explicit for popped `VALUE_t` values so cleanup is consistent and auditable. 

### Description
- Added file-local helpers in `src/libcall.c`: `lc_value_is_type`, `lc_invalid_args_return`, `lc_cleanup_values`, and `lc_cleanup_cstr`, and documented popped-value ownership rules. 
- Refactored the first-pass libcalls to use the helpers without changing return contracts: `lc_sys_compile`, `lc_task_newgametask`, `lc_task_killtask`, and `lc_net_write`. 
- Kept existing behavior on all code paths (e.g. `sys.compile` still returns `VALUE_FALSE` on invalid args; task/net handlers still return `VALUE_NIL` on invalid args). 
- Added runtime regression test coverage exercising invalid-argument branches in `tests/core/test_libcall_registry.c` and registered the new test in `tests/shared/test_compiler.c`.

### Testing
- Ran the full test harness with `make test`. 
- All tests including the new invalid-argument coverage passed. 
- No behavioral changes to the public return contracts for the modified libcalls were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1185a47bfc832e933bd95aa6f292d0)