### PR TITLE
semant: mark resolved local entries when seeding parameters

### DIFF
--- a/src/semant.c
+++ b/src/semant.c
@@ -80,6 +80,17 @@ static void sem_add_local(SEM_CTX *ctx, const char *name) {
   ctx->count++;
 }
 
+static uint32_t sem_resolve_local_index(SEM_CTX *ctx, const char *name) {
+  uint8_t index = 0;
+  if (!sem_get_local_index(ctx, name, &index)) {
+    sem_add_local(ctx, name);
+    if (!sem_get_local_index(ctx, name, &index)) {
+      return ctx->count > 0 ? ctx->count - 1 : 0;
+    }
+  }
+  return index;
+}
+
 static void sem_set_error(SEM_CTX *ctx, int8_t errnum, const char *local_name) {
   if (!ctx) return;
   compdiag_set_once(&ctx->errnum, &ctx->errdetail, errnum, "semant",
@@ -123,8 +134,8 @@ static void sem_seed_code_params(SEM_CTX *ctx, AS_NODE *params) {
     if (param && param->nodetype == N_VALUE) {
       AS_VALUE *value = (AS_VALUE *)param->lhs;
       if (value && value->valtype == V_LOCAL && value->value.s) {
-        sem_add_local(ctx, value->value.s);
-        ctx->locals[ctx->count - 1].param = true;
+        uint32_t index = sem_resolve_local_index(ctx, value->value.s);
+        ctx->locals[index].param = true;
       }
     }
 
@@ -244,7 +255,7 @@ void sem_seed_params(SEM_CTX *ctx, const char **params, size_t count) {
   if (!ctx || !params) return;
   for (size_t i = 0; i < count; i++) {
     if (!params[i]) continue;
-    sem_add_local(ctx, params[i]);
-    ctx->locals[ctx->count - 1].param = true;
+    uint32_t index = sem_resolve_local_index(ctx, params[i]);
+    ctx->locals[index].param = true;
   }
 }

--- a/tests/core/test_semant.c
+++ b/tests/core/test_semant.c
@@ -66,6 +66,55 @@ void test_sem_duplicate_local_keeps_original_index(void) {
   sem_delete_ctx(ctx);
 }
 
+
+void test_sem_seed_params_duplicate_name_only_marks_target_symbol(void) {
+  SEM_CTX *ctx = sem_create_ctx();
+  ASSERT_NOT_NULL(ctx);
+
+  AS_NODE *list = as_new_stmtlist_node();
+  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("z"), t_int(1)));
+  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("a"), t_int(2)));
+
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(list, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  const char *params[] = {"a", "a"};
+  sem_seed_params(ctx, params, 2);
+
+  uint8_t idx = 255;
+  ASSERT_TRUE(sem_get_local_index(ctx, "a", &idx));
+  ASSERT_TRUE(ctx->locals[idx].param);
+  ASSERT_TRUE(sem_get_local_index(ctx, "z", &idx));
+  ASSERT_TRUE(!ctx->locals[idx].param);
+
+  as_delete(list);
+  sem_delete_ctx(ctx);
+}
+
+void test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption(void) {
+  AS_NODE *params_tail = as_new_node(N_ARGLIST, t_local("a"), NULL);
+  AS_NODE *params = as_new_node(N_ARGLIST, t_local("a"), params_tail);
+
+  AS_NODE *body = as_new_stmtlist_node();
+  body = as_stmtlist_append(body, t_node(N_ASSLOCAL, t_local("m"), t_int(1)));
+  body = as_stmtlist_append(body, t_node(N_ASSLOCAL, t_local("n"), t_int(2)));
+  body = as_stmtlist_append(body, t_node(N_EXPRSTMT, t_local("m"), NULL));
+
+  AS_NODE *code = t_node(N_CODE, params, body);
+  AS_NODE *program = t_stmtlist_with_one(t_node(N_EXPRSTMT, code, NULL));
+
+  SEM_CTX *ctx = sem_create_ctx();
+  ASSERT_NOT_NULL(ctx);
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(program, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  as_delete(program);
+  sem_delete_ctx(ctx);
+}
 void test_sem_code_params_are_treated_as_defined_locals(void) {
   SEM_CTX *ctx = sem_create_ctx();
   ASSERT_NOT_NULL(ctx);

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -21,6 +21,8 @@ void test_absyn_item_deref_chains(void);
 void test_sem_check_locals_reusable_context(void);
 void test_sem_duplicate_local_keeps_original_index(void);
 void test_sem_code_params_are_treated_as_defined_locals(void);
+void test_sem_seed_params_duplicate_name_only_marks_target_symbol(void);
+void test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption(void);
 void test_ir_validate(void);
 void test_opcode_schema_consistency(void);
 void test_parser_input_api(void);
@@ -119,6 +121,8 @@ static const test_case_t core_tests[] = {
     {"test_sem_check_locals_reusable_context", test_sem_check_locals_reusable_context},
     {"test_sem_duplicate_local_keeps_original_index", test_sem_duplicate_local_keeps_original_index},
     {"test_sem_code_params_are_treated_as_defined_locals", test_sem_code_params_are_treated_as_defined_locals},
+    {"test_sem_seed_params_duplicate_name_only_marks_target_symbol", test_sem_seed_params_duplicate_name_only_marks_target_symbol},
+    {"test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption", test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption},
     {"test_ir_validate", test_ir_validate},
     {"test_opcode_schema_consistency", test_opcode_schema_consistency},
     {"test_parser_input_api", test_parser_input_api},


### PR DESCRIPTION
### Motivation
- Parameter seeding previously assumed the newly-added local lived at `ctx->count - 1`, which can be incorrect when resolving or reusing existing locals and can mutate the wrong local's `.param` flag.
- The change ensures parameter flags are applied to the intended local symbol by resolving the actual local index by name and inserting only if missing.

### Description
- Added helper `sem_resolve_local_index(SEM_CTX *ctx, const char *name)` that returns the resolved local index, inserting the local when missing via `sem_add_local()` and using `sem_get_local_index()` for lookup.
- Updated `sem_seed_code_params()` to call `sem_resolve_local_index()` and set `.param = true` on the resolved local index rather than using `ctx->count - 1`.
- Updated `sem_seed_params()` to use `sem_resolve_local_index()` and mark the resolved local's `.param` flag instead of mutating the last slot.
- Avoided evaluation-order / reallocation hazards by resolving the index into a local variable before mutating the `ctx->locals` array.
- Added two unit tests in `tests/core/test_semant.c`: `test_sem_seed_params_duplicate_name_only_marks_target_symbol()` and `test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption()` and registered them in the shared harness so duplicate parameter seeding and the regression shape are covered.

### Testing
- Ran the test suite with `make test`, which executed the harness and completed successfully (53 tests across core, compiler and interpreter suites).
- The new tests exercise duplicate parameter seeding and a regression case with duplicate params after unrelated locals and passed as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1302489e08832e9866428658eb264b)