### PR TITLE
Refactor VM value helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ TEST_CORE_SOURCES := \
 	$(TEST_DIR)/core/test_parser_input_api.c \
 	$(TEST_DIR)/core/test_item_cache.c \
 	$(TEST_DIR)/core/test_libcall_registry.c \
-	$(TEST_DIR)/core/test_relative_item_leading_dot.c
+	$(TEST_DIR)/core/test_relative_item_leading_dot.c \
+	$(TEST_DIR)/core/test_value_behavior.c
 TEST_COMPILER_SOURCES := \
 	$(TEST_DIR)/compiler/test_emitbc_header.c \
 	$(TEST_DIR)/compiler/test_emitbc_opcode_map.c \

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -108,7 +108,18 @@ static void strbuf_track(char *ptr, size_t cap) {
 static void free_runtime_string(char *s) {
   if (!s) return;
   strbuf_forget(s);
-  FREE_ARRAY(char, s, strlen(s) + 1);
+  free(s);
+}
+
+static void value_free_runtime(VALUE_t *value) {
+  if (!value) return;
+  if (value->type == VALUE_str) {
+    free_runtime_string(value->s);
+    value->type = VALUE_nil;
+    value->i = 0;
+  } else {
+    value_free(value);
+  }
 }
 
 static size_t strbuf_growth_capacity(size_t needed) {
@@ -133,7 +144,7 @@ static VALUE_t concat_two_strings(VALUE_t left, VALUE_t right) {
     memcpy(out + left_len, right.s, right_len + 1);
     out_cap = left_meta->cap;
     strbuf_forget(right.s);
-    FREE_ARRAY(char, right.s, right_len + 1);
+    free(right.s);
   } else {
     if (left_meta) {
       out_cap = strbuf_growth_capacity(needed);
@@ -152,10 +163,10 @@ static VALUE_t concat_two_strings(VALUE_t left, VALUE_t right) {
 }
 
 static inline int binary_int_operands(VALUE_t v1, VALUE_t v2, const char *opcode_name) {
-  int valid = (v1.type == VALUE_int && v2.type == VALUE_int);
+  int valid = (value_is_type(&v1, VALUE_int) && value_is_type(&v2, VALUE_int));
   if (!valid) {
-    logerr("%s invalid operand types: left '%c', right '%c'.\n",
-          opcode_name, v2.type, v1.type);
+    logerr("%s invalid operand types: left '%s', right '%s'.\n",
+          opcode_name, value_type_name(v2.type), value_type_name(v1.type));
   }
   return valid;
 }
@@ -198,19 +209,19 @@ static inline int pop_compare_and_push_bool(VM_t *vm, CMP_MODE_t mode, const cha
   // Intentional quirk preserved: OP_NOTEQUAL treats mismatched types as true,
   // while the other comparison operators treat unsupported/mismatched operands
   // as false.
-  if (v1.type == VALUE_int && v2.type == VALUE_int) {
-    comparison_true = apply_comparison(mode, v2.i, v1.i);
-  } else if (v1.type == VALUE_bool && v2.type == VALUE_bool) {
-    comparison_true = apply_comparison(mode, v2.i, v1.i);
-  } else if ((mode == CMP_EQ || mode == CMP_NE)
-             && v1.type == VALUE_str && v2.type == VALUE_str) {
-    int cmp = strcmp(v2.s, v1.s);
-    comparison_true = (mode == CMP_EQ) ? (cmp == 0) : (cmp != 0);
-  } else if (mode == CMP_NE && v1.type != v2.type) {
-    comparison_true = 1;
+  if (mode == CMP_EQ || mode == CMP_NE) {
+    comparison_true = value_equal(&v2, &v1);
+    if (mode == CMP_NE) comparison_true = !comparison_true;
+  } else {
+    int cmp = 0;
+    if (value_order(&v2, &v1, &cmp)) {
+      comparison_true = apply_comparison(mode, cmp, 0);
+    }
   }
 
   result.i = comparison_true;
+  value_free_runtime(&v1);
+  value_free_runtime(&v2);
   push_stack(VM->stack, result);
   if (!comparison_true) {
     DISASS_LOG("%s: types %d and %d\n", opcode_tag, v1.type, v2.type);
@@ -335,7 +346,7 @@ uint8_t *op_jumpfalse(uint8_t *nextop, ITEM_t *item) {
     // A true value means that we don't branch.  Skip over
     // the next two bytes.
     DISASS_LOG("OP_JUMPFALSE: evaluates to true (no jump).\n");
-    FREE_STR(v1);
+    value_free(&v1);
     return nextop + 2;
   } else {
     // If not true then it must be false.  That's logic.
@@ -351,14 +362,8 @@ uint8_t *op_savelocal(uint8_t *nextop, ITEM_t *item) {
   // Interpret the next byte as an index into the stack.
   uint8_t index = *nextop + VM->stack->base;
   // First check if the current value is a string.  If so, free it.
-  if (VM->stack->stack[index].type == VALUE_str) {
-    free(VM->stack->stack[index].s);
-  }
-  // Then copy the top of the stack into that location.
-  memcpy(&(VM->stack->stack[index]), &(VM->stack->stack[VM->stack->current]),
-                                                    sizeof(VALUE_t));
-  // Then reduce the size of the stack.
-  VM->stack->current--;
+  VALUE_t top = pop_stack(VM->stack);
+  value_move(&VM->stack->stack[index], &top);
   DISASS_LOG("OP_SAVELOCAL: index %d\n", index);
   return nextop+1;
 }
@@ -368,15 +373,7 @@ uint8_t *op_getlocal(uint8_t *nextop, ITEM_t *item) {
   // Interpret the next byte as an index into the stack.
   uint8_t index = *nextop + VM->stack->base;
 
-  // Then increase the size of the stack.
-  VM->stack->current++;
-  // Then copy that location to the top of the stack.
-  memcpy(&(VM->stack->stack[VM->stack->current]), &(VM->stack->stack[index]),
-                                                    sizeof(VALUE_t));
-  // Remember to copy the string if necessary.
-  if (VM->stack->stack[VM->stack->current].type == VALUE_str) {
-    VM->stack->stack[VM->stack->current].s = strdup(VM->stack->stack[index].s);
-  }
+  push_stack(VM->stack, value_clone(&VM->stack->stack[index]));
 #ifdef DISASS
   VALUE_t v;
   v = peek_stack(VM->stack);
@@ -428,14 +425,12 @@ uint8_t *op_add(uint8_t *nextop, ITEM_t *item) {
   } else if (v1.type == VALUE_str && v2.type == VALUE_str) {
     push_stack(VM->stack, concat_two_strings(v2, v1));
   } else {
-    if (v1.type == VALUE_str) {
-      free_runtime_string(v1.s);
-    }
-    if (v2.type == VALUE_str) {
-      free_runtime_string(v2.s);
-    }
-    logerr("OP_ADD invalid operand types: left '%c', right '%c'. Result is NIL.\n",
-          v2.type, v1.type);
+    VALUE_e left_type = v2.type;
+    VALUE_e right_type = v1.type;
+    value_free_runtime(&v1);
+    value_free_runtime(&v2);
+    logerr("OP_ADD invalid operand types: left '%s', right '%s'. Result is NIL.\n",
+          value_type_name(left_type), value_type_name(right_type));
     push_stack(VM->stack, VALUE_NIL);
   }
   DISASS_LOG("OP_ADD: types %d and %d\n", v1.type, v2.type);
@@ -455,12 +450,8 @@ uint8_t *op_subtract(uint8_t *nextop, ITEM_t *item) {
     DISASS_LOG("OP_SUB: operand types %d and %d\n", v2.type, v1.type);
   } else {
     DISASS_LOG("OP_SUB: invalid operand types %d and %d\n", v2.type, v1.type);
-    if (v1.type == VALUE_str) {
-      FREE_ARRAY(char, v1.s, strlen(v1.s) + 1);
-    }
-    if (v2.type == VALUE_str) {
-      FREE_ARRAY(char, v2.s, strlen(v2.s) + 1);
-    }
+    value_free_runtime(&v1);
+    value_free_runtime(&v2);
     v2 = VALUE_NIL;
   }
   push_stack(VM->stack, v2);
@@ -485,12 +476,8 @@ uint8_t *op_divide(uint8_t *nextop, ITEM_t *item) {
     DISASS_LOG("OP_DIV: operand types %d and %d\n", v2.type, v1.type);
   } else {
     DISASS_LOG("OP_DIV: invalid operand types %d and %d\n", v2.type, v1.type);
-    if (v1.type == VALUE_str) {
-      FREE_ARRAY(char, v1.s, strlen(v1.s) + 1);
-    }
-    if (v2.type == VALUE_str) {
-      FREE_ARRAY(char, v2.s, strlen(v2.s) + 1);
-    }
+    value_free_runtime(&v1);
+    value_free_runtime(&v2);
     v2 = VALUE_NIL;
   }
   v2.type = VALUE_int;
@@ -510,12 +497,8 @@ uint8_t *op_multiply(uint8_t *nextop, ITEM_t *item) {
     DISASS_LOG("OP_MUL: operand types %d and %d\n", v2.type, v1.type);
   } else {
     DISASS_LOG("OP_MUL: invalid operand types %d and %d\n", v2.type, v1.type);
-    if (v1.type == VALUE_str) {
-      FREE_ARRAY(char, v1.s, strlen(v1.s) + 1);
-    }
-    if (v2.type == VALUE_str) {
-      FREE_ARRAY(char, v2.s, strlen(v2.s) + 1);
-    }
+    value_free_runtime(&v1);
+    value_free_runtime(&v2);
     v2 = VALUE_NIL;
   }
   push_stack(VM->stack, v2);

--- a/src/item.c
+++ b/src/item.c
@@ -453,8 +453,8 @@ ITEM_t *make_root_item(const char* name) {
 void destroy_item(ITEM_t *item) {
   if (item->type == ITEM_code) {
     free(item->bytecode);
-  } else if (item->type == ITEM_value && item->value.type == VALUE_str) {
-    free(item->value.s);
+  } else if (item->type == ITEM_value) {
+    value_free(&item->value);
   }
   // Free the item's innards
   free_hashtable(item->children);
@@ -495,10 +495,8 @@ ITEM_t *insert_item(ITEM_t *root, const char *item_name, VALUE_t value) {
       // If there's no next dot, we've reached the last layer
       // Possibly free currently in-use memory
       // (it might have been newly-created, or might already exist)
-      if (current_item->type == ITEM_value &&
-                                    current_item->value.type == VALUE_str) {
-          FREE_ARRAY(char, current_item->value.s,
-                                           strlen(current_item->value.s+1));
+      if (current_item->type == ITEM_value) {
+          value_free(&current_item->value);
       } else if (current_item->type == ITEM_code) {
         if (current_item->inuse) {
           char name[MAX_ITEM_NAME];
@@ -553,10 +551,8 @@ ITEM_t *insert_code_item(ITEM_t *root, const char *item_name, uint32_t len,
     if (next_dot == NULL) {
       // If there's no next dot, we've reached the last layer
       // It's code item, remember!
-      if (current_item->type == ITEM_value
-                              && current_item->value.type == VALUE_str) {
-        FREE_ARRAY(char, current_item->value.s,
-                                           strlen(current_item->value.s+1));
+      if (current_item->type == ITEM_value) {
+        value_free(&current_item->value);
       }
       current_item->type = ITEM_code;
       current_item->value.type = VALUE_nil; // Just to be safe
@@ -660,10 +656,7 @@ void set_item(ITEM_t *root, const char *item_name, VALUE_t value) {
   ITEM_t *item = find_item(root, item_name);
   if (item) {
     // Item exists, so just update its value.
-    if (item->value.type == VALUE_str) {
-      free(item->value.s);
-    }
-    item->value = value;
+    value_replace(&item->value, value);
   } else {
     // Item doesn't exist, so create it.
     insert_item(root, item_name, value);

--- a/src/libcall.c
+++ b/src/libcall.c
@@ -33,7 +33,7 @@ extern LINE_t *line;
 // - Callers own popped values and must free any owned string payload exactly once.
 // - FREE_STR(v) is the canonical cleanup helper; it is a safe no-op for non-string values.
 static inline bool lc_value_is_type(VALUE_t v, VALUE_e type) {
-  return v.type == type;
+  return value_is_type(&v, type);
 }
 
 static inline uint8_t *lc_invalid_args_return(uint8_t *nextop, VALUE_t ret) {
@@ -44,7 +44,7 @@ static inline uint8_t *lc_invalid_args_return(uint8_t *nextop, VALUE_t ret) {
 
 static inline void lc_cleanup_values(VALUE_t *values, size_t count) {
   for (size_t i = 0; i < count; i++) {
-    FREE_STR(values[i]);
+    value_free(&values[i]);
   }
 }
 
@@ -189,7 +189,8 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
   int32_t stack_top_before_interpret = VM->stack->current;
   (void)interpret(tmpitem);
   while (VM->stack->current > stack_top_before_interpret) {
-    FREE_STR(pop_stack(VM->stack));
+    VALUE_t dropped = pop_stack(VM->stack);
+    value_free(&dropped);
   }
 
   // Best-effort cleanup of temp item
@@ -221,7 +222,7 @@ void execute_task_cb(uv_timer_t *req) {
       logmsg("Bytecode interpreter returned: %ld\n", ret.i);
     } else if (ret.type == VALUE_str) {
       logmsg("Bytecode interpreter returned: %s\n", ret.s);
-      FREE_ARRAY(char, ret.s, strlen(ret.s));
+      value_free(&ret);
     } else if (ret.type == VALUE_bool) {
       logmsg("Bytecode interpreter returned: %s\n", ret.i?"true":"false");
     } else if (ret.type == VALUE_nil) {

--- a/src/stack.c
+++ b/src/stack.c
@@ -32,11 +32,7 @@ void reset_stack(STACK_t *stack) {
   // Note that this includes any local variables!
   // Really simple!
   for (int v = 0; v < (stack->current + stack->locals); v++) {
-    if (stack->stack[v].type == VALUE_str) {
-      STRINGDEBUG_LOG("Freeing string: %s\n", stack->stack[v].s);
-      FREE_ARRAY(char, stack->stack[v].s,
-                                    strlen(stack->stack[v].s) + 1);
-    }
+    value_free(&stack->stack[v]);
   }
   stack->current = -1;
 }
@@ -82,11 +78,7 @@ void throwaway_stack(STACK_t *stack) {
   // Set the type on the stack to nil, to prevent inadvertent
   // freeing of strings which may be in use elsewhere.
   if (stack->current >= 0) {
-    if (stack->stack[stack->current].type == VALUE_str) {
-      FREE_ARRAY(char, stack->stack[stack->current].s,
-                                   strlen(stack->stack[stack->current].s));
-    }
-    stack->stack[stack->current].type = VALUE_nil;
+    value_free(&stack->stack[stack->current]);
     stack->current--;
   }
   logerr("Stack cleared.\n");

--- a/src/value.c
+++ b/src/value.c
@@ -3,7 +3,9 @@
 // Licensed under the MIT License - see LICENSE file for details.
 
 #include <stddef.h>
-#include <malloc.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
 #define VALUE_INTERNAL
 #include "value.h"
@@ -13,13 +15,63 @@ const VALUE_t VALUE_TRUE = {VALUE_bool, {1}};
 const VALUE_t VALUE_FALSE = {VALUE_bool, {0}};
 const VALUE_t VALUE_ZERO = {VALUE_int, {0}};
 
+const char *value_type_name(VALUE_e type) {
+  switch (type) {
+    case VALUE_int: return "int";
+    case VALUE_str: return "str";
+    case VALUE_nil: return "nil";
+    case VALUE_bool: return "bool";
+  }
+  return "unknown";
+}
+
+bool value_is_type(const VALUE_t *value, VALUE_e type) {
+  return value != NULL && value->type == type;
+}
+
+void value_free(VALUE_t *value) {
+  if (!value) return;
+  if (value->type == VALUE_str && value->s) {
+    free(value->s);
+  }
+  value->type = VALUE_nil;
+  value->i = 0;
+}
+
+VALUE_t value_clone(const VALUE_t *value) {
+  if (!value) return VALUE_NIL;
+  VALUE_t out = *value;
+  if (value->type == VALUE_str) {
+    out.s = value->s ? strdup(value->s) : strdup("");
+  }
+  return out;
+}
+
+void value_move(VALUE_t *dst, VALUE_t *src) {
+  if (!dst || !src || dst == src) return;
+  value_free(dst);
+  *dst = *src;
+  src->type = VALUE_nil;
+  src->i = 0;
+}
+
+void value_replace(VALUE_t *dst, VALUE_t src) {
+  if (!dst) {
+    value_free(&src);
+    return;
+  }
+  value_free(dst);
+  *dst = src;
+}
+
 int value_is_truthy(const VALUE_t *value) {
+  if (!value) return 0;
   switch (value->type) {
     case VALUE_bool:
     case VALUE_int:
       return value->i != 0;
     case VALUE_str:
-      return value->s[0] != '\0';
+      return value->s && value->s[0] != '\0';
     case VALUE_nil:
     default:
       return 0;
@@ -28,17 +80,64 @@ int value_is_truthy(const VALUE_t *value) {
 
 void value_to_bool_inplace(VALUE_t *value) {
   int truthy = value_is_truthy(value);
-
-  if (value->type == VALUE_str) {
-    free(value->s);
-  }
-
+  value_free(value);
   value->type = VALUE_bool;
   value->i = truthy;
 }
 
 VALUE_t convert_to_bool(VALUE_t from) {
-  // Backward-compatible wrapper around in-place conversion.
   value_to_bool_inplace(&from);
   return from;
+}
+
+bool value_equal(const VALUE_t *left, const VALUE_t *right) {
+  if (!left || !right || left->type != right->type) return false;
+  switch (left->type) {
+    case VALUE_int:
+    case VALUE_bool:
+      return left->i == right->i;
+    case VALUE_str:
+      return strcmp(left->s ? left->s : "", right->s ? right->s : "") == 0;
+    case VALUE_nil:
+      return true;
+  }
+  return false;
+}
+
+bool value_order(const VALUE_t *left, const VALUE_t *right, int *comparison) {
+  if (!left || !right || left->type != right->type) return false;
+  switch (left->type) {
+    case VALUE_int:
+    case VALUE_bool:
+      *comparison = (left->i > right->i) - (left->i < right->i);
+      return true;
+    default:
+      return false;
+  }
+}
+
+const char *value_debug_string(const VALUE_t *value, char *buffer, size_t buffer_size) {
+  if (!buffer || buffer_size == 0) return "";
+  if (!value) {
+    snprintf(buffer, buffer_size, "<null>");
+    return buffer;
+  }
+  switch (value->type) {
+    case VALUE_int:
+      snprintf(buffer, buffer_size, "%ld", value->i);
+      break;
+    case VALUE_bool:
+      snprintf(buffer, buffer_size, "%s", value->i ? "true" : "false");
+      break;
+    case VALUE_str:
+      snprintf(buffer, buffer_size, "'%s'", value->s ? value->s : "");
+      break;
+    case VALUE_nil:
+      snprintf(buffer, buffer_size, "nil");
+      break;
+    default:
+      snprintf(buffer, buffer_size, "<%s>", value_type_name(value->type));
+      break;
+  }
+  return buffer;
 }

--- a/src/value.h
+++ b/src/value.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
 
 typedef enum { VALUE_int,
                VALUE_str,
@@ -27,11 +29,7 @@ extern VALUE_t VALUE_TRUE;
 extern VALUE_t VALUE_FALSE;
 #endif
 
-#define FREE_STR(val) \
-  if ((val).type == VALUE_str) { \
-    STRINGDEBUG_LOG("Freeing: %s\n", val.s); \
-    FREE_ARRAY(char, (val).s, strlen((val).s) + 1); \
-  }
+#define FREE_STR(val) value_free(&(val))
   
 VALUE_t convert_to_bool(VALUE_t from);
 
@@ -47,3 +45,14 @@ VALUE_t convert_to_bool(VALUE_t from);
 //   storage if and only if the input value owns VALUE_str memory.
 int value_is_truthy(const VALUE_t *value);
 void value_to_bool_inplace(VALUE_t *value);
+
+
+const char *value_type_name(VALUE_e type);
+const char *value_debug_string(const VALUE_t *value, char *buffer, size_t buffer_size);
+bool value_is_type(const VALUE_t *value, VALUE_e type);
+void value_free(VALUE_t *value);
+VALUE_t value_clone(const VALUE_t *value);
+void value_move(VALUE_t *dst, VALUE_t *src);
+void value_replace(VALUE_t *dst, VALUE_t src);
+bool value_equal(const VALUE_t *left, const VALUE_t *right);
+bool value_order(const VALUE_t *left, const VALUE_t *right, int *comparison);

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -1,0 +1,125 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "config.h"
+#include "interpret.h"
+#include "item.h"
+#include "test_assert.h"
+#include "value.h"
+#include "vm.h"
+
+extern CONFIG_t config;
+
+static void setup_runtime(void) {
+  memset(&config, 0, sizeof(config));
+  config.itemroot = make_root_item("root");
+  ASSERT_NOT_NULL(config.itemroot);
+  config.vm = make_vm();
+  ASSERT_NOT_NULL(config.vm);
+}
+
+static void teardown_runtime(void) {
+  destroy_vm(config.vm);
+  destroy_item(config.itemroot);
+  memset(&config, 0, sizeof(config));
+}
+
+static void emit_i64(uint8_t *code, size_t *pos, int64_t value) {
+  memcpy(code + *pos, &value, sizeof(value));
+  *pos += sizeof(value);
+}
+
+static void emit_str(uint8_t *code, size_t *pos, const char *value) {
+  uint16_t len = (uint16_t)strlen(value);
+  memcpy(code + *pos, &len, sizeof(len));
+  *pos += sizeof(len);
+  memcpy(code + *pos, value, len);
+  *pos += len;
+}
+
+static VALUE_t run_code(const char *name, const uint8_t *template_code, size_t len) {
+  uint8_t *bytecode = malloc(len);
+  ASSERT_NOT_NULL(bytecode);
+  memcpy(bytecode, template_code, len);
+  ITEM_t *code = insert_code_item(config.itemroot, name, (uint32_t)len, bytecode);
+  ASSERT_NOT_NULL(code);
+  return interpret(code);
+}
+
+void test_value_integer_arithmetic_helpers(void) {
+  setup_runtime();
+  uint8_t code[64] = {0};
+  size_t pos = 0;
+  code[pos++] = 0;
+  code[pos++] = 0;
+  code[pos++] = 'p'; emit_i64(code, &pos, 9);
+  code[pos++] = 'p'; emit_i64(code, &pos, 4);
+  code[pos++] = 's';
+  code[pos++] = 'p'; emit_i64(code, &pos, 3);
+  code[pos++] = 'm';
+  code[pos++] = 'p'; emit_i64(code, &pos, 5);
+  code[pos++] = 'd';
+  code[pos++] = 'h';
+
+  VALUE_t result = run_code("test.value_int_arithmetic", code, pos);
+  ASSERT_EQ_INT(VALUE_int, result.type);
+  ASSERT_EQ_INT(3, result.i);
+  value_free(&result);
+  teardown_runtime();
+}
+
+void test_value_string_concat_helpers(void) {
+  setup_runtime();
+  uint8_t code[64] = {0};
+  size_t pos = 0;
+  code[pos++] = 0;
+  code[pos++] = 0;
+  code[pos++] = 'l'; emit_str(code, &pos, "hello");
+  code[pos++] = 'l'; emit_str(code, &pos, " world");
+  code[pos++] = 'a';
+  code[pos++] = 'h';
+
+  VALUE_t result = run_code("test.value_string_concat", code, pos);
+  ASSERT_EQ_INT(VALUE_str, result.type);
+  ASSERT_TRUE(strcmp(result.s, "hello world") == 0);
+  value_free(&result);
+  teardown_runtime();
+}
+
+void test_value_bool_nil_truthiness_helpers(void) {
+  VALUE_t nil = VALUE_NIL;
+  VALUE_t t = VALUE_TRUE;
+  VALUE_t f = VALUE_FALSE;
+  VALUE_t empty = {VALUE_str, {.s = strdup("")}};
+  VALUE_t text = {VALUE_str, {.s = strdup("x")}};
+
+  ASSERT_TRUE(!value_is_truthy(&nil));
+  ASSERT_TRUE(value_is_truthy(&t));
+  ASSERT_TRUE(!value_is_truthy(&f));
+  ASSERT_TRUE(!value_is_truthy(&empty));
+  ASSERT_TRUE(value_is_truthy(&text));
+
+  value_free(&empty);
+  value_free(&text);
+}
+
+void test_value_string_local_load_store_clones(void) {
+  setup_runtime();
+  uint8_t code[96] = {0};
+  size_t pos = 0;
+  code[pos++] = 1;
+  code[pos++] = 0;
+  code[pos++] = 'l'; emit_str(code, &pos, "foo");
+  code[pos++] = 'c'; code[pos++] = 0;
+  code[pos++] = 'e'; code[pos++] = 0;
+  code[pos++] = 'l'; emit_str(code, &pos, "bar");
+  code[pos++] = 'a';
+  code[pos++] = 'h';
+
+  VALUE_t result = run_code("test.value_local_string_clone", code, pos);
+  ASSERT_EQ_INT(VALUE_str, result.type);
+  ASSERT_TRUE(strcmp(result.s, "foobar") == 0);
+  value_free(&result);
+  teardown_runtime();
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -58,6 +58,10 @@ void test_relative_item_leading_dot_nil_or_empty_non_leading_rejected(void);
 void test_relative_item_leading_dot_boundary_max_name_after_prefix_expansion_compiles(void);
 void test_relative_item_leading_dot_existing_absolute_item_unchanged(void);
 void test_relative_item_leading_dot_parse_still_rejects_bad_double_dot(void);
+void test_value_integer_arithmetic_helpers(void);
+void test_value_string_concat_helpers(void);
+void test_value_bool_nil_truthiness_helpers(void);
+void test_value_string_local_load_store_clones(void);
 
 /* Compiler component tests. */
 void test_emitbc_header(void);
@@ -156,6 +160,10 @@ static const test_case_t core_tests[] = {
     {"test_relative_item_leading_dot_boundary_max_name_after_prefix_expansion_compiles", test_relative_item_leading_dot_boundary_max_name_after_prefix_expansion_compiles},
     {"test_relative_item_leading_dot_existing_absolute_item_unchanged", test_relative_item_leading_dot_existing_absolute_item_unchanged},
     {"test_relative_item_leading_dot_parse_still_rejects_bad_double_dot", test_relative_item_leading_dot_parse_still_rejects_bad_double_dot},
+    {"test_value_integer_arithmetic_helpers", test_value_integer_arithmetic_helpers},
+    {"test_value_string_concat_helpers", test_value_string_concat_helpers},
+    {"test_value_bool_nil_truthiness_helpers", test_value_bool_nil_truthiness_helpers},
+    {"test_value_string_local_load_store_clones", test_value_string_local_load_store_clones},
 };
 
 static const test_case_t compiler_tests[] = {


### PR DESCRIPTION
### Motivation

- Centralize VALUE_t ownership, cleanup, cloning, and comparison logic to reduce ad-hoc string frees and duplicate behavior scattered across the interpreter, itemstore, stack, and libcall code paths.
- Prepare a single well-defined surface for future type additions (e.g. floats) by providing canonical helpers for move/clone/replace, truthiness, equality, ordering, and debug formatting.

### Description

- Add a value helper API in `src/value.h`/`src/value.c` including `value_free`, `value_clone`, `value_move`, `value_replace`, `value_is_type`, `value_type_name`, `value_debug_string`, `value_equal`, and `value_order`, and switch `FREE_STR` to delegate to `value_free`.
- Update the interpreter (`src/interpret.c`) to use the helpers for local save/load (`value_move` / `value_clone`), boolean conversions, arithmetic and comparison error paths (`value_free_runtime`, `value_equal`, `value_order`), and string concatenation cleanup.
- Replace manual string frees and direct `VALUE_t.type` inspections in `src/libcall.c`, `src/item.c`, and `src/stack.c` to use the centralized helpers (`value_free`, `value_replace`, `value_is_type`) to enforce ownership semantics consistently.
- Add focused tests in `tests/core/test_value_behavior.c` and wire them into the test harness and `Makefile` to lock in current semantics for integer arithmetic, string concatenation, bool/nil truthiness, and string ownership across local load/store and stack operations.

### Testing

- Ran the full test suite via `make test` and all tests passed (65/65).
- Added and executed targeted tests in `tests/core/test_value_behavior.c` which exercise integer arithmetic, string concat, truthiness, and local load/store string ownership and passed under the refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f863b74f8832eb7bce090344850fb)