### PR TITLE
build: avoid duplicate parser generation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ sdiss: $(SDISS_OBJECTS) $(LIB)
 sin: $(SIN_OBJECTS) $(LIB)
 	$(CC) -o $@ $^ $(LDFLAGS) $(LIBS)
 
-$(PARSER_GENERATED): $(PARSER_SOURCES)
+$(PARSER_GENERATED) &: $(PARSER_SOURCES)
 	$(YACC) -o $(SRC_DIR)/parser.c --defines=$(SRC_DIR)/parser.h $<
 
 $(LEXER_GENERATED): $(LEXER_SOURCES) $(PARSER_GENERATED)


### PR DESCRIPTION
### Motivation
- The parser generator produced `parser.c` and `parser.h` together but the Makefile treated them as separate targets, causing `bison` to run twice and creating unnecessary build churn; this change models the multi-output generation correctly for correctness and performance.

### Description
- Change the Makefile parser rule from `$(PARSER_GENERATED): $(PARSER_SOURCES)` to a grouped target `$(PARSER_GENERATED) &: $(PARSER_SOURCES)` so `bison` is invoked once to produce both `parser.c` and `parser.h`.

### Testing
- Ran `make -j4 test` and `make clean && make -j4 test` and the test harness completed successfully with all tests passing (51 tests across core/compiler/interpreter suites).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fe6309f4832eaeade8f889dce523)