### PR TITLE
Refactor pipeline golden fixtures into a shared case module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ TEST_BIN := $(TEST_DIR)/test-compiler
 TEST_SHARED_SOURCES := \
 	$(TEST_DIR)/shared/test_compiler.c \
 	$(TEST_DIR)/shared/test_helpers.c \
-	$(TEST_DIR)/shared/test_fixture_policy.c
+	$(TEST_DIR)/shared/test_fixture_policy.c \
+	$(TEST_DIR)/shared/test_pipeline_cases.c
 TEST_CORE_SOURCES := \
 	$(TEST_DIR)/core/test_absyn_lifecycle.c \
 	$(TEST_DIR)/core/test_semant.c \

--- a/tests/compiler/test_pipeline_golden.c
+++ b/tests/compiler/test_pipeline_golden.c
@@ -8,20 +8,11 @@
 #include "semant.h"
 #include "test_assert.h"
 #include "test_helpers.h"
+#include "shared/test_pipeline_cases.h"
 
-typedef AS_NODE *(*AstBuilder)(void);
-
-typedef struct {
-  const char *name;
-  AstBuilder build;
-  const char *fixture_path;
-} GoldenCase;
-
-static AS_NODE *v_int(int64_t n) { return t_int(n); }
-static AS_NODE *v_str(const char *s) { return as_new_valnode(V_STR, strdup(s)); }
-
-static void run_case(const GoldenCase *tc) {
-  AS_NODE *root = tc->build();
+static void run_ast_case(const PipelineGoldenCase *tc) {
+  ASSERT_NOT_NULL(tc->build_ast);
+  AS_NODE *root = tc->build_ast();
   ASSERT_NOT_NULL(root);
 
   SEM_CTX *sem = sem_create_ctx();
@@ -59,71 +50,27 @@ static void run_case(const GoldenCase *tc) {
   as_delete(root);
 }
 
-static AS_NODE *build_int_literal_program(void) {
-  AS_NODE *stmt = t_node(N_EXPRSTMT, v_int(42), NULL);
-  return t_stmtlist_with_one(stmt);
-}
-
-static AS_NODE *build_string_literal_program(void) {
-  AS_NODE *stmt = t_node(N_EXPRSTMT, v_str("hi"), NULL);
-  return t_stmtlist_with_one(stmt);
-}
-
-static AS_NODE *build_locals_store_load_program(void) {
-  AS_NODE *list = as_new_stmtlist_node();
-  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("x"), v_int(7)));
-  list = as_stmtlist_append(list, t_node(N_EXPRSTMT, t_local("x"), NULL));
-  return list;
-}
-
-static AS_NODE *build_arithmetic_program(void) {
-  AS_NODE *add = t_node(N_ADD, v_int(2), v_int(3));
-  AS_NODE *stmt = t_node(N_EXPRSTMT, add, NULL);
-  return t_stmtlist_with_one(stmt);
-}
-
-static AS_NODE *build_boolean_compare_program(void) {
-  AS_NODE *cmp = t_node(N_LT, v_int(1), v_int(2));
-  AS_NODE *stmt = t_node(N_EXPRSTMT, cmp, NULL);
-  return t_stmtlist_with_one(stmt);
-}
-
-static AS_NODE *build_simple_if_program(void) {
-  AS_NODE *then_list = as_new_stmtlist_node();
-  then_list = as_stmtlist_append(then_list, t_node(N_EXPRSTMT, v_int(9), NULL));
-  AS_IF *branch = as_new_if(t_node(N_LT, v_int(1), v_int(2)), then_list, NULL);
-  AS_NODE *ifstmt = t_node(N_IFSTMT, branch, NULL);
-  AS_NODE *list = as_new_stmtlist_node();
-  return as_stmtlist_append(list, ifstmt);
-}
-
 static AS_NODE *build_many_locals_with_duplicate_program(void) {
   AS_NODE *list = as_new_stmtlist_node();
   char name[32];
 
   for (int i = 0; i < 120; i++) {
     snprintf(name, sizeof(name), "local_%03d", i);
-    list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local(name), v_int(i)));
+    list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local(name), t_int(i)));
   }
 
-  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("local_057"), v_int(999)));
+  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("local_057"), t_int(999)));
   list = as_stmtlist_append(list, t_node(N_EXPRSTMT, t_local("local_057"), NULL));
   list = as_stmtlist_append(list, t_node(N_EXPRSTMT, t_local("local_119"), NULL));
   return list;
 }
 
 void test_pipeline_golden(void) {
-  const GoldenCase cases[] = {
-      {"int_literal", build_int_literal_program, "tests/fixtures/int_literal.hex"},
-      {"string_literal", build_string_literal_program, "tests/fixtures/string_literal.hex"},
-      {"locals_store_load", build_locals_store_load_program, "tests/fixtures/locals_store_load.hex"},
-      {"arithmetic_add", build_arithmetic_program, "tests/fixtures/arithmetic_add.hex"},
-      {"boolean_compare", build_boolean_compare_program, "tests/fixtures/boolean_compare.hex"},
-      {"simple_if", build_simple_if_program, "tests/fixtures/simple_if.hex"},
-  };
+  size_t case_count = 0;
+  const PipelineGoldenCase *cases = pipeline_cases_for_layers(PIPELINE_LAYER_AST, &case_count);
 
-  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
-    run_case(&cases[i]);
+  for (size_t i = 0; i < case_count; i++) {
+    run_ast_case(&cases[i]);
   }
 }
 

--- a/tests/compiler/test_pipeline_source_golden.c
+++ b/tests/compiler/test_pipeline_source_golden.c
@@ -7,15 +7,10 @@
 #include "parser.h"
 #include "test_assert.h"
 #include "test_helpers.h"
+#include "shared/test_pipeline_cases.h"
 
-typedef struct {
-  const char *name;
-  const char *source;
-  const char *fixture_path;
-} SourceGoldenCase;
-
-static void run_source_case(const SourceGoldenCase *tc) {
-  (void)tc->name;
+static void run_source_case(const PipelineGoldenCase *tc) {
+  ASSERT_NOT_NULL(tc->source);
   compile_source_and_assert_hex(tc->source, tc->fixture_path);
 }
 
@@ -71,18 +66,10 @@ static void test_source_pipeline_bool_and_truthiness_nonregression(void) {
 }
 
 void test_pipeline_source_golden(void) {
-  const SourceGoldenCase cases[] = {
-      {"int_literal", "42;", "tests/fixtures/int_literal.hex"},
-      {"locals_store_load", "@x = 7; @x;", "tests/fixtures/locals_store_load.hex"},
-      {"arithmetic_add", "2 + 3;", "tests/fixtures/arithmetic_add.hex"},
-      {"if_elsif_else", "if 1 < 2 then 9; elsif 0 < 1 then 8; else 7; endif;", "tests/fixtures/if_elsif_else.hex"},
-      {"locals_inc", "@x = 1; @x++; @x;", "tests/fixtures/locals_inc.hex"},
-      {"locals_dec", "@x = 2; @x--; @x;", "tests/fixtures/locals_dec.hex"},
-      {"libcall_exprstmt", "sys.log{\"hello\"};", "tests/fixtures/libcall_exprstmt.hex"},
-      {"item_numeric_layer", "foo.12;", "tests/fixtures/item_numeric_layer.hex"},
-  };
+  size_t case_count = 0;
+  const PipelineGoldenCase *cases = pipeline_cases_for_layers(PIPELINE_LAYER_SOURCE, &case_count);
 
-  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+  for (size_t i = 0; i < case_count; i++) {
     run_source_case(&cases[i]);
   }
 

--- a/tests/shared/test_fixture_policy.c
+++ b/tests/shared/test_fixture_policy.c
@@ -31,16 +31,16 @@ void test_fixture_policy_declared_goldens_exist(void) {
 
   static const FixtureEntry bytecode_hex_fixtures[] = {
       {"int_literal_hex", "tests/fixtures/int_literal.hex", "SOT: pipeline output for tests/fixtures/int_literal.src | regen: make regen-fixtures"},
-      {"string_literal_hex", "tests/fixtures/string_literal.hex", "SOT: AST builder in tests/test_pipeline_golden.c | regen: make regen-fixtures"},
+      {"string_literal_hex", "tests/fixtures/string_literal.hex", "SOT: AST builder in tests/shared/test_pipeline_cases.c | regen: make regen-fixtures"},
       {"locals_store_load_hex", "tests/fixtures/locals_store_load.hex", "SOT: pipeline/source golden tables | regen: make regen-fixtures"},
       {"arithmetic_add_hex", "tests/fixtures/arithmetic_add.hex", "SOT: pipeline/source golden tables | regen: make regen-fixtures"},
-      {"boolean_compare_hex", "tests/fixtures/boolean_compare.hex", "SOT: AST builder in tests/test_pipeline_golden.c | regen: make regen-fixtures"},
-      {"simple_if_hex", "tests/fixtures/simple_if.hex", "SOT: AST builder in tests/test_pipeline_golden.c | regen: make regen-fixtures"},
-      {"if_elsif_else_hex", "tests/fixtures/if_elsif_else.hex", "SOT: inline source in tests/test_pipeline_source_golden.c | regen: make regen-fixtures"},
-      {"locals_inc_hex", "tests/fixtures/locals_inc.hex", "SOT: inline source in tests/test_pipeline_source_golden.c | regen: make regen-fixtures"},
-      {"locals_dec_hex", "tests/fixtures/locals_dec.hex", "SOT: inline source in tests/test_pipeline_source_golden.c | regen: make regen-fixtures"},
-      {"libcall_exprstmt_hex", "tests/fixtures/libcall_exprstmt.hex", "SOT: inline source in tests/test_pipeline_source_golden.c | regen: make regen-fixtures"},
-      {"item_numeric_layer_hex", "tests/fixtures/item_numeric_layer.hex", "SOT: inline source in tests/test_pipeline_source_golden.c | regen: make regen-fixtures"},
+      {"boolean_compare_hex", "tests/fixtures/boolean_compare.hex", "SOT: AST builder in tests/shared/test_pipeline_cases.c | regen: make regen-fixtures"},
+      {"simple_if_hex", "tests/fixtures/simple_if.hex", "SOT: AST builder in tests/shared/test_pipeline_cases.c | regen: make regen-fixtures"},
+      {"if_elsif_else_hex", "tests/fixtures/if_elsif_else.hex", "SOT: source case in tests/shared/test_pipeline_cases.c | regen: make regen-fixtures"},
+      {"locals_inc_hex", "tests/fixtures/locals_inc.hex", "SOT: source case in tests/shared/test_pipeline_cases.c | regen: make regen-fixtures"},
+      {"locals_dec_hex", "tests/fixtures/locals_dec.hex", "SOT: source case in tests/shared/test_pipeline_cases.c | regen: make regen-fixtures"},
+      {"libcall_exprstmt_hex", "tests/fixtures/libcall_exprstmt.hex", "SOT: source case in tests/shared/test_pipeline_cases.c | regen: make regen-fixtures"},
+      {"item_numeric_layer_hex", "tests/fixtures/item_numeric_layer.hex", "SOT: source case in tests/shared/test_pipeline_cases.c | regen: make regen-fixtures"},
       {"sdiss_basic_hex", "tests/fixtures/sdiss/basic.hex", "SOT: hand-authored disassembly sample | regen: manual update plus expected sync"},
   };
 

--- a/tests/shared/test_pipeline_cases.c
+++ b/tests/shared/test_pipeline_cases.c
@@ -1,0 +1,93 @@
+#include "test_pipeline_cases.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "test_helpers.h"
+
+static AS_NODE *v_int(int64_t n) { return t_int(n); }
+static AS_NODE *v_str(const char *s) { return as_new_valnode(V_STR, strdup(s)); }
+
+static AS_NODE *build_int_literal_program(void) {
+  AS_NODE *stmt = t_node(N_EXPRSTMT, v_int(42), NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_string_literal_program(void) {
+  AS_NODE *stmt = t_node(N_EXPRSTMT, v_str("hi"), NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_locals_store_load_program(void) {
+  AS_NODE *list = as_new_stmtlist_node();
+  list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local("x"), v_int(7)));
+  list = as_stmtlist_append(list, t_node(N_EXPRSTMT, t_local("x"), NULL));
+  return list;
+}
+
+static AS_NODE *build_arithmetic_program(void) {
+  AS_NODE *add = t_node(N_ADD, v_int(2), v_int(3));
+  AS_NODE *stmt = t_node(N_EXPRSTMT, add, NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_boolean_compare_program(void) {
+  AS_NODE *cmp = t_node(N_LT, v_int(1), v_int(2));
+  AS_NODE *stmt = t_node(N_EXPRSTMT, cmp, NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_simple_if_program(void) {
+  AS_NODE *then_list = as_new_stmtlist_node();
+  then_list = as_stmtlist_append(then_list, t_node(N_EXPRSTMT, v_int(9), NULL));
+  AS_IF *branch = as_new_if(t_node(N_LT, v_int(1), v_int(2)), then_list, NULL);
+  AS_NODE *ifstmt = t_node(N_IFSTMT, branch, NULL);
+  AS_NODE *list = as_new_stmtlist_node();
+  return as_stmtlist_append(list, ifstmt);
+}
+
+static const PipelineGoldenCase PIPELINE_CASES[] = {
+    {"int_literal", build_int_literal_program, "42;", "tests/fixtures/int_literal.hex",
+     PIPELINE_LAYER_AST | PIPELINE_LAYER_SOURCE},
+    {"string_literal", build_string_literal_program, NULL, "tests/fixtures/string_literal.hex",
+     PIPELINE_LAYER_AST},
+    {"locals_store_load", build_locals_store_load_program, "@x = 7; @x;", "tests/fixtures/locals_store_load.hex",
+     PIPELINE_LAYER_AST | PIPELINE_LAYER_SOURCE},
+    {"arithmetic_add", build_arithmetic_program, "2 + 3;", "tests/fixtures/arithmetic_add.hex",
+     PIPELINE_LAYER_AST | PIPELINE_LAYER_SOURCE},
+    {"boolean_compare", build_boolean_compare_program, NULL, "tests/fixtures/boolean_compare.hex",
+     PIPELINE_LAYER_AST},
+    {"simple_if", build_simple_if_program, NULL, "tests/fixtures/simple_if.hex", PIPELINE_LAYER_AST},
+    {"if_elsif_else", NULL, "if 1 < 2 then 9; elsif 0 < 1 then 8; else 7; endif;", "tests/fixtures/if_elsif_else.hex",
+     PIPELINE_LAYER_SOURCE},
+    {"locals_inc", NULL, "@x = 1; @x++; @x;", "tests/fixtures/locals_inc.hex", PIPELINE_LAYER_SOURCE},
+    {"locals_dec", NULL, "@x = 2; @x--; @x;", "tests/fixtures/locals_dec.hex", PIPELINE_LAYER_SOURCE},
+    {"libcall_exprstmt", NULL, "sys.log{\"hello\"};", "tests/fixtures/libcall_exprstmt.hex", PIPELINE_LAYER_SOURCE},
+    {"item_numeric_layer", NULL, "foo.12;", "tests/fixtures/item_numeric_layer.hex", PIPELINE_LAYER_SOURCE},
+};
+
+const PipelineGoldenCase *pipeline_golden_cases(size_t *count) {
+  if (count != NULL) {
+    *count = sizeof(PIPELINE_CASES) / sizeof(PIPELINE_CASES[0]);
+  }
+  return PIPELINE_CASES;
+}
+
+const PipelineGoldenCase *pipeline_cases_for_layers(unsigned layers, size_t *count) {
+  static PipelineGoldenCase filtered[sizeof(PIPELINE_CASES) / sizeof(PIPELINE_CASES[0])];
+  size_t total = 0;
+  size_t all_count = 0;
+  const PipelineGoldenCase *all = pipeline_golden_cases(&all_count);
+
+  for (size_t i = 0; i < all_count; i++) {
+    if ((all[i].layers & layers) == layers) {
+      filtered[total++] = all[i];
+    }
+  }
+
+  if (count != NULL) {
+    *count = total;
+  }
+  return filtered;
+}

--- a/tests/shared/test_pipeline_cases.h
+++ b/tests/shared/test_pipeline_cases.h
@@ -1,0 +1,26 @@
+#ifndef TEST_PIPELINE_CASES_H
+#define TEST_PIPELINE_CASES_H
+
+#include <stddef.h>
+
+#include "absyn.h"
+
+typedef AS_NODE *(*PipelineAstBuilder)(void);
+
+typedef enum {
+  PIPELINE_LAYER_AST = 1u << 0,
+  PIPELINE_LAYER_SOURCE = 1u << 1,
+} PipelineLayerMask;
+
+typedef struct {
+  const char *name;
+  PipelineAstBuilder build_ast;
+  const char *source;
+  const char *fixture_path;
+  unsigned layers;
+} PipelineGoldenCase;
+
+const PipelineGoldenCase *pipeline_golden_cases(size_t *count);
+const PipelineGoldenCase *pipeline_cases_for_layers(unsigned layers, size_t *count);
+
+#endif


### PR DESCRIPTION
### Motivation
- Reduce duplicated fixture tables across AST-driven and source-driven pipeline tests by centralizing canonical cases in one shared module. 
- Make test intent explicit by annotating which pipeline layer(s) each case validates (AST, source, or both). 

### Description
- Added `tests/shared/test_pipeline_cases.h` and `tests/shared/test_pipeline_cases.c` containing the canonical `PipelineGoldenCase` table, builders, source snippets, and layer flags (`PIPELINE_LAYER_AST` / `PIPELINE_LAYER_SOURCE`).
- Exposed helper accessors `pipeline_golden_cases` and `pipeline_cases_for_layers(unsigned layers, size_t *count)` to filter cases by layer.
- Refactored `tests/compiler/test_pipeline_golden.c` to include `shared/test_pipeline_cases.h` and run AST-tagged cases via `run_ast_case` which consumes `PipelineGoldenCase` entries.
- Refactored `tests/compiler/test_pipeline_source_golden.c` to include `shared/test_pipeline_cases.h` and run source-tagged cases via `run_source_case` which consumes `PipelineGoldenCase` entries.
- Updated `tests/shared/test_fixture_policy.c` provenance strings to reference the new shared module as the source-of-truth for fixtures and wired `tests/shared/test_pipeline_cases.c` into the test build via `Makefile`.

### Testing
- Ran `make test -j4` and executed the full test harness; the test run completed successfully with all tests passing (56 tests across `core`, `compiler`, and `runtime`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130bbfe37c832e9ec406cc3305a69e)