### PR TITLE
Improve semantic error provenance for embedded N_CODE scopes

### DIFF
--- a/src/semant.c
+++ b/src/semant.c
@@ -97,6 +97,14 @@ static void sem_set_error(SEM_CTX *ctx, int8_t errnum, const char *local_name) {
                     local_name ? local_name : "<null>");
 }
 
+static void sem_set_embedded_error(SEM_CTX *ctx, int8_t errnum,
+                                   const char *embedded_detail) {
+  if (!ctx) return;
+  compdiag_setf_once(&ctx->errnum, &ctx->errdetail, errnum, "semant",
+                     "embedded code: %s",
+                     embedded_detail ? embedded_detail : "<null>");
+}
+
 SEM_CTX *sem_create_ctx() {
   SEM_CTX *ctx = NULL;
   ctx = GROW_ARRAY(SEM_CTX, ctx, 0, 1);
@@ -199,7 +207,9 @@ static void sem_walk(SEM_CTX *ctx, AS_NODE *node) {
       sem_walk(embedded, (AS_NODE *)node->rhs);
 
       if (embedded->errnum != ERR_NOERROR) {
-        sem_set_error(ctx, embedded->errnum, embedded->errdetail);
+        // Preserve embedded scope provenance in the final semantic error:
+        // semant: embedded code: semant: <detail>
+        sem_set_embedded_error(ctx, embedded->errnum, embedded->errdetail);
       }
 
       sem_delete_ctx(embedded);
@@ -223,6 +233,14 @@ static void sem_walk(SEM_CTX *ctx, AS_NODE *node) {
 int8_t sem_check_locals(AS_NODE *root, char **errdetail, SEM_CTX *ctx) {
   // sem_check_locals is reusable per SEM_CTX. It preserves discovered locals
   // across calls, but resets and re-computes per-call error state.
+  //
+  // Error detail text is stable and phase-qualified. Parent scope errors use:
+  //   semant: <detail>
+  // Embedded N_CODE errors use:
+  //   semant: embedded code: semant: <detail>
+  //
+  // When an output buffer is requested, the detail is copied exactly once and
+  // owned by the caller.
   compdiag_reset_detail(&ctx->errdetail);
   ctx->errnum = ERR_NOERROR;
 

--- a/tests/core/test_semant.c
+++ b/tests/core/test_semant.c
@@ -133,3 +133,42 @@ void test_sem_code_params_are_treated_as_defined_locals(void) {
   as_delete(program);
   sem_delete_ctx(ctx);
 }
+
+void test_sem_parent_scope_error_detail_format(void) {
+  SEM_CTX *ctx = sem_create_ctx();
+  ASSERT_NOT_NULL(ctx);
+
+  AS_NODE *bad_stmt = t_node(N_EXPRSTMT, t_local("missing_parent"), NULL);
+  AS_NODE *program = t_stmtlist_with_one(bad_stmt);
+
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(program, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strcmp(errdetail, "semant: missing_parent") == 0);
+
+  free(errdetail);
+  as_delete(program);
+  sem_delete_ctx(ctx);
+}
+
+void test_sem_embedded_scope_error_detail_includes_provenance(void) {
+  SEM_CTX *ctx = sem_create_ctx();
+  ASSERT_NOT_NULL(ctx);
+
+  AS_NODE *embedded_body =
+      t_stmtlist_with_one(t_node(N_EXPRSTMT, t_local("missing_embedded"), NULL));
+  AS_NODE *embedded = t_node(N_CODE, NULL, embedded_body);
+  AS_NODE *program = t_stmtlist_with_one(t_node(N_EXPRSTMT, embedded, NULL));
+
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(program, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(
+      strcmp(errdetail, "semant: embedded code: semant: missing_embedded") == 0);
+
+  free(errdetail);
+  as_delete(program);
+  sem_delete_ctx(ctx);
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -23,6 +23,8 @@ void test_sem_duplicate_local_keeps_original_index(void);
 void test_sem_code_params_are_treated_as_defined_locals(void);
 void test_sem_seed_params_duplicate_name_only_marks_target_symbol(void);
 void test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption(void);
+void test_sem_parent_scope_error_detail_format(void);
+void test_sem_embedded_scope_error_detail_includes_provenance(void);
 void test_ir_validate(void);
 void test_opcode_schema_consistency(void);
 void test_parser_input_api(void);
@@ -123,6 +125,8 @@ static const test_case_t core_tests[] = {
     {"test_sem_code_params_are_treated_as_defined_locals", test_sem_code_params_are_treated_as_defined_locals},
     {"test_sem_seed_params_duplicate_name_only_marks_target_symbol", test_sem_seed_params_duplicate_name_only_marks_target_symbol},
     {"test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption", test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption},
+    {"test_sem_parent_scope_error_detail_format", test_sem_parent_scope_error_detail_format},
+    {"test_sem_embedded_scope_error_detail_includes_provenance", test_sem_embedded_scope_error_detail_includes_provenance},
     {"test_ir_validate", test_ir_validate},
     {"test_opcode_schema_consistency", test_opcode_schema_consistency},
     {"test_parser_input_api", test_parser_input_api},


### PR DESCRIPTION
### Motivation
- Ensure semantic errors originating in embedded `N_CODE` scopes keep explicit provenance so callers can distinguish parent-scope vs embedded-scope failures. 
- Make ownership and copying of returned error detail unambiguous when `sem_check_locals` hands a detail string to callers.

### Description
- Add a new helper `sem_set_embedded_error` that uses `compdiag_setf_once` to wrap embedded failures with the prefix `embedded code: %s` and record the `semant` phase. 
- Change `N_CODE` handling in `sem_walk` to call `sem_set_embedded_error` when an embedded context reports an error so the final detail contains provenance. 
- Document the expected detail text format and caller ownership semantics near `sem_check_locals` (examples: `semant: <detail>` and `semant: embedded code: semant: <detail>`). 
- Add two tests (`test_sem_parent_scope_error_detail_format` and `test_sem_embedded_scope_error_detail_includes_provenance`) and register them in the shared test harness to validate stable and distinguishable detail strings. 

### Testing
- Ran `make test`; the project built and the full test harness completed successfully (all suites ran and tests passed). 
- The new semantic tests executed as part of the core suite and passed, verifying both parent-scope and embedded-scope error detail formats.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13040324d4832e818bda61bf679809)