### PR TITLE
Add documentation improvement roadmap and reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - The structure of the language is broadly complete, but library functions are almost nonexistent.  Player connection/disconnection/activity is handled, but what can be done with such events is limited.  Still, the engine is sufficiently developed that it can run a simple echoserver.
 - The code is written in the vernacular style without any formal design.  In other words, I'm making it up as I go along.  There are various code styles and design patterns in use, depending on the mood I was in when I wrote each particular bit of code.  Much of the code is quite naïve, and will require tightening up and optimisation.  I follow the mantra "first, make it work; then make it work well; finally make it work fast".
 - The compiler isn't particularly helpful if it encounters something it doesn't like.
-- Documentation is sparse.
+- Documentation is sparse, though `docs/documentation-roadmap.md` tracks proposed improvements for organising reader guides and preparing a future formal language reference.
 
 ## Compiling and Running ##
 

--- a/docs/documentation-roadmap.md
+++ b/docs/documentation-roadmap.md
@@ -1,0 +1,116 @@
+# Documentation Improvement Roadmap
+
+This roadmap proposes follow-up documentation tasks for making Sinistra easier to
+learn now, while leaving space for a formal language reference once the language
+has stabilised. It focuses on documentation structure, source-of-truth ownership,
+and reviewable increments rather than prematurely freezing syntax or semantics.
+
+## Near-term tasks
+
+### Create a documentation index
+
+Add a `docs/README.md` index that explains the purpose and stability level of
+each document. The index should help readers choose between the quickstart,
+conceptual overview, bytecode reference, libcall reference, history, test
+coverage map, and future language reference.
+
+### Split the concepts guide into reader-focused pages
+
+Break `docs/concepts.md` into smaller pages with stable responsibilities:
+
+- items and item hierarchy;
+- code items, evaluation, parameters, and local variables;
+- expressions, operators, and truthiness;
+- control flow;
+- comments and source-layout rules;
+- runtime tasks and event flow.
+
+This would make the existing material easier to review and create natural homes
+for future examples and formal reference links.
+
+### Add an examples guide
+
+Create a guide that walks through the files in `examples/` and explains the
+runtime behaviour they demonstrate. Start with the existing echo and chat server
+examples, then add small single-purpose examples for language features as they
+stabilise.
+
+### Document command-line tools consistently
+
+Add a tools reference for `sin`, `scomp`, and `sdiss`. For each tool, document
+its purpose, expected inputs and outputs, common flags, generated files, and how
+it fits into the quickstart workflow.
+
+### Add a diagnostics and troubleshooting page
+
+Document common compiler and runtime failure modes, including how `error` and
+`error.msg` are set, where log output appears, how invalid libcall arguments are
+reported, and how to reset generated itemstore/source-root state during local
+experiments.
+
+### Add documentation maintenance notes
+
+Extend contributor guidance with a small documentation checklist. The checklist
+should identify which documents must be considered when changing syntax,
+semantics, libcalls, bytecode encoding, examples, tests, or command-line flags.
+
+## Medium-term tasks
+
+### Establish a language-reference skeleton
+
+Create a placeholder language reference with intentionally marked unstable
+sections. Suggested top-level sections are lexical structure, item names,
+literals, expressions, statements, code items, parameters, local variables,
+libcall syntax, evaluation order, errors, and implementation limits.
+
+### Define stability labels
+
+Use simple stability labels in documentation so readers know whether a page is
+introductory, normative, implementation-derived, or provisional. This is
+especially useful while the formal language documentation is being prepared but
+not yet authoritative.
+
+### Add grammar-oriented documentation
+
+Once the parser rules settle, add a grammar appendix derived from the parser and
+lexer. Until then, document only the practical syntax that examples and tests
+exercise, and mark gaps explicitly.
+
+### Cross-link implementation-derived references
+
+For implementation-derived documents such as the bytecode and libcall references,
+add explicit links to their source-of-truth files and tests. This makes drift
+easier to spot during review.
+
+### Expand the test coverage map into a documentation coverage map
+
+Track not only what code is tested, but also what language/runtime behaviours are
+documented. This can highlight features that are implemented and tested but not
+yet explained to users.
+
+## Long-term tasks
+
+### Promote the formal language reference to canonical status
+
+When the language stabilises, promote the language reference from provisional to
+canonical and make other guides link back to it for normative definitions.
+
+### Generate reference tables where possible
+
+Consider generating or checking selected reference tables from implementation
+metadata, especially opcode and libcall inventories. Generated checks can reduce
+manual drift without requiring every document to be generated.
+
+### Add versioned documentation notes
+
+If Sinistra starts preserving compatibility across releases, add versioned notes
+for syntax, bytecode, library calls, and itemstore/runtime behaviour.
+
+## Suggested first documentation issues
+
+1. Add `docs/README.md` and link it from `README.md`.
+2. Split `docs/concepts.md` into focused concept pages without changing content
+   semantics.
+3. Add a `docs/tools.md` reference for `sin`, `scomp`, and `sdiss`.
+4. Add `docs/troubleshooting.md` for diagnostics, logs, and generated state.
+5. Add a provisional `docs/language-reference.md` skeleton with stability notes.


### PR DESCRIPTION
### Motivation
- Provide a lightweight, reviewable plan for improving docs and preparing a formal language reference once the language stabilises.
- Make it easier for contributors and readers to find next documentation work and reduce drift between implementation and docs.

### Description
- Add `docs/documentation-roadmap.md` with near-, medium-, and long-term documentation tasks covering index, concept split, examples, tools, troubleshooting, maintenance notes, and a provisional language-reference skeleton.
- Update the `README.md` limitations section to reference the new roadmap via `docs/documentation-roadmap.md`.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff issues, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7ed64b04832ea8dffd705de728f7)