### PR TITLE
Add lexer/parser support for true/false boolean literals

### DIFF
--- a/src/absyn.c
+++ b/src/absyn.c
@@ -16,7 +16,7 @@ AS_VALUE *as_new_value(ENUM_VALUE valtype, uint64_t ival, char *sval) {
   // Items are encoded as the name of the item.
   AS_VALUE *newval = GROW_ARRAY(AS_VALUE, NULL, 0, 1);
   newval->valtype = valtype;
-  if (valtype == V_INT) {
+  if (valtype == V_INT || valtype == V_BOOLTRUE || valtype == V_BOOLFALSE) {
     newval->value.i = ival;
   } else {
     newval->value.s = sval;  // Remember to free this eventually!
@@ -31,6 +31,10 @@ AS_NODE *as_new_valnode(ENUM_VALUE valtype, char *sval) {
   if (valtype == V_INT) {
     newval = as_new_value(V_INT, atoll(sval), NULL);
     free(sval);
+  } else if (valtype == V_BOOLTRUE) {
+    newval = as_new_value(V_BOOLTRUE, 1, NULL);
+  } else if (valtype == V_BOOLFALSE) {
+    newval = as_new_value(V_BOOLFALSE, 0, NULL);
   } else {
     newval = as_new_value(valtype, 0, sval);
   }
@@ -135,7 +139,7 @@ void as_delete(AS_NODE *root) {
   switch (root->nodetype) {
     case N_VALUE: {
       AS_VALUE *val = (AS_VALUE*)root->lhs;
-      if (val->valtype != V_INT) free(val->value.s);
+      if (val->valtype != V_INT && val->valtype != V_BOOLTRUE && val->valtype != V_BOOLFALSE) free(val->value.s);
       FREE_ARRAY(AS_VALUE, root->lhs, 1);
       // rhs is always null for this nodetype
       break;
@@ -203,7 +207,7 @@ void as_delete(AS_NODE *root) {
 }
 
 // Keep this in sync with ENUM_VALUE!
-const char *valname[] = { "V_INT", "V_STR", "V_LOCAL", "V_LAYER" };
+const char *valname[] = { "V_INT", "V_STR", "V_LOCAL", "V_LAYER", "V_BOOLTRUE", "V_BOOLFALSE" };
 // And keep this in sync with ENUM_NODE!
 const char *nodename[] = { "N_VALUE", "N_ADD", "N_SUB", "N_MUL", "N_DIV", "N_INC", "N_DEC", "N_EQUAL", "N_NOTEQ", "N_OR", "N_AND", "N_LT", "N_LTEQ", "N_GT", "N_GTEQ", "N_DEREF", "N_EXISTS", "N_DELETE", "N_NTHNAME", "N_ROOTNAME", "N_ITEM", "N_RELITEM", "N_NOT", "N_LIBCALL", "N_ARGLIST", "N_CODE", "N_CALL", "N_ASSITEM", "N_ASSLOCAL", "N_EXPRSTMT", "N_RETURN", "N_STMTLIST", "N_STMT", "N_WHILESTMT", "N_IFSTMT" };
 
@@ -217,7 +221,7 @@ void as_reconstruct_value(AS_NODE *node) {
   // Given a N_VALUE node, output the type and the contents
   AS_VALUE *val = (AS_VALUE*)node->lhs;
   logmsg("%s: ", valname[val->valtype]);
-  if (val->valtype == V_INT) {
+  if (val->valtype == V_INT || val->valtype == V_BOOLTRUE || val->valtype == V_BOOLFALSE) {
     logmsg("%lld", val->value.i);
   } else {
     logmsg("%s", val->value.s);
@@ -235,7 +239,7 @@ void as_reconstruct_item(AS_NODE *root) {
   // An item node can only have children of type N_VALUE or N_DEREF
   if (node->nodetype == N_VALUE) {
     AS_VALUE *val = (AS_VALUE*)node->lhs;
-    if (val->valtype == V_INT) {
+    if (val->valtype == V_INT || val->valtype == V_BOOLTRUE || val->valtype == V_BOOLFALSE) {
       logmsg("%lld", val->value.i);
     } else {
       logmsg("%s", val->value.s);

--- a/src/absyn.h
+++ b/src/absyn.h
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-typedef enum { V_INT, V_STR, V_LOCAL, V_LAYER } ENUM_VALUE;
+typedef enum { V_INT, V_STR, V_LOCAL, V_LAYER, V_BOOLTRUE, V_BOOLFALSE } ENUM_VALUE;
 struct AS_VALUE_s {
   ENUM_VALUE valtype;
   union {

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -89,6 +89,8 @@ integer     [0-9]+
   "sys"         { yylval->TSTRINGLIT = strdup_lc(yytext); return TLIBNAME; }
   "task"        { yylval->TSTRINGLIT = strdup_lc(yytext); return TLIBNAME; }
   "then"        { return TTHEN; }
+  "true"        { return TTRUE; }
+  "false"       { return TFALSE; }
   "while"       { return TWHILE; }
   "="           { return TASSIGN; }
   "=="          { return TEQUAL; }

--- a/src/lower.c
+++ b/src/lower.c
@@ -191,6 +191,8 @@ static void lower_value_expr(LOWER_CTX *ctx, AS_NODE *node) {
 
   switch (value->valtype) {
     case V_INT:
+    case V_BOOLTRUE:
+    case V_BOOLFALSE:
       ir_emit(ctx->ir, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = value->value.i});
       return;
     case V_STR:

--- a/src/parser.y
+++ b/src/parser.y
@@ -123,6 +123,7 @@ int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail) 
 %token <char *> TLIBNAME
 %token <char *> TCODEBODY
 %token <char *> TUNKNOWNCHAR
+%token TTRUE TFALSE
 %nonassoc TSEMI TWHILE TDO TENDWHILE TIF TTHEN TELSE TELSIF TENDIF TRETURN
 
 %type <AS_NODE*> deref_content dereference first_layer subsequent_layers layer
@@ -186,6 +187,8 @@ stmt:   TWHILE expr TDO stmtlist TENDWHILE { $$ = as_new_node(N_WHILESTMT, $2, $
 expr:     TLOCAL { $$ = as_new_valnode(V_LOCAL, $1); }
         |	TINTEGER { $$ = as_new_valnode(V_INT, $1); }
         |	TSTRINGLIT { $$ = as_new_valnode(V_STR, $1); }
+        | TTRUE { $$ = as_new_valnode(V_BOOLTRUE, NULL); }
+        | TFALSE { $$ = as_new_valnode(V_BOOLFALSE, NULL); }
         |	item args { $$ = as_new_node(N_CALL, $1, $2); }
         | expr TEQUAL expr { $$ = as_new_node(N_EQUAL, $1, $3); }
         | expr TNOTEQUAL expr { $$ = as_new_node(N_NOTEQ, $1, $3); }


### PR DESCRIPTION
### Motivation
- Enable source-level boolean literals `true` and `false` so code can express boolean constants directly. 
- Ensure keywords are recognized as booleans rather than falling through to generic layer tokens.

### Description
- Added `"true"` and `"false"` rules to `src/lexer.l` in the `<INITIAL>` section returning `TTRUE` and `TFALSE`, placed among other keywords before the `{layer}` matcher. 
- Declared `%token TTRUE TFALSE` in `src/parser.y` and added `expr` productions that create AST value nodes via `as_new_valnode(V_BOOLTRUE, NULL)` and `as_new_valnode(V_BOOLFALSE, NULL)`. 
- Extended the AST value enum in `src/absyn.h` with `V_BOOLTRUE` and `V_BOOLFALSE` and updated `src/absyn.c` to construct, free, and pretty-print these value kinds. 
- Updated `src/lower.c` to treat the new boolean value kinds as immediate integer pushes (`IR_OP_PUSH_INT`) so the existing IR/VM pipeline handles them as `1`/`0`. 

### Testing
- Ran `make src/parser.c src/parser.h src/lexer.c` to regenerate parser and lexer artifacts, and the command completed successfully. 
- Built the shared library with `make -j2 lib`, and the compilation completed successfully. 
- Verified that the project build targets using the new parser/lexer integrate cleanly by compiling dependent objects, and no build errors were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f4b981ac832e9c20f0d5cb31275b)