### PR TITLE
Make local-index table append-only and lazily sorted for deterministic lookup

### DIFF
--- a/src/semant.c
+++ b/src/semant.c
@@ -18,6 +18,19 @@ static bool sem_has_local(SEM_CTX *ctx, const char *name) {
   return sem_get_local_index(ctx, name, NULL);
 }
 
+static int sem_local_index_cmp(const void *a, const void *b) {
+  const SEM_LOCAL_INDEX *lhs = (const SEM_LOCAL_INDEX *)a;
+  const SEM_LOCAL_INDEX *rhs = (const SEM_LOCAL_INDEX *)b;
+  return strcmp(lhs->name, rhs->name);
+}
+
+static void sem_sort_local_index_if_needed(SEM_CTX *ctx) {
+  if (!ctx || ctx->local_index_sorted || ctx->count < 2) return;
+  qsort(ctx->local_index, ctx->count, sizeof(SEM_LOCAL_INDEX),
+        sem_local_index_cmp);
+  ctx->local_index_sorted = true;
+}
+
 static bool sem_find_local_index_slot(SEM_CTX *ctx, const char *name,
                                       uint32_t *pos_out, bool *found_out) {
   uint32_t lo = 0;
@@ -44,11 +57,7 @@ static bool sem_find_local_index_slot(SEM_CTX *ctx, const char *name,
 }
 
 static void sem_add_local(SEM_CTX *ctx, const char *name) {
-  uint32_t slot = 0;
-  bool found = false;
-
-  sem_find_local_index_slot(ctx, name, &slot, &found);
-  if (found) {
+  if (sem_get_local_index(ctx, name, NULL)) {
     return;
   }
 
@@ -70,14 +79,11 @@ static void sem_add_local(SEM_CTX *ctx, const char *name) {
   local->index = ctx->count;
   local->param = false;
 
-  if (slot < ctx->count) {
-    memmove(&ctx->local_index[slot + 1], &ctx->local_index[slot],
-            (ctx->count - slot) * sizeof(SEM_LOCAL_INDEX));
-  }
-  ctx->local_index[slot].name = local->name;
-  ctx->local_index[slot].index = local->index;
+  ctx->local_index[ctx->count].name = local->name;
+  ctx->local_index[ctx->count].index = local->index;
 
   ctx->count++;
+  ctx->local_index_sorted = false;
 }
 
 static uint32_t sem_resolve_local_index(SEM_CTX *ctx, const char *name) {
@@ -113,6 +119,7 @@ SEM_CTX *sem_create_ctx() {
   (*ctx).count = 0;
   (*ctx).capacity = 0;
   (*ctx).index_capacity = 0;
+  (*ctx).local_index_sorted = true;
   (*ctx).errnum = ERR_NOERROR;
   (*ctx).errdetail = NULL;
 
@@ -263,6 +270,7 @@ bool sem_get_local_index(SEM_CTX *ctx, const char *name, uint8_t *index_out) {
   uint32_t slot = 0;
   bool found = false;
 
+  sem_sort_local_index_if_needed(ctx);
   sem_find_local_index_slot(ctx, name, &slot, &found);
   if (!found) return false;
   if (index_out) *index_out = ctx->local_index[slot].index;

--- a/src/semant.h
+++ b/src/semant.h
@@ -22,11 +22,16 @@ typedef struct {
 } SEM_LOCAL_INDEX;
 
 typedef struct {
+  // Locals in first-seen append order; semantic local indices are stable and
+  // match positions in this array.
   SEM_LOCAL *locals;
+  // Name->index table built in append order and batch-sorted on demand before
+  // lookups, trading O(n) insertion shifts for amortized O(1) appends.
   SEM_LOCAL_INDEX *local_index;
   uint32_t count;
   uint32_t capacity;
   uint32_t index_capacity;
+  bool local_index_sorted;
   int8_t errnum;
   char *errdetail;
 } SEM_CTX;

--- a/tests/core/test_semant.c
+++ b/tests/core/test_semant.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include "error.h"
 #include "semant.h"
@@ -170,5 +171,41 @@ void test_sem_embedded_scope_error_detail_includes_provenance(void) {
 
   free(errdetail);
   as_delete(program);
+  sem_delete_ctx(ctx);
+}
+
+
+void test_sem_many_locals_deterministic_indices(void) {
+  SEM_CTX *ctx = sem_create_ctx();
+  ASSERT_NOT_NULL(ctx);
+
+  AS_NODE *list = as_new_stmtlist_node();
+  for (int i = 0; i < 220; i++) {
+    char name[32];
+    snprintf(name, sizeof(name), "local_%03d", i);
+    list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local(name), t_int(i)));
+  }
+
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(list, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_EQ_INT(220, (int)ctx->count);
+
+  uint8_t idx = 255;
+  ASSERT_TRUE(sem_get_local_index(ctx, "local_000", &idx));
+  ASSERT_EQ_INT(0, (int)idx);
+  ASSERT_TRUE(sem_get_local_index(ctx, "local_099", &idx));
+  ASSERT_EQ_INT(99, (int)idx);
+  ASSERT_TRUE(sem_get_local_index(ctx, "local_219", &idx));
+  ASSERT_EQ_INT(219, (int)idx);
+
+  rc = sem_check_locals(list, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_TRUE(sem_get_local_index(ctx, "local_099", &idx));
+  ASSERT_EQ_INT(99, (int)idx);
+
+  as_delete(list);
   sem_delete_ctx(ctx);
 }

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -25,6 +25,7 @@ void test_sem_seed_params_duplicate_name_only_marks_target_symbol(void);
 void test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption(void);
 void test_sem_parent_scope_error_detail_format(void);
 void test_sem_embedded_scope_error_detail_includes_provenance(void);
+void test_sem_many_locals_deterministic_indices(void);
 void test_ir_validate(void);
 void test_opcode_schema_consistency(void);
 void test_parser_input_api(void);
@@ -127,6 +128,7 @@ static const test_case_t core_tests[] = {
     {"test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption", test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption},
     {"test_sem_parent_scope_error_detail_format", test_sem_parent_scope_error_detail_format},
     {"test_sem_embedded_scope_error_detail_includes_provenance", test_sem_embedded_scope_error_detail_includes_provenance},
+    {"test_sem_many_locals_deterministic_indices", test_sem_many_locals_deterministic_indices},
     {"test_ir_validate", test_ir_validate},
     {"test_opcode_schema_consistency", test_opcode_schema_consistency},
     {"test_parser_input_api", test_parser_input_api},


### PR DESCRIPTION
### Motivation

- Avoid O(n) memmoves on every local insertion and keep semantic local indices stable while preserving deterministic name->index lookups. 
- Ensure lookups remain efficient and deterministic even when many locals are added (batch-sort on-demand instead of shifting on insert).

### Description

- Introduces a `local_index_sorted` flag to `SEM_CTX` and documents the append-order semantics in `semant.h`. 
- Adds `sem_local_index_cmp` and `sem_sort_local_index_if_needed` and calls the sorter from `sem_get_local_index` to lazily sort the `local_index` table before binary search. 
- Changes `sem_add_local` to append to `local_index` instead of inserting with `memmove` and marks the index as unsorted after append. 
- Initializes `local_index_sorted` in `sem_create_ctx` and updates tests by adding `test_sem_many_locals_deterministic_indices` and registering it in the test list.

### Testing

- Ran the unit test suite including the new `test_sem_many_locals_deterministic_indices`, and the test passed. 
- Existing semantic tests such as `test_sem_check_locals_reusable_context` and `test_sem_embedded_scope_error_detail_includes_provenance` were exercised and passed. 
- All core tests in the repository test harness were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1304ea54f4832e91b60550ff0de567)