### PR TITLE
Enforce 255-local semantic limit and add boundary tests

### DIFF
--- a/src/semant.c
+++ b/src/semant.c
@@ -18,6 +18,8 @@ static bool sem_has_local(SEM_CTX *ctx, const char *name) {
   return sem_get_local_index(ctx, name, NULL);
 }
 
+static void sem_set_error(SEM_CTX *ctx, int8_t errnum, const char *local_name);
+
 static int sem_local_index_cmp(const void *a, const void *b) {
   const SEM_LOCAL_INDEX *lhs = (const SEM_LOCAL_INDEX *)a;
   const SEM_LOCAL_INDEX *rhs = (const SEM_LOCAL_INDEX *)b;
@@ -57,7 +59,14 @@ static bool sem_find_local_index_slot(SEM_CTX *ctx, const char *name,
 }
 
 static void sem_add_local(SEM_CTX *ctx, const char *name) {
+  if (!ctx || !name || ctx->errnum != ERR_NOERROR) return;
+
   if (sem_get_local_index(ctx, name, NULL)) {
+    return;
+  }
+
+  if (ctx->count > UINT8_MAX) {
+    sem_set_error(ctx, ERR_COMP_TOOMANYLOCALS, name);
     return;
   }
 
@@ -87,13 +96,23 @@ static void sem_add_local(SEM_CTX *ctx, const char *name) {
 }
 
 static uint32_t sem_resolve_local_index(SEM_CTX *ctx, const char *name) {
-  uint8_t index = 0;
-  if (!sem_get_local_index(ctx, name, &index)) {
+  uint32_t index = 0;
+  uint8_t narrowed = 0;
+
+  if (!ctx || !name) return 0;
+  if (ctx->errnum != ERR_NOERROR) return ctx->count > 0 ? ctx->count - 1 : 0;
+
+  if (!sem_get_local_index(ctx, name, &narrowed)) {
     sem_add_local(ctx, name);
-    if (!sem_get_local_index(ctx, name, &index)) {
+    if (ctx->errnum != ERR_NOERROR) {
+      return ctx->count > 0 ? ctx->count - 1 : 0;
+    }
+    if (!sem_get_local_index(ctx, name, &narrowed)) {
       return ctx->count > 0 ? ctx->count - 1 : 0;
     }
   }
+  index = (uint32_t)narrowed;
+
   return index;
 }
 
@@ -273,6 +292,12 @@ bool sem_get_local_index(SEM_CTX *ctx, const char *name, uint8_t *index_out) {
   sem_sort_local_index_if_needed(ctx);
   sem_find_local_index_slot(ctx, name, &slot, &found);
   if (!found) return false;
+
+  if (ctx->local_index[slot].index > UINT8_MAX) {
+    sem_set_error(ctx, ERR_COMP_TOOMANYLOCALS, name);
+    return false;
+  }
+
   if (index_out) *index_out = ctx->local_index[slot].index;
   return true;
 }

--- a/tests/core/test_semant.c
+++ b/tests/core/test_semant.c
@@ -209,3 +209,51 @@ void test_sem_many_locals_deterministic_indices(void) {
   as_delete(list);
   sem_delete_ctx(ctx);
 }
+
+void test_sem_local_limit_255_is_accepted(void) {
+  SEM_CTX *ctx = sem_create_ctx();
+  ASSERT_NOT_NULL(ctx);
+
+  AS_NODE *list = as_new_stmtlist_node();
+  for (int i = 0; i < 256; i++) {
+    char name[32];
+    snprintf(name, sizeof(name), "local_%03d", i);
+    list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local(name), t_int(i)));
+  }
+
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(list, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_EQ_INT(256, (int)ctx->count);
+
+  uint8_t idx = 0;
+  ASSERT_TRUE(sem_get_local_index(ctx, "local_255", &idx));
+  ASSERT_EQ_INT(255, (int)idx);
+
+  as_delete(list);
+  sem_delete_ctx(ctx);
+}
+
+void test_sem_local_limit_over_255_fails_deterministically(void) {
+  SEM_CTX *ctx = sem_create_ctx();
+  ASSERT_NOT_NULL(ctx);
+
+  AS_NODE *list = as_new_stmtlist_node();
+  for (int i = 0; i < 257; i++) {
+    char name[32];
+    snprintf(name, sizeof(name), "local_%03d", i);
+    list = as_stmtlist_append(list, t_node(N_ASSLOCAL, t_local(name), t_int(i)));
+  }
+
+  char *errdetail = NULL;
+  int8_t rc = sem_check_locals(list, &errdetail, ctx);
+  ASSERT_EQ_INT(ERR_COMP_TOOMANYLOCALS, rc);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, "local_256") != NULL);
+  ASSERT_EQ_INT(256, (int)ctx->count);
+
+  free(errdetail);
+  as_delete(list);
+  sem_delete_ctx(ctx);
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -26,6 +26,8 @@ void test_sem_code_params_duplicate_after_unrelated_locals_no_param_corruption(v
 void test_sem_parent_scope_error_detail_format(void);
 void test_sem_embedded_scope_error_detail_includes_provenance(void);
 void test_sem_many_locals_deterministic_indices(void);
+void test_sem_local_limit_255_is_accepted(void);
+void test_sem_local_limit_over_255_fails_deterministically(void);
 void test_ir_validate(void);
 void test_opcode_schema_consistency(void);
 void test_parser_input_api(void);
@@ -132,6 +134,8 @@ static const test_case_t core_tests[] = {
     {"test_sem_parent_scope_error_detail_format", test_sem_parent_scope_error_detail_format},
     {"test_sem_embedded_scope_error_detail_includes_provenance", test_sem_embedded_scope_error_detail_includes_provenance},
     {"test_sem_many_locals_deterministic_indices", test_sem_many_locals_deterministic_indices},
+    {"test_sem_local_limit_255_is_accepted", test_sem_local_limit_255_is_accepted},
+    {"test_sem_local_limit_over_255_fails_deterministically", test_sem_local_limit_over_255_fails_deterministically},
     {"test_ir_validate", test_ir_validate},
     {"test_opcode_schema_consistency", test_opcode_schema_consistency},
     {"test_parser_input_api", test_parser_input_api},


### PR DESCRIPTION
### Motivation
- Prevent silent uint8_t wraparound for local indices by enforcing the compiler’s hard 255-local limit and making lookups width-safe. 

### Description
- Replace the intermediate `uint8_t` usage in `sem_resolve_local_index` with a width-safe internal flow that only narrows at the `sem_get_local_index(..., uint8_t*)` API boundary. 
- Add a guard in `sem_add_local` to detect attempts to exceed `UINT8_MAX` and emit `ERR_COMP_TOOMANYLOCALS` instead of allowing overflow. 
- Add a defensive bounds check in `sem_get_local_index` that emits `ERR_COMP_TOOMANYLOCALS` if an out-of-range stored index is observed before any narrowing cast. 
- Add two tests (`test_sem_local_limit_255_is_accepted` and `test_sem_local_limit_over_255_fails_deterministically`) in `tests/core/test_semant.c` and register them in `tests/shared/test_compiler.c` to validate correct behavior at the 255 boundary. 

### Testing
- Ran the full test harness with `make test -j4`, which completed and reported all suites passing including the new core semantic limit tests. 
- The new boundary tests verify that 256 locals (indices 0..255) succeed and that adding the 257th local fails deterministically with `ERR_COMP_TOOMANYLOCALS` while preserving `ctx->count == 256`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131d3b4724832e8913d535c0fc5343)