### PR TITLE
tests: rename interpreter suite label to runtime

### DIFF
--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -195,9 +195,9 @@ int main(void) {
   run_suite("core", core_tests, sizeof(core_tests) / sizeof(core_tests[0]), &total_ran);
   run_suite("compiler", compiler_tests,
             sizeof(compiler_tests) / sizeof(compiler_tests[0]), &total_ran);
-  run_suite("interpreter", interpreter_tests,
+  run_suite("runtime", interpreter_tests,
             sizeof(interpreter_tests) / sizeof(interpreter_tests[0]), &total_ran);
 
-  printf("\n[test-harness] completed: %zu tests across 3 suites\n", total_ran);
+  printf("\n[test-harness] completed: %zu tests across 3 suites (core, compiler, runtime)\n", total_ran);
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Ensure the test-harness suite label and final summary consistently refer to the runtime suite instead of "interpreter" and explicitly name all three sections.

### Description
- In `tests/shared/test_compiler.c` replaced the `run_suite("interpreter", ...)` call with `run_suite("runtime", ...)` and updated the final `printf` to include "(core, compiler, runtime)".

### Testing
- No automated tests were executed because this is a string-only change to test labels and output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1308ad6e50832e9eb2caad509333cc)