### PR TITLE
tests: add exhaustive IR opcode coverage manifest test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ TEST_CORE_SOURCES := \
 TEST_COMPILER_SOURCES := \
 	$(TEST_DIR)/compiler/test_emitbc_header.c \
 	$(TEST_DIR)/compiler/test_emitbc_opcode_map.c \
+	$(TEST_DIR)/compiler/test_emitbc_all_ir_ops_accounted_for.c \
 	$(TEST_DIR)/compiler/test_emitbc_jumps.c \
 	$(TEST_DIR)/compiler/test_emitbc_invariants.c \
 	$(TEST_DIR)/compiler/test_pipeline_golden.c \

--- a/tests/compiler/test_emitbc_all_ir_ops_accounted_for.c
+++ b/tests/compiler/test_emitbc_all_ir_ops_accounted_for.c
@@ -1,0 +1,74 @@
+#include <stddef.h>
+
+#include "compiler/ir/opcode_schema.h"
+#include "test_assert.h"
+
+typedef struct {
+  IR_Op op;
+  uint8_t expected_symbol;
+} ExpectedCoverage;
+
+void test_emitbc_all_ir_ops_accounted_for(void) {
+  /*
+   * Keep this manifest in sync with src/compiler/ir/opcode_schema.def.
+   * If a new IR opcode is added without updating this list, this test must fail.
+   */
+  static const ExpectedCoverage expected[] = {
+      {IR_OP_HALT, 'h'},
+      {IR_OP_PUSH_INT, 'p'},
+      {IR_OP_PUSH_BOOL, 'b'},
+      {IR_OP_PUSH_STRING, 'l'},
+      {IR_OP_ADD, 'a'},
+      {IR_OP_SUB, 's'},
+      {IR_OP_MUL, 'm'},
+      {IR_OP_DIV, 'd'},
+      {IR_OP_NEG, 'n'},
+      {IR_OP_EQ, 'o'},
+      {IR_OP_NEQ, 'q'},
+      {IR_OP_LT, 'r'},
+      {IR_OP_GT, 't'},
+      {IR_OP_LE, 'u'},
+      {IR_OP_GE, 'v'},
+      {IR_OP_NOT, 'x'},
+      {IR_OP_AND, 'y'},
+      {IR_OP_OR, 'z'},
+      {IR_OP_LOAD_LOCAL, 'e'},
+      {IR_OP_STORE_LOCAL, 'c'},
+      {IR_OP_INC_LOCAL, 'f'},
+      {IR_OP_DEC_LOCAL, 'g'},
+      {IR_OP_JUMP, 'j'},
+      {IR_OP_JUMP_IF_FALSE, 'k'},
+      {IR_OP_LABEL, 0},
+      {IR_OP_ITEM_BEGIN, 'I'},
+      {IR_OP_ITEM_BEGIN_REL, 'R'},
+      {IR_OP_ITEM_PUSH_LAYER, 'L'},
+      {IR_OP_ITEM_PUSH_DEREF, 'D'},
+      {IR_OP_ITEM_END, 'E'},
+      {IR_OP_ITEM_DEREF, 'F'},
+      {IR_OP_ITEM_SAVE, 'C'},
+      {IR_OP_CALL, 'F'},
+      {IR_OP_LIBCALL_TOKEN, 'M'},
+      {IR_OP_EXISTS, 'X'},
+      {IR_OP_DELETE, 'W'},
+      {IR_OP_NTHNAME, 'Y'},
+      {IR_OP_ROOTNAME, 'Z'},
+      {IR_OP_ITEM_SAVE_CODE, 'B'},
+  };
+
+  ASSERT_EQ_INT((int)g_ir_opcode_schema_count, (int)(sizeof(expected) / sizeof(expected[0])));
+
+  for (size_t i = 0; i < g_ir_opcode_schema_count; i++) {
+    const IR_OpSchema *meta = &g_ir_opcode_schema[i];
+    int found = 0;
+
+    for (size_t j = 0; j < sizeof(expected) / sizeof(expected[0]); j++) {
+      if (expected[j].op == meta->op) {
+        found = 1;
+        ASSERT_EQ_INT((int)expected[j].expected_symbol, (int)meta->encoded_symbol);
+        break;
+      }
+    }
+
+    ASSERT_TRUE(found);
+  }
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -55,6 +55,7 @@ void test_emitbc_header(void);
 void test_emitbc_opcode_map(void);
 void test_emitbc_opcode_map_unsupported_ir_op(void);
 void test_emitbc_opcode_map_call_item_deref_alias_layout(void);
+void test_emitbc_all_ir_ops_accounted_for(void);
 void test_emitbc_jumps(void);
 void test_emitbc_invariants(void);
 void test_pipeline_golden(void);
@@ -147,6 +148,7 @@ static const test_case_t core_tests[] = {
 static const test_case_t compiler_tests[] = {
     {"test_emitbc_header", test_emitbc_header},
     {"test_emitbc_opcode_map", test_emitbc_opcode_map},
+    {"test_emitbc_all_ir_ops_accounted_for", test_emitbc_all_ir_ops_accounted_for},
     {"test_emitbc_opcode_map_call_item_deref_alias_layout", test_emitbc_opcode_map_call_item_deref_alias_layout},
     {"test_emitbc_opcode_map_unsupported_ir_op", test_emitbc_opcode_map_unsupported_ir_op},
     {"test_emitbc_jumps", test_emitbc_jumps},


### PR DESCRIPTION
### Motivation
- Ensure the compiler's IR-to-bytecode opcode mapping remains fully accounted for by introducing a deterministic, manifest-driven test that catches missing updates when new IR opcodes are added.

### Description
- Add a new test `tests/compiler/test_emitbc_all_ir_ops_accounted_for.c` which declares a manifest of `IR_Op` entries and expected `encoded_symbol` values and verifies each schema entry is present with the expected symbol.
- The test asserts the manifest length equals `g_ir_opcode_schema_count` and iterates `g_ir_opcode_schema` to validate presence and symbol equality against the manifest.
- Wire the new test into the shared harness by declaring `test_emitbc_all_ir_ops_accounted_for` and adding it to the `compiler_tests` array in `tests/shared/test_compiler.c`.
- Add the new test source to `TEST_COMPILER_SOURCES` in `Makefile` so it is compiled into the test runner.

### Testing
- Ran `make test`, which built and executed the test runner and reported success for the full suite; all tests passed (the run completed: 57 tests across core, compiler, and runtime suites).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130eee1a40832eb82866d2c202d02e)