### PR TITLE
Add boolean pipeline coverage and truthiness non-regression tests

### DIFF
--- a/tests/compiler/test_pipeline_negative_matrix.c
+++ b/tests/compiler/test_pipeline_negative_matrix.c
@@ -92,9 +92,15 @@ void test_pipeline_negative_matrix(void) {
       {"parser_malformed_item_syntax", CASE_SOURCE, "foo..bar;", NULL, ERR_COMP_SYNTAX, STAGE_PARSER, "syntax error"},
       {"parser_unterminated_string", CASE_SOURCE, "\"unterminated;", NULL, ERR_COMP_UNKNOWNCHAR, STAGE_PARSER, "Unterminated string literal."},
       {"parser_bad_if_endif_pairing", CASE_SOURCE, "endif;", NULL, ERR_COMP_SYNTAX, STAGE_PARSER, "syntax error"},
+      {"parser_return_keyword_edge", CASE_SOURCE, "return @l == false;", NULL, ERR_COMP_SYNTAX, STAGE_PARSER, "syntax error"},
 
       {"semantic_use_before_def", CASE_SOURCE, "@x;", NULL, ERR_COMP_LOCALBEFOREDEF, STAGE_SEMANTIC, "semant: @x"},
       {"semantic_invalid_increment_target", CASE_SOURCE, "@x = 1; @y++;", NULL, ERR_COMP_LOCALBEFOREDEF, STAGE_SEMANTIC, "semant: @y"},
+
+      {"semantic_boolean_local_roundtrip", CASE_SOURCE, "@l = true; @l == false;", NULL, ERR_NOERROR, STAGE_SEMANTIC, NULL},
+      {"semantic_boolean_if_clause", CASE_SOURCE, "@l = false; if @l == false then sys.log{\"False\"}; endif;", NULL, ERR_NOERROR, STAGE_SEMANTIC, NULL},
+      {"semantic_truthiness_int_unchanged", CASE_SOURCE, "if 1 then sys.log{\"t\"}; endif;", NULL, ERR_NOERROR, STAGE_SEMANTIC, NULL},
+      {"semantic_truthiness_empty_string_unchanged", CASE_SOURCE, "if \"\" then sys.log{\"t\"}; endif;", NULL, ERR_NOERROR, STAGE_SEMANTIC, NULL},
 
       {"ir_validate_local_index_bounds", CASE_BUILDER, NULL, run_ir_case_bad_local_index, ERR_COMP_LOCALBEFOREDEF, STAGE_LOWER_IR_VALIDATE, "ir: Instruction 0 (INC_LOCAL) has out-of-range local index"},
       {"ir_validate_arity_constraint", CASE_BUILDER, NULL, run_ir_case_bad_arity, ERR_COMP_TOOMANYARGS, STAGE_LOWER_IR_VALIDATE, "ir: Instruction 0 (CALL) has negative arity"},
@@ -106,19 +112,27 @@ void test_pipeline_negative_matrix(void) {
   for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
     const NEG_CASE *tc = &cases[i];
     char *errdetail = NULL;
+    OUTPUT_t *out = NULL;
     int8_t rc = ERR_NOERROR;
 
     if (tc->source_or_builder == CASE_SOURCE) {
-      OUTPUT_t *out = NULL;
       rc = compile_source_to_bytecode(tc->source, strlen(tc->source), &out, &errdetail);
-      ASSERT_TRUE(out == NULL);
+      if (tc->expected_code == ERR_NOERROR) {
+        ASSERT_NOT_NULL(out);
+      } else {
+        ASSERT_TRUE(out == NULL);
+      }
     } else {
       rc = tc->builder(&errdetail);
     }
 
     ASSERT_EQ_INT(tc->expected_code, rc);
-    ASSERT_NOT_NULL(errdetail);
-    ASSERT_TRUE(strstr(errdetail, tc->expected_substring) != NULL);
+    if (tc->expected_code == ERR_NOERROR) {
+      ASSERT_TRUE(errdetail == NULL);
+    } else {
+      ASSERT_NOT_NULL(errdetail);
+      ASSERT_TRUE(strstr(errdetail, tc->expected_substring) != NULL);
+    }
 
     switch (tc->expected_stage) {
       case STAGE_PARSER:
@@ -135,6 +149,10 @@ void test_pipeline_negative_matrix(void) {
         break;
     }
 
-    free(errdetail);
+    if (out) {
+      free(out->bytecode);
+      free(out);
+    }
+    if (errdetail) free(errdetail);
   }
 }

--- a/tests/compiler/test_pipeline_source_golden.c
+++ b/tests/compiler/test_pipeline_source_golden.c
@@ -48,6 +48,28 @@ static void test_source_pipeline_negative_cases(void) {
   free(errdetail);
 }
 
+static void test_source_pipeline_bool_and_truthiness_nonregression(void) {
+  const char *ok_cases[] = {
+      "@l = true;",
+      "foo.bar = false;",
+      "@l = false; @l == false;",
+      "@l = false; if @l == false then sys.log{\"False\"}; endif;",
+      "if 1 then sys.log{\"int truthy\"}; endif;",
+      "if \"\" then sys.log{\"empty string truthy\"}; endif;",
+  };
+
+  for (size_t i = 0; i < sizeof(ok_cases) / sizeof(ok_cases[0]); i++) {
+    OUTPUT_t *out = NULL;
+    char *errdetail = NULL;
+    int8_t rc = compile_source_to_bytecode(ok_cases[i], strlen(ok_cases[i]), &out, &errdetail);
+    ASSERT_EQ_INT(ERR_NOERROR, rc);
+    ASSERT_TRUE(errdetail == NULL);
+    ASSERT_NOT_NULL(out);
+    free(out->bytecode);
+    free(out);
+  }
+}
+
 void test_pipeline_source_golden(void) {
   const SourceGoldenCase cases[] = {
       {"int_literal", "42;", "tests/fixtures/int_literal.hex"},
@@ -65,4 +87,5 @@ void test_pipeline_source_golden(void) {
   }
 
   test_source_pipeline_negative_cases();
+  test_source_pipeline_bool_and_truthiness_nonregression();
 }

--- a/tests/compiler/test_sys_compile_libcall.c
+++ b/tests/compiler/test_sys_compile_libcall.c
@@ -37,12 +37,22 @@ static void assert_bool(VALUE_t v, int expected) {
   ASSERT_EQ_INT(expected, v.i);
 }
 
+static void assert_compile_success_bool(const char *source) {
+  push_stack(config.vm->stack, vstr(source));
+  (void)lc_sys_compile(NULL, config.itemroot);
+  assert_bool(pop_stack(config.vm->stack), 1);
+}
+
 void test_sys_compile_libcall_runtime(void) {
   setup_runtime();
 
-  push_stack(config.vm->stack, vstr("sys.log{\"ok\\n\"};"));
-  (void)lc_sys_compile(NULL, config.itemroot);
-  assert_bool(pop_stack(config.vm->stack), 1);
+  assert_compile_success_bool("sys.log{\"ok\\n\"};");
+  assert_compile_success_bool("@l = true;");
+  assert_compile_success_bool("foo.bar = false;");
+  assert_compile_success_bool("@l = false; @l == false;");
+  assert_compile_success_bool("@l = false; if @l == false then sys.log{\"False\"}; endif;");
+  assert_compile_success_bool("if 1 then sys.log{\"int truthy\"}; endif;");
+  assert_compile_success_bool("if \"\" then sys.log{\"empty string truthy\"}; endif;");
 
   push_stack(config.vm->stack, vstr("sys.log{;"));
   (void)lc_sys_compile(NULL, config.itemroot);


### PR DESCRIPTION
### Motivation
- Add compile-time coverage for boolean literals/assignments and comparison expression round-trips to prevent regressions in boolean handling.
- Verify truthiness semantics remain unchanged for existing idioms such as `if 1 then` and `if "" then`.
- Add a parser keyword-edge case for `return` to ensure the parser continues to reject that construct where appropriate.

### Description
- Added `test_source_pipeline_bool_and_truthiness_nonregression` to `tests/compiler/test_pipeline_source_golden.c` with source snippets including `@l = true;`, `foo.bar = false;`, boolean comparisons and truthiness checks, and invoked it from the golden test harness.
- Extended `tests/compiler/test_pipeline_negative_matrix.c` with a `parser_return_keyword_edge` case and semantic-stage success rows for boolean round-trips and truthiness, and updated the negative-matrix runner to handle both expected-success and expected-failure source cases while cleaning up `OUTPUT_t` buffers and `errdetail` properly.
- Added a runtime helper `assert_compile_success_bool` and new runtime assertions to `tests/compiler/test_sys_compile_libcall.c` to exercise `sys.compile` on the same boolean/truthiness snippets and assert the stack result is `VALUE_bool` success.
- Modified harness assertions and cleanup to avoid memory leaks and to correctly handle `out` when a case is expected to succeed.

### Testing
- Ran `make test` and executed the full test harness, which completed all suites and tests successfully (test-harness reported completion of 51 tests across the core, compiler, and interpreter suites).
- The changes were validated by the automated test run with no failing tests remaining after the updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fa14d688832e98a67b83642b3469)