### PR TITLE
Enforce u8 local/param limits in compiler pipeline

### DIFF
--- a/src/compiler_pipeline.c
+++ b/src/compiler_pipeline.c
@@ -4,6 +4,7 @@
 #include "compiler_pipeline.h"
 
 #include "compiler_context.h"
+#include "compdiag.h"
 #include "error.h"
 #include "lower.h"
 #include "parser.h"
@@ -51,14 +52,26 @@ int8_t compile_source_to_bytecode_with_params(const char *source, size_t len,
     goto done;
   }
 
-  uint8_t emitted_param_count = 0;
+  uint32_t emitted_param_count = 0;
   for (uint32_t i = 0; i < ctx.sem_ctx->count; i++) {
     if (ctx.sem_ctx->locals[i].param) {
       emitted_param_count++;
     }
   }
 
-  rc = emit_bytecode(ctx.ir_unit, (uint8_t)ctx.sem_ctx->count, emitted_param_count, ctx.bytecode_out, errdetail);
+  if (ctx.sem_ctx->count > UINT8_MAX) {
+    compdiag_setf_once(&rc, errdetail, ERR_COMP_TOOMANYLOCALS, "compile",
+                       "locals+params exceeds u8 max: %u", ctx.sem_ctx->count);
+    goto done;
+  }
+
+  if (emitted_param_count > UINT8_MAX) {
+    compdiag_setf_once(&rc, errdetail, ERR_COMP_TOOMANYPARAMS, "compile",
+                       "param count exceeds u8 max: %u", emitted_param_count);
+    goto done;
+  }
+
+  rc = emit_bytecode(ctx.ir_unit, (uint8_t)ctx.sem_ctx->count, (uint8_t)emitted_param_count, ctx.bytecode_out, errdetail);
   if (rc != ERR_NOERROR) {
     goto done;
   }

--- a/tests/compiler/test_pipeline_negative_matrix.c
+++ b/tests/compiler/test_pipeline_negative_matrix.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -87,6 +88,28 @@ static int8_t run_ir_case_bad_arity(char **errdetail) {
   return rc;
 }
 
+static int8_t run_compile_case_too_many_params(char **errdetail) {
+  const size_t param_count = UINT8_MAX + 1u;
+  const char **params = calloc(param_count, sizeof(char *));
+  char **owned = calloc(param_count, sizeof(char *));
+  ASSERT_NOT_NULL(params);
+  ASSERT_NOT_NULL(owned);
+  for (size_t i = 0; i < param_count; i++) {
+    owned[i] = malloc(16);
+    ASSERT_NOT_NULL(owned[i]);
+    snprintf(owned[i], 16, "p%zu", i);
+    params[i] = owned[i];
+  }
+
+  OUTPUT_t *out = NULL;
+  int8_t rc = compile_source_to_bytecode_with_params("1;", 2, params, param_count, &out, errdetail);
+  ASSERT_TRUE(out == NULL);
+  for (size_t i = 0; i < param_count; i++) free(owned[i]);
+  free(owned);
+  free(params);
+  return rc;
+}
+
 void test_pipeline_negative_matrix(void) {
   static const NEG_CASE cases[] = {
       {"parser_unknown_char", CASE_SOURCE, "^;", NULL, ERR_COMP_UNKNOWNCHAR, STAGE_PARSER, "^", 1},
@@ -111,6 +134,7 @@ void test_pipeline_negative_matrix(void) {
 
       {"emitter_invalid_label", CASE_BUILDER, NULL, run_emit_case_invalid_label, ERR_COMP_SYNTAX, STAGE_EMITTER, "emitbc: jump invalid label id", 1},
       {"emitter_unsupported_op", CASE_BUILDER, NULL, run_emit_case_unsupported_op, ERR_COMP_SYNTAX, STAGE_EMITTER, "emitbc: unsupported IR op", 1},
+      {"semantic_compile_param_count_guard", CASE_BUILDER, NULL, run_compile_case_too_many_params, ERR_COMP_TOOMANYLOCALS, STAGE_SEMANTIC, "", 1},
   };
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {


### PR DESCRIPTION
### Motivation
- Prevent truncated or malformed bytecode headers by ensuring the total locals+params and emitted param count fit in `uint8_t` before calling the emitter. 

### Description
- Added checks in `compile_source_to_bytecode_with_params` to validate `ctx.sem_ctx->count <= UINT8_MAX` and computed `emitted_param_count <= UINT8_MAX` and return a compiler diagnostic when either is out of range. 
- Populate `errdetail` via `compdiag_setf_once` with a precise message that includes the offending numeric count and return the appropriate error (`ERR_COMP_TOOMANYLOCALS` or `ERR_COMP_TOOMANYPARAMS`). 
- Changed `emitted_param_count` accumulation to `uint32_t` to avoid overflow during counting and cast to `uint8_t` only after range checks. 
- Added a negative test `run_compile_case_too_many_params` in `tests/compiler/test_pipeline_negative_matrix.c` that seeds `UINT8_MAX + 1` params and asserts the compiler fails cleanly with diagnostics.

### Testing
- Ran `make test TESTS='tests/compiler/test_pipeline_negative_matrix.c'` during development to iterate on the test and implementation fixes. 
- Executed the test build and full test harness, and all suites (core, compiler, runtime) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131eb7241c832ea04c46f417ee7c4c)