### PR TITLE
Add value comparison helpers and integrate into interpreter

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -179,53 +179,43 @@ typedef enum {
   CMP_GTE,
 } CMP_MODE_t;
 
-static inline int apply_comparison(CMP_MODE_t mode, int64_t left, int64_t right) {
-  switch (mode) {
-    case CMP_EQ:
-      return left == right;
-    case CMP_NE:
-      return left != right;
-    case CMP_LT:
-      return left < right;
-    case CMP_LTE:
-      return left <= right;
-    case CMP_GT:
-      return left > right;
-    case CMP_GTE:
-      return left >= right;
-  }
-  return 0;
-}
-
 static inline int pop_compare_and_push_bool(VM_t *vm, CMP_MODE_t mode, const char *opcode_tag) {
   VALUE_t v1 = pop_stack(VM->stack);
   VALUE_t v2 = pop_stack(VM->stack);
-  VALUE_t result;
-  int comparison_true = 0;
+  VALUE_t result = {VALUE_bool, {.i = 0}};
+  VALUE_e v1_type = v1.type;
+  VALUE_e v2_type = v2.type;
+  (void)v1_type;
+  (void)v2_type;
 
-  result.type = VALUE_bool;
-
-  // Intentional quirk preserved: OP_NOTEQUAL treats mismatched types as true,
-  // while the other comparison operators treat unsupported/mismatched operands
-  // as false.
-  if (mode == CMP_EQ || mode == CMP_NE) {
-    comparison_true = value_equal(&v2, &v1);
-    if (mode == CMP_NE) comparison_true = !comparison_true;
-  } else {
-    int cmp = 0;
-    if (value_order(&v2, &v1, &cmp)) {
-      comparison_true = apply_comparison(mode, cmp, 0);
-    }
+  switch (mode) {
+    case CMP_EQ:
+      result.i = value_equal(&v2, &v1);
+      break;
+    case CMP_NE:
+      result.i = value_not_equal(&v2, &v1);
+      break;
+    case CMP_LT:
+      result.i = value_less_than(&v2, &v1);
+      break;
+    case CMP_LTE:
+      result.i = value_less_equal(&v2, &v1);
+      break;
+    case CMP_GT:
+      result.i = value_greater_than(&v2, &v1);
+      break;
+    case CMP_GTE:
+      result.i = value_greater_equal(&v2, &v1);
+      break;
   }
 
-  result.i = comparison_true;
   value_free_runtime(&v1);
   value_free_runtime(&v2);
   push_stack(VM->stack, result);
-  if (!comparison_true) {
-    DISASS_LOG("%s: types %d and %d\n", opcode_tag, v1.type, v2.type);
+  if (!result.i) {
+    DISASS_LOG("%s: types %d and %d\n", opcode_tag, v1_type, v2_type);
   }
-  return comparison_true;
+  return result.i;
 }
 
 

--- a/src/value.c
+++ b/src/value.c
@@ -104,6 +104,39 @@ bool value_equal(const VALUE_t *left, const VALUE_t *right) {
   return false;
 }
 
+bool value_not_equal(const VALUE_t *left, const VALUE_t *right) {
+  // Preserve the VM quirk: mismatched types are not equal, so != is true.
+  return !value_equal(left, right);
+}
+
+static bool value_order_matches(const VALUE_t *left, const VALUE_t *right,
+                                bool (*predicate)(int comparison)) {
+  int comparison = 0;
+  if (!predicate || !value_order(left, right, &comparison)) return false;
+  return predicate(comparison);
+}
+
+static bool comparison_lt(int comparison) { return comparison < 0; }
+static bool comparison_lte(int comparison) { return comparison <= 0; }
+static bool comparison_gt(int comparison) { return comparison > 0; }
+static bool comparison_gte(int comparison) { return comparison >= 0; }
+
+bool value_less_than(const VALUE_t *left, const VALUE_t *right) {
+  return value_order_matches(left, right, comparison_lt);
+}
+
+bool value_less_equal(const VALUE_t *left, const VALUE_t *right) {
+  return value_order_matches(left, right, comparison_lte);
+}
+
+bool value_greater_than(const VALUE_t *left, const VALUE_t *right) {
+  return value_order_matches(left, right, comparison_gt);
+}
+
+bool value_greater_equal(const VALUE_t *left, const VALUE_t *right) {
+  return value_order_matches(left, right, comparison_gte);
+}
+
 bool value_is_numeric(const VALUE_t *value) {
   return value_numeric_kind(value) != VALUE_NUMERIC_NONE;
 }

--- a/src/value.h
+++ b/src/value.h
@@ -59,6 +59,11 @@ VALUE_t value_clone(const VALUE_t *value);
 void value_move(VALUE_t *dst, VALUE_t *src);
 void value_replace(VALUE_t *dst, VALUE_t src);
 bool value_equal(const VALUE_t *left, const VALUE_t *right);
+bool value_not_equal(const VALUE_t *left, const VALUE_t *right);
+bool value_less_than(const VALUE_t *left, const VALUE_t *right);
+bool value_less_equal(const VALUE_t *left, const VALUE_t *right);
+bool value_greater_than(const VALUE_t *left, const VALUE_t *right);
+bool value_greater_equal(const VALUE_t *left, const VALUE_t *right);
 bool value_is_numeric(const VALUE_t *value);
 VALUE_numeric_kind_e value_numeric_kind(const VALUE_t *value);
 // Arithmetic helpers currently support integer arithmetic only. OP_ADD

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -173,3 +173,76 @@ void test_value_string_local_load_store_clones(void) {
   value_free(&result);
   teardown_runtime();
 }
+
+void test_value_comparison_int_helpers(void) {
+  VALUE_t four = {VALUE_int, {.i = 4}};
+  VALUE_t also_four = {VALUE_int, {.i = 4}};
+  VALUE_t nine = {VALUE_int, {.i = 9}};
+
+  ASSERT_TRUE(value_equal(&four, &also_four));
+  ASSERT_TRUE(!value_not_equal(&four, &also_four));
+  ASSERT_TRUE(value_not_equal(&four, &nine));
+  ASSERT_TRUE(value_less_than(&four, &nine));
+  ASSERT_TRUE(value_less_equal(&four, &also_four));
+  ASSERT_TRUE(value_greater_than(&nine, &four));
+  ASSERT_TRUE(value_greater_equal(&also_four, &four));
+  ASSERT_TRUE(!value_less_than(&nine, &four));
+}
+
+void test_value_comparison_bool_helpers(void) {
+  VALUE_t false_value = VALUE_FALSE;
+  VALUE_t true_value = VALUE_TRUE;
+  VALUE_t another_true = VALUE_TRUE;
+
+  ASSERT_TRUE(value_equal(&true_value, &another_true));
+  ASSERT_TRUE(value_not_equal(&false_value, &true_value));
+  ASSERT_TRUE(value_less_than(&false_value, &true_value));
+  ASSERT_TRUE(value_less_equal(&true_value, &another_true));
+  ASSERT_TRUE(value_greater_than(&true_value, &false_value));
+  ASSERT_TRUE(value_greater_equal(&another_true, &true_value));
+}
+
+void test_value_comparison_string_helpers(void) {
+  VALUE_t left = {VALUE_str, {.s = strdup("same")}};
+  VALUE_t same = {VALUE_str, {.s = strdup("same")}};
+  VALUE_t different = {VALUE_str, {.s = strdup("different")}};
+
+  ASSERT_TRUE(value_equal(&left, &same));
+  ASSERT_TRUE(!value_not_equal(&left, &same));
+  ASSERT_TRUE(value_not_equal(&left, &different));
+
+  value_free(&left);
+  value_free(&same);
+  value_free(&different);
+}
+
+void test_value_comparison_mismatched_type_equality_quirk(void) {
+  VALUE_t int_value = {VALUE_int, {.i = 1}};
+  VALUE_t bool_value = VALUE_TRUE;
+  VALUE_t nil_value = VALUE_NIL;
+  VALUE_t str_value = {VALUE_str, {.s = strdup("1")}};
+
+  ASSERT_TRUE(!value_equal(&int_value, &bool_value));
+  ASSERT_TRUE(value_not_equal(&int_value, &bool_value));
+  ASSERT_TRUE(!value_equal(&nil_value, &str_value));
+  ASSERT_TRUE(value_not_equal(&nil_value, &str_value));
+
+  value_free(&str_value);
+}
+
+void test_value_comparison_unsupported_ordering_is_false(void) {
+  VALUE_t left = {VALUE_str, {.s = strdup("a")}};
+  VALUE_t right = {VALUE_str, {.s = strdup("b")}};
+  VALUE_t int_value = {VALUE_int, {.i = 1}};
+  VALUE_t nil_value = VALUE_NIL;
+
+  ASSERT_TRUE(!value_less_than(&left, &right));
+  ASSERT_TRUE(!value_less_equal(&left, &right));
+  ASSERT_TRUE(!value_greater_than(&left, &right));
+  ASSERT_TRUE(!value_greater_equal(&left, &right));
+  ASSERT_TRUE(!value_less_than(&int_value, &nil_value));
+  ASSERT_TRUE(!value_greater_equal(&nil_value, &int_value));
+
+  value_free(&left);
+  value_free(&right);
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -63,6 +63,11 @@ void test_value_arithmetic_invalid_and_nil_operands(void);
 void test_value_string_concat_helpers(void);
 void test_value_bool_nil_truthiness_helpers(void);
 void test_value_string_local_load_store_clones(void);
+void test_value_comparison_int_helpers(void);
+void test_value_comparison_bool_helpers(void);
+void test_value_comparison_string_helpers(void);
+void test_value_comparison_mismatched_type_equality_quirk(void);
+void test_value_comparison_unsupported_ordering_is_false(void);
 
 /* Compiler component tests. */
 void test_emitbc_header(void);
@@ -166,6 +171,11 @@ static const test_case_t core_tests[] = {
     {"test_value_string_concat_helpers", test_value_string_concat_helpers},
     {"test_value_bool_nil_truthiness_helpers", test_value_bool_nil_truthiness_helpers},
     {"test_value_string_local_load_store_clones", test_value_string_local_load_store_clones},
+    {"test_value_comparison_int_helpers", test_value_comparison_int_helpers},
+    {"test_value_comparison_bool_helpers", test_value_comparison_bool_helpers},
+    {"test_value_comparison_string_helpers", test_value_comparison_string_helpers},
+    {"test_value_comparison_mismatched_type_equality_quirk", test_value_comparison_mismatched_type_equality_quirk},
+    {"test_value_comparison_unsupported_ordering_is_false", test_value_comparison_unsupported_ordering_is_false},
 };
 
 static const test_case_t compiler_tests[] = {


### PR DESCRIPTION
### Motivation
- Centralize comparison logic so ordered and equality semantics live in `src/value.*` instead of inline interpreter code.
- Preserve the VM compatibility quirk that `!=` on mismatched types evaluates true while unsupported ordered comparisons evaluate false.
- Make interpreter comparison handling simpler and safer by delegating to a single comparison layer.

### Description
- Added comparison API declarations in `src/value.h`: `value_not_equal`, `value_less_than`, `value_less_equal`, `value_greater_than`, and `value_greater_equal` in addition to the existing `value_equal`.
- Implemented the new helpers in `src/value.c` and factored ordered-comparison logic to use `value_order`, preserving existing mismatch/unsupported ordering behavior.
- Reworked `pop_compare_and_push_bool` in `src/interpret.c` to pop operands, call the appropriate `value_*` helper, free popped operands as needed, push a `VALUE_bool` result, and log types on false results.
- Added regression tests in `tests/core/test_value_behavior.c` and registered them in `tests/shared/test_compiler.c` covering int, bool, string equality/ordering, mismatched-type equality/inequality, and unsupported ordered comparisons.

### Testing
- Ran the full test suite with `make test`, which built the test binary and executed the test harness; all tests passed (`71/71`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fa00e8d44832ebb700c9425359a78)