### PR TITLE
Add opt-in runtime benchmark regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ TEST_COMPILER_SOURCES := \
 	$(TEST_DIR)/compiler/test_libcall_dispatch_microbench.c
 TEST_INTERPRETER_SOURCES := \
 	$(TEST_DIR)/interpreter/test_interpret_semantics_golden.c \
-	$(TEST_DIR)/interpreter/test_interpret_stress.c
+	$(TEST_DIR)/interpreter/test_interpret_stress.c \
+	$(TEST_DIR)/interpreter/test_runtime_benchmark_optin.c
 TEST_SOURCES := $(TEST_SHARED_SOURCES) $(TEST_CORE_SOURCES) $(TEST_COMPILER_SOURCES) $(TEST_INTERPRETER_SOURCES)
 
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	@mkdir -p $(@D)
 	$(CC) -c $(CFLAGS) $(DEBUG) $< -o $@
 
-.PHONY: all clean lib test
+.PHONY: all clean lib test teststrict
 
 all: $(LIB) scomp sdiss sin
 
@@ -126,6 +126,9 @@ $(OBJ_DIR)/lexer.o: $(SRC_DIR)/lexer.c
 
 test: $(TEST_BIN)
 	./$(TEST_BIN)
+
+teststrict: $(TEST_BIN)
+	SIN_STRICT_BENCH=1 ./$(TEST_BIN)
 
 $(TEST_BIN): $(TEST_SOURCES) $(LIB) scomp sdiss sin
 	$(CC) $(CFLAGS) $(DEBUG) -Isrc -I$(TEST_DIR) -o $@ $(TEST_SOURCES) $(LIB) $(LDFLAGS) $(LIBS)

--- a/tests/interpreter/test_runtime_benchmark_optin.c
+++ b/tests/interpreter/test_runtime_benchmark_optin.c
@@ -1,0 +1,78 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "libcall.h"
+#include "test_assert.h"
+
+static uint64_t now_ns(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ((uint64_t)ts.tv_sec * 1000000000ull) + (uint64_t)ts.tv_nsec;
+}
+
+static int strict_bench_enabled(void) {
+  const char *flag = getenv("SIN_STRICT_BENCH");
+  if (flag == NULL) {
+    return 0;
+  }
+  return strcmp(flag, "1") == 0 || strcmp(flag, "true") == 0 || strcmp(flag, "TRUE") == 0;
+}
+
+void test_runtime_benchmark_optin(void) {
+  uint8_t token = 0;
+  uint8_t args = 0;
+  ASSERT_TRUE(libcall_lookup_token("str", "upper", &token, &args));
+  ASSERT_NOT_NULL(libcall_func_token(token));
+
+  const int lookup_iters = 150000;
+  const int dispatch_iters = 3000000;
+  volatile uintptr_t sink = 0;
+
+  uint64_t t0 = now_ns();
+  for (int i = 0; i < lookup_iters; i++) {
+    uint8_t tk = 0;
+    uint8_t ar = 0;
+    int ok = libcall_lookup_token("str", "upper", &tk, &ar);
+    sink ^= (uintptr_t)tk;
+    sink ^= (uintptr_t)ar;
+    ASSERT_TRUE(ok);
+  }
+  uint64_t t1 = now_ns();
+
+  uint64_t t2 = now_ns();
+  for (int i = 0; i < dispatch_iters; i++) {
+    OP_t fn = libcall_func_token(token);
+    sink ^= (uintptr_t)fn;
+    ASSERT_NOT_NULL(fn);
+  }
+  uint64_t t3 = now_ns();
+
+  uint64_t lookup_total = t1 - t0;
+  uint64_t dispatch_total = t3 - t2;
+  uint64_t lookup_per_op = lookup_total / (uint64_t)lookup_iters;
+  uint64_t dispatch_per_op = dispatch_total / (uint64_t)dispatch_iters;
+
+  printf("[bench] lookup_token(str.upper): total=%llu ns iters=%d per_op=%llu ns\n",
+         (unsigned long long)lookup_total, lookup_iters, (unsigned long long)lookup_per_op);
+  printf("[bench] dispatch_token(str.upper): total=%llu ns iters=%d per_op=%llu ns\n",
+         (unsigned long long)dispatch_total, dispatch_iters, (unsigned long long)dispatch_per_op);
+
+  ASSERT_TRUE(sink == 0 || sink != 0);
+
+  if (!strict_bench_enabled()) {
+    printf("[bench] strict thresholds disabled (set SIN_STRICT_BENCH=1 to enforce budget checks)\n");
+    return;
+  }
+
+  const uint64_t lookup_per_op_max_ns = 3000;
+  const uint64_t dispatch_per_op_max_ns = 500;
+
+  printf("[bench] strict thresholds enabled: lookup<=%llu ns/op dispatch<=%llu ns/op\n",
+         (unsigned long long)lookup_per_op_max_ns, (unsigned long long)dispatch_per_op_max_ns);
+
+  ASSERT_TRUE(lookup_per_op <= lookup_per_op_max_ns);
+  ASSERT_TRUE(dispatch_per_op <= dispatch_per_op_max_ns);
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -74,6 +74,7 @@ void test_libcall_dispatch_microbench(void);
 /* Runtime component tests. */
 void test_interpret_semantics_golden(void);
 void test_interpret_stress(void);
+void test_runtime_benchmark_optin(void);
 
 static void test_absyn_helpers(void) {
   AS_NODE *lhs = t_int(1);
@@ -181,6 +182,7 @@ static const test_case_t runtime_tests[] = {
     {"test_sys_compile_libcall_runtime", test_sys_compile_libcall_runtime},
     {"test_libcall_lookup_precomputed", test_libcall_lookup_precomputed},
     {"test_libcall_dispatch_microbench", test_libcall_dispatch_microbench},
+    {"test_runtime_benchmark_optin", test_runtime_benchmark_optin},
 };
 
 static void run_suite(const char *suite_name, const test_case_t *cases, size_t count,


### PR DESCRIPTION
### Motivation
- Add a lightweight runtime benchmark that exercises interpreter/libcall hot paths to detect coarse performance regressions. 
- Keep functional verification always enabled while making strict budget checks opt-in so CI can choose whether to enforce performance budgets. 

### Description
- Add `tests/interpreter/test_runtime_benchmark_optin.c` which times `libcall_lookup_token` and `libcall_func_token`, prints total and ns/op metrics, and performs sanity checks. 
- Gate strict assertions behind the `SIN_STRICT_BENCH` environment flag so thresholds are only enforced when the flag is set. 
- Register the new test in the runtime suite by updating `tests/shared/test_compiler.c`. 
- Include the new test source in the test build by updating the `Makefile` test source list. 

### Testing
- Ran `make test`, which builds and executes the full test harness; the new benchmark printed timing metrics and the run completed with all tests passing. 
- Ran `SIN_STRICT_BENCH=1 ./tests/test-compiler`, which enabled and evaluated the strict budget assertions; the run completed and the assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1314e462e4832e8fe023514faa713b)