### PR TITLE
Improve test harness suite/test status logging

### DIFF
--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -181,12 +181,18 @@ static const test_case_t runtime_tests[] = {
 
 static void run_suite(const char *suite_name, const test_case_t *cases, size_t count,
                       size_t *ran_count) {
-  printf("\n[test-harness] === %s (%zu tests) ===\n", suite_name, count);
+  size_t suite_ran = 0;
+  printf("\n[test-harness][%s][START] total=%zu\n", suite_name, count);
   for (size_t i = 0; i < count; ++i) {
-    printf("[test-harness][%s][%zu/%zu] %s\n", suite_name, i + 1, count, cases[i].name);
+    printf("[test-harness][%s][START] index=%zu/%zu test=%s\n", suite_name, i + 1, count,
+           cases[i].name);
     cases[i].fn();
+    printf("[test-harness][%s][PASS] index=%zu/%zu test=%s\n", suite_name, i + 1, count,
+           cases[i].name);
     (*ran_count)++;
+    suite_ran++;
   }
+  printf("[test-harness][%s][COMPLETE] executed=%zu status=PASS\n", suite_name, suite_ran);
 }
 
 int main(void) {


### PR DESCRIPTION
### Motivation
- Make test output compact and machine-greppable by emitting explicit, consistent status lines for suites and tests using a single prefix.
- Provide per-test and per-suite visibility so external tooling can track start/completion and counts without parsing human-facing banners.
- Preserve existing assert semantics while exposing as much context as possible for failures.

### Description
- Update `run_suite()` in `tests/shared/test_compiler.c` to emit suite-level `START` and `COMPLETE` lines with total and executed counts using the `[test-harness][%s][STATUS]` prefix.
- Emit per-test `START` and `PASS` lines with stable `index=%zu/%zu` and `test=%s` fields so consumers can correlate events.
- Add a `suite_ran` counter to track executed tests for the suite completion summary, and keep the final summary `status=PASS` for suites that fully run.
- Maintain existing behavior where assertions abort on failure, so `FAIL` lines are not emitted from `run_suite()` itself.

### Testing
- No automated unit test suite was executed as part of this change; only the source modification and commit were performed.
- The modified file was inspected after the patch and compiled-level changes were committed successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130d27af9c832e8ce1ba6c0f460515)