### PR TITLE
Prepare numeric arithmetic helpers

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -162,13 +162,12 @@ static VALUE_t concat_two_strings(VALUE_t left, VALUE_t right) {
   return left;
 }
 
-static inline int binary_int_operands(VALUE_t v1, VALUE_t v2, const char *opcode_name) {
-  int valid = (value_is_type(&v1, VALUE_int) && value_is_type(&v2, VALUE_int));
-  if (!valid) {
-    logerr("%s invalid operand types: left '%s', right '%s'.\n",
-          opcode_name, value_type_name(v2.type), value_type_name(v1.type));
-  }
-  return valid;
+static void log_invalid_binary_operands(const char *opcode_name,
+                                        const VALUE_t *left,
+                                        const VALUE_t *right) {
+  logerr("%s invalid operand types: left '%s', right '%s'.\n",
+         opcode_name, value_type_name(left ? left->type : VALUE_nil),
+         value_type_name(right ? right->type : VALUE_nil));
 }
 
 typedef enum {
@@ -416,12 +415,11 @@ uint8_t *op_add(uint8_t *nextop, ITEM_t *item) {
   VALUE_t v1, v2;
   v1 = pop_stack(VM->stack);
   v2 = pop_stack(VM->stack);
-  // It makes sense to treat nil as 0 in this context.
-  if ((v1.type == VALUE_nil || v1.type == VALUE_int) &&
-                            (v2.type==VALUE_nil || v2.type == VALUE_int)) {
-    v2.i += v1.i;
-    v2.type = VALUE_int;
-    push_stack(VM->stack, v2);
+  VALUE_t result;
+  if (value_add(&v2, &v1, &result)) {
+    value_free_runtime(&v1);
+    value_free_runtime(&v2);
+    push_stack(VM->stack, result);
   } else if (v1.type == VALUE_str && v2.type == VALUE_str) {
     push_stack(VM->stack, concat_two_strings(v2, v1));
   } else {
@@ -444,17 +442,16 @@ uint8_t *op_subtract(uint8_t *nextop, ITEM_t *item) {
   VALUE_t v1, v2;
   v1 = pop_stack(VM->stack);
   v2 = pop_stack(VM->stack);
-  if (binary_int_operands(v1, v2, "OP_SUB")) {
-    v2.i -= v1.i;
-    v2.type = VALUE_int;
+  VALUE_t result;
+  if (value_sub(&v2, &v1, &result)) {
     DISASS_LOG("OP_SUB: operand types %d and %d\n", v2.type, v1.type);
   } else {
+    log_invalid_binary_operands("OP_SUB", &v2, &v1);
     DISASS_LOG("OP_SUB: invalid operand types %d and %d\n", v2.type, v1.type);
-    value_free_runtime(&v1);
-    value_free_runtime(&v2);
-    v2 = VALUE_NIL;
   }
-  push_stack(VM->stack, v2);
+  value_free_runtime(&v1);
+  value_free_runtime(&v2);
+  push_stack(VM->stack, result);
   return nextop;
 }
 
@@ -466,22 +463,19 @@ uint8_t *op_divide(uint8_t *nextop, ITEM_t *item) {
   VALUE_t v1, v2;
   v1 = pop_stack(VM->stack);
   v2 = pop_stack(VM->stack);
-  if (binary_int_operands(v1, v2, "OP_DIV")) {
+  VALUE_t result;
+  if (value_div(&v2, &v1, &result)) {
     if (v1.i == 0) {
       logerr("Attempt to divide by zero.  Substitute zero as result.\n");
-      v2.i = 0;
-    } else {
-      v2.i /= v1.i;
     }
     DISASS_LOG("OP_DIV: operand types %d and %d\n", v2.type, v1.type);
   } else {
+    log_invalid_binary_operands("OP_DIV", &v2, &v1);
     DISASS_LOG("OP_DIV: invalid operand types %d and %d\n", v2.type, v1.type);
-    value_free_runtime(&v1);
-    value_free_runtime(&v2);
-    v2 = VALUE_NIL;
   }
-  v2.type = VALUE_int;
-  push_stack(VM->stack, v2);
+  value_free_runtime(&v1);
+  value_free_runtime(&v2);
+  push_stack(VM->stack, result);
   return nextop;
 }
 
@@ -491,26 +485,23 @@ uint8_t *op_multiply(uint8_t *nextop, ITEM_t *item) {
   VALUE_t v1, v2;
   v1 = pop_stack(VM->stack);
   v2 = pop_stack(VM->stack);
-  if (binary_int_operands(v1, v2, "OP_MUL")) {
-    v2.i *= v1.i;
-    v2.type = VALUE_int;
+  VALUE_t result;
+  if (value_mul(&v2, &v1, &result)) {
     DISASS_LOG("OP_MUL: operand types %d and %d\n", v2.type, v1.type);
   } else {
+    log_invalid_binary_operands("OP_MUL", &v2, &v1);
     DISASS_LOG("OP_MUL: invalid operand types %d and %d\n", v2.type, v1.type);
-    value_free_runtime(&v1);
-    value_free_runtime(&v2);
-    v2 = VALUE_NIL;
   }
-  push_stack(VM->stack, v2);
+  value_free_runtime(&v1);
+  value_free_runtime(&v2);
+  push_stack(VM->stack, result);
   return nextop;
 }
 
 uint8_t *op_negate(uint8_t *nextop, ITEM_t *item) {
   // If the top value on the stack is an int, negate it.
   //  Complain bitterly if not.
-  if (VM->stack->stack[VM->stack->current].type == VALUE_int) {
-    VM->stack->stack[VM->stack->current].i = -VM->stack->stack[VM->stack->current].i;
-  } else {
+  if (!value_neg(&VM->stack->stack[VM->stack->current])) {
     logerr("Attempt to negate a value of type '%d'.\n",
                                  VM->stack->stack[VM->stack->current].type);
   }

--- a/src/value.c
+++ b/src/value.c
@@ -104,6 +104,97 @@ bool value_equal(const VALUE_t *left, const VALUE_t *right) {
   return false;
 }
 
+bool value_is_numeric(const VALUE_t *value) {
+  return value_numeric_kind(value) != VALUE_NUMERIC_NONE;
+}
+
+VALUE_numeric_kind_e value_numeric_kind(const VALUE_t *value) {
+  if (!value) return VALUE_NUMERIC_NONE;
+  switch (value->type) {
+    case VALUE_int:
+      return VALUE_NUMERIC_INT;
+    default:
+      return VALUE_NUMERIC_NONE;
+  }
+}
+
+static bool value_as_add_int_operand(const VALUE_t *value, int64_t *out) {
+  if (!value || !out) return false;
+  if (value->type == VALUE_nil) {
+    *out = 0;
+    return true;
+  }
+  if (value->type == VALUE_int) {
+    *out = value->i;
+    return true;
+  }
+  return false;
+}
+
+static bool value_as_int_operand(const VALUE_t *value, int64_t *out) {
+  if (!value || !out || value->type != VALUE_int) return false;
+  *out = value->i;
+  return true;
+}
+
+bool value_add(const VALUE_t *left, const VALUE_t *right, VALUE_t *result) {
+  int64_t lhs;
+  int64_t rhs;
+  if (!result || !value_as_add_int_operand(left, &lhs) ||
+      !value_as_add_int_operand(right, &rhs)) {
+    if (result) *result = VALUE_NIL;
+    return false;
+  }
+  result->type = VALUE_int;
+  result->i = lhs + rhs;
+  return true;
+}
+
+bool value_sub(const VALUE_t *left, const VALUE_t *right, VALUE_t *result) {
+  int64_t lhs;
+  int64_t rhs;
+  if (!result || !value_as_int_operand(left, &lhs) ||
+      !value_as_int_operand(right, &rhs)) {
+    if (result) *result = VALUE_NIL;
+    return false;
+  }
+  result->type = VALUE_int;
+  result->i = lhs - rhs;
+  return true;
+}
+
+bool value_mul(const VALUE_t *left, const VALUE_t *right, VALUE_t *result) {
+  int64_t lhs;
+  int64_t rhs;
+  if (!result || !value_as_int_operand(left, &lhs) ||
+      !value_as_int_operand(right, &rhs)) {
+    if (result) *result = VALUE_NIL;
+    return false;
+  }
+  result->type = VALUE_int;
+  result->i = lhs * rhs;
+  return true;
+}
+
+bool value_div(const VALUE_t *left, const VALUE_t *right, VALUE_t *result) {
+  int64_t lhs;
+  int64_t rhs;
+  if (!result) return false;
+  if (!value_as_int_operand(left, &lhs) || !value_as_int_operand(right, &rhs)) {
+    *result = VALUE_ZERO;
+    return false;
+  }
+  result->type = VALUE_int;
+  result->i = rhs == 0 ? 0 : lhs / rhs;
+  return true;
+}
+
+bool value_neg(VALUE_t *value) {
+  if (!value || value->type != VALUE_int) return false;
+  value->i = -value->i;
+  return true;
+}
+
 bool value_order(const VALUE_t *left, const VALUE_t *right, int *comparison) {
   if (!left || !right || left->type != right->type) return false;
   switch (left->type) {

--- a/src/value.h
+++ b/src/value.h
@@ -14,6 +14,10 @@ typedef enum { VALUE_int,
                VALUE_bool
              } VALUE_e;
 
+typedef enum { VALUE_NUMERIC_NONE,
+               VALUE_NUMERIC_INT
+             } VALUE_numeric_kind_e;
+
 typedef struct {
   VALUE_e type; // What sort of value am I?
   union {
@@ -55,4 +59,15 @@ VALUE_t value_clone(const VALUE_t *value);
 void value_move(VALUE_t *dst, VALUE_t *src);
 void value_replace(VALUE_t *dst, VALUE_t src);
 bool value_equal(const VALUE_t *left, const VALUE_t *right);
+bool value_is_numeric(const VALUE_t *value);
+VALUE_numeric_kind_e value_numeric_kind(const VALUE_t *value);
+// Arithmetic helpers currently support integer arithmetic only. OP_ADD
+// intentionally preserves the VM quirk that nil participates as integer 0;
+// the other arithmetic operators require int operands until more numeric
+// kinds are added. value_div preserves the VM invalid-operand result of int 0.
+bool value_add(const VALUE_t *left, const VALUE_t *right, VALUE_t *result);
+bool value_sub(const VALUE_t *left, const VALUE_t *right, VALUE_t *result);
+bool value_mul(const VALUE_t *left, const VALUE_t *right, VALUE_t *result);
+bool value_div(const VALUE_t *left, const VALUE_t *right, VALUE_t *result);
+bool value_neg(VALUE_t *value);
 bool value_order(const VALUE_t *left, const VALUE_t *right, int *comparison);

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -48,6 +48,24 @@ static VALUE_t run_code(const char *name, const uint8_t *template_code, size_t l
 }
 
 void test_value_integer_arithmetic_helpers(void) {
+  VALUE_t left = {VALUE_int, {.i = 9}};
+  VALUE_t right = {VALUE_int, {.i = 4}};
+  VALUE_t result = VALUE_NIL;
+
+  ASSERT_TRUE(value_is_numeric(&left));
+  ASSERT_EQ_INT(VALUE_NUMERIC_INT, value_numeric_kind(&left));
+  ASSERT_TRUE(value_add(&left, &right, &result));
+  ASSERT_EQ_INT(VALUE_int, result.type);
+  ASSERT_EQ_INT(13, result.i);
+  ASSERT_TRUE(value_sub(&left, &right, &result));
+  ASSERT_EQ_INT(5, result.i);
+  ASSERT_TRUE(value_mul(&left, &right, &result));
+  ASSERT_EQ_INT(36, result.i);
+  ASSERT_TRUE(value_div(&left, &right, &result));
+  ASSERT_EQ_INT(2, result.i);
+  ASSERT_TRUE(value_neg(&result));
+  ASSERT_EQ_INT(-2, result.i);
+
   setup_runtime();
   uint8_t code[64] = {0};
   size_t pos = 0;
@@ -62,11 +80,43 @@ void test_value_integer_arithmetic_helpers(void) {
   code[pos++] = 'd';
   code[pos++] = 'h';
 
-  VALUE_t result = run_code("test.value_int_arithmetic", code, pos);
+  result = run_code("test.value_int_arithmetic", code, pos);
   ASSERT_EQ_INT(VALUE_int, result.type);
   ASSERT_EQ_INT(3, result.i);
   value_free(&result);
   teardown_runtime();
+}
+
+void test_value_arithmetic_invalid_and_nil_operands(void) {
+  VALUE_t int_value = {VALUE_int, {.i = 7}};
+  VALUE_t nil_value = VALUE_NIL;
+  VALUE_t str_value = {VALUE_str, {.s = strdup("x")}};
+  VALUE_t bool_value = VALUE_TRUE;
+  VALUE_t result = VALUE_NIL;
+
+  ASSERT_TRUE(!value_is_numeric(&nil_value));
+  ASSERT_EQ_INT(VALUE_NUMERIC_NONE, value_numeric_kind(&str_value));
+
+  ASSERT_TRUE(value_add(&nil_value, &int_value, &result));
+  ASSERT_EQ_INT(VALUE_int, result.type);
+  ASSERT_EQ_INT(7, result.i);
+  ASSERT_TRUE(value_add(&nil_value, &nil_value, &result));
+  ASSERT_EQ_INT(0, result.i);
+
+  ASSERT_TRUE(!value_add(&str_value, &int_value, &result));
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  ASSERT_TRUE(!value_sub(&nil_value, &int_value, &result));
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  ASSERT_TRUE(!value_mul(&str_value, &int_value, &result));
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  ASSERT_TRUE(!value_div(&str_value, &int_value, &result));
+  ASSERT_EQ_INT(VALUE_int, result.type);
+  ASSERT_EQ_INT(0, result.i);
+  ASSERT_TRUE(!value_neg(&bool_value));
+  ASSERT_EQ_INT(VALUE_bool, bool_value.type);
+  ASSERT_EQ_INT(1, bool_value.i);
+
+  value_free(&str_value);
 }
 
 void test_value_string_concat_helpers(void) {

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -59,6 +59,7 @@ void test_relative_item_leading_dot_boundary_max_name_after_prefix_expansion_com
 void test_relative_item_leading_dot_existing_absolute_item_unchanged(void);
 void test_relative_item_leading_dot_parse_still_rejects_bad_double_dot(void);
 void test_value_integer_arithmetic_helpers(void);
+void test_value_arithmetic_invalid_and_nil_operands(void);
 void test_value_string_concat_helpers(void);
 void test_value_bool_nil_truthiness_helpers(void);
 void test_value_string_local_load_store_clones(void);
@@ -161,6 +162,7 @@ static const test_case_t core_tests[] = {
     {"test_relative_item_leading_dot_existing_absolute_item_unchanged", test_relative_item_leading_dot_existing_absolute_item_unchanged},
     {"test_relative_item_leading_dot_parse_still_rejects_bad_double_dot", test_relative_item_leading_dot_parse_still_rejects_bad_double_dot},
     {"test_value_integer_arithmetic_helpers", test_value_integer_arithmetic_helpers},
+    {"test_value_arithmetic_invalid_and_nil_operands", test_value_arithmetic_invalid_and_nil_operands},
     {"test_value_string_concat_helpers", test_value_string_concat_helpers},
     {"test_value_bool_nil_truthiness_helpers", test_value_bool_nil_truthiness_helpers},
     {"test_value_string_local_load_store_clones", test_value_string_local_load_store_clones},


### PR DESCRIPTION
### Motivation
- Introduce a small numeric abstraction and centralize arithmetic logic so different numeric kinds (e.g. floats later) can be added without scattering integer-only rules across the VM. 
- Preserve the current runtime behavior: `OP_ADD` continues to treat `nil` as integer `0`, while other arithmetic ops remain int-only until more numeric kinds are introduced. 
- Keep string concatenation as a VM-level special case for `+` rather than changing its semantics.

### Description
- Added `VALUE_numeric_kind_e` and new declarations in `src/value.h` including `value_is_numeric`, `value_numeric_kind`, `value_add`, `value_sub`, `value_mul`, `value_div`, and `value_neg`.
- Implemented the helpers in `src/value.c` with integer-only semantics: `value_add` accepts `nil` as `0` (preserving the VM quirk), `value_sub/mul`/`value_neg` require `int` operands, and `value_div` preserves the previous divide-by-zero/invalid-operand behavior (returns `0` on invalid/zero-divide as before).
- Updated interpreter arithmetic to delegate to the new helpers in `src/interpret.c` for `op_add`, `op_subtract`, `op_multiply`, `op_divide`, and `op_negate`, while keeping string concatenation in `op_add` as the VM-level special case; added `log_invalid_binary_operands` to unify error logging.
- Added regression tests in `tests/core/test_value_behavior.c` and registered the new test in `tests/shared/test_compiler.c` to cover integer arithmetic, invalid/mixed operands, `nil`-as-zero addition, negation failures, and string concatenation.

### Testing
- Built and ran the full test suite with `make test` which compiled the code and executed the test harness; all automated tests passed (`66/66`).
- New/modified tests include the arithmetic helper unit checks and bytecode execution coverage in `tests/core/test_value_behavior.c`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f88a605d4832eb4ad5b316e6df9a7)