### PR TITLE
lc_net_write: ignore disconnected/non-writable lines and add tests

### DIFF
--- a/src/libcall.c
+++ b/src/libcall.c
@@ -367,6 +367,13 @@ uint8_t *lc_net_write(uint8_t *nextop, ITEM_t *item) {
     FREE_STR(out);
     return lc_invalid_args_return(nextop, VALUE_NIL);
   } else {
+    if ((line[linenum.i].status != LINE_data
+        && line[linenum.i].status != LINE_idle)
+        || line[linenum.i].telnet == NULL) {
+      FREE_STR(out);
+      push_stack(VM->stack, VALUE_NIL);
+      return nextop;
+    }
     switch(out.type) {
       case VALUE_str:
         telnet_send_text(line[linenum.i].telnet, out.s, strlen(out.s));

--- a/tests/core/test_libcall_registry.c
+++ b/tests/core/test_libcall_registry.c
@@ -211,3 +211,45 @@ void test_libcall_invalid_arg_branches_return_contracts(void) {
 
   teardown_libcall_runtime();
 }
+
+void test_net_write_ignores_disconnected_lines(void) {
+  setup_libcall_runtime();
+
+  config.maxconns = 2;
+  line = calloc((size_t)config.maxconns, sizeof(LINE_t));
+  ASSERT_NOT_NULL(line);
+  line[1].status = LINE_empty;
+  line[1].telnet = NULL;
+
+  VALUE_t target_line = {VALUE_int, {.i = 1}};
+  VALUE_t out = {VALUE_str, {.s = strdup("hello")}};
+  push_stack(config.vm->stack, target_line);
+  push_stack(config.vm->stack, out);
+
+  (void)lc_net_write(NULL, config.itemroot);
+  VALUE_t ret = pop_stack(config.vm->stack);
+  ASSERT_EQ_INT(VALUE_nil, ret.type);
+
+  teardown_libcall_runtime();
+}
+
+void test_net_write_ignores_non_writable_line_states(void) {
+  setup_libcall_runtime();
+
+  config.maxconns = 1;
+  line = calloc((size_t)config.maxconns, sizeof(LINE_t));
+  ASSERT_NOT_NULL(line);
+  line[0].status = LINE_connecting;
+  line[0].telnet = NULL;
+
+  VALUE_t target_line = {VALUE_int, {.i = 0}};
+  VALUE_t out = {VALUE_str, {.s = strdup("hello")}};
+  push_stack(config.vm->stack, target_line);
+  push_stack(config.vm->stack, out);
+
+  (void)lc_net_write(NULL, config.itemroot);
+  VALUE_t ret = pop_stack(config.vm->stack);
+  ASSERT_EQ_INT(VALUE_nil, ret.type);
+
+  teardown_libcall_runtime();
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -35,6 +35,8 @@ void test_libcall_name_duplicate_detection(void);
 void test_missing_libcall_is_null_and_interpret_deterministic(void);
 void test_libcall_registry_self_check_invalid_entries(void);
 void test_libcall_invalid_arg_branches_return_contracts(void);
+void test_net_write_ignores_disconnected_lines(void);
+void test_net_write_ignores_non_writable_line_states(void);
 void test_relative_item_leading_dot_parse_accepts_deref_chain(void);
 void test_relative_item_leading_dot_nested_relative_deref_layers(void);
 void test_relative_item_leading_dot_nested_deref_nil_or_empty_leading_allowed(void);
@@ -131,6 +133,8 @@ static const test_case_t core_tests[] = {
     {"test_missing_libcall_is_null_and_interpret_deterministic", test_missing_libcall_is_null_and_interpret_deterministic},
     {"test_libcall_registry_self_check_invalid_entries", test_libcall_registry_self_check_invalid_entries},
     {"test_libcall_invalid_arg_branches_return_contracts", test_libcall_invalid_arg_branches_return_contracts},
+    {"test_net_write_ignores_disconnected_lines", test_net_write_ignores_disconnected_lines},
+    {"test_net_write_ignores_non_writable_line_states", test_net_write_ignores_non_writable_line_states},
     {"test_relative_item_leading_dot_parse_accepts_deref_chain", test_relative_item_leading_dot_parse_accepts_deref_chain},
     {"test_relative_item_leading_dot_nested_relative_deref_layers", test_relative_item_leading_dot_nested_relative_deref_layers},
     {"test_relative_item_leading_dot_nested_deref_nil_or_empty_leading_allowed", test_relative_item_leading_dot_nested_deref_nil_or_empty_leading_allowed},


### PR DESCRIPTION
### Motivation

- Prevent attempts to write to a line that is not connected or has no telnet context, avoiding crashes or invalid sends.

### Description

- Add an early validation in `lc_net_write` to return `nil` (and free the outgoing string) when the target `line` is not in a writable state (`LINE_data` or `LINE_idle`) or when its `telnet` pointer is `NULL`.
- Preserve the existing behavior for valid lines and all `out.type` branches (`VALUE_str`, `VALUE_int`, `VALUE_bool`, `VALUE_nil`).
- Add two unit tests: `test_net_write_ignores_disconnected_lines` and `test_net_write_ignores_non_writable_line_states` in `tests/core/test_libcall_registry.c` and register them in the shared test list in `tests/shared/test_compiler.c`.

### Testing

- Added `tests/core/test_libcall_registry.c::test_net_write_ignores_disconnected_lines` and `::test_net_write_ignores_non_writable_line_states` and executed the core tests. Both new tests passed. 
- Ran the project's automated test suite (via `make test`) and the run completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d3ee7960832e88ffcaa1428bd4cc)