### PR TITLE
Prepare fixed-width bytecode immediate helpers

### DIFF
--- a/docs/bytecode.md
+++ b/docs/bytecode.md
@@ -23,9 +23,15 @@ execution at byte offset 2.
 ## Encoding conventions
 
 Unless an opcode description says otherwise, numeric immediates are written in
-the platform representation used by the C emitter and interpreter (`memcpy` for
-multi-byte values). Current encodings are therefore little-endian on supported
-little-endian builds.
+the platform representation used by the C emitter and interpreter. The compiler
+centralizes fixed-width writes through helpers for `uint8_t`, `uint16_t`,
+`int16_t`, `int64_t`, and raw `uint64_t` payloads; the interpreter uses matching
+fixed-width read helpers. Multi-byte helpers copy bytes with `memcpy` rather
+than pointer casts, so unaligned instruction streams are safe while preserving
+the existing byte-for-byte format. Current encodings are therefore little-endian
+on supported little-endian builds, and persisted bytecode is portable only across
+platforms with the same integer widths, two's-complement signed representation,
+and byte order assumptions.
 
 * **Opcode bytes** are single-byte character symbols. For example, `p` is
   `IR_OP_PUSH_INT` and `h` is `IR_OP_HALT`.
@@ -34,7 +40,9 @@ little-endian builds.
 * **Two-byte immediates** (`u16` or signed `i16`) follow the opcode directly.
   Strings and embedded source blocks use unsigned 16-bit lengths. Jumps use a
   signed 16-bit relative offset.
-* **Eight-byte immediates** (`i64`) are used by `p` / `IR_OP_PUSH_INT`.
+* **Eight-byte immediates** (`i64`) are used by `p` / `IR_OP_PUSH_INT`. Raw
+  `uint64_t` payload helpers are reserved for future eight-byte payloads such as
+  binary64 bit patterns and intentionally do not imply numeric conversion.
 * **Strings** are encoded as a 16-bit unsigned byte length followed by exactly
   that many bytes. A trailing NUL is not stored in bytecode.
 * **Jumps** (`j`, `k`) encode a signed 16-bit offset measured from the first

--- a/src/compiler/emitbc.c
+++ b/src/compiler/emitbc.c
@@ -46,18 +46,30 @@ static int bw_write_u8(BC_Writer *w, uint8_t v) {
   return 1;
 }
 static int bw_write_u16(BC_Writer *w, uint16_t v) {
-  if (!bw_ensure(w, 2)) return 0;
-  memcpy(w->out->nextbyte, &v, 2);
-  w->out->nextbyte += 2;
-  w->used += 2;
+  if (!bw_ensure(w, sizeof(v))) return 0;
+  memcpy(w->out->nextbyte, &v, sizeof(v));
+  w->out->nextbyte += sizeof(v);
+  w->used += sizeof(v);
+  return 1;
+}
+static int bw_write_i16(BC_Writer *w, int16_t v) {
+  if (!bw_ensure(w, sizeof(v))) return 0;
+  memcpy(w->out->nextbyte, &v, sizeof(v));
+  w->out->nextbyte += sizeof(v);
+  w->used += sizeof(v);
+  return 1;
+}
+static int bw_write_u64_payload(BC_Writer *w, uint64_t v) {
+  if (!bw_ensure(w, sizeof(v))) return 0;
+  memcpy(w->out->nextbyte, &v, sizeof(v));
+  w->out->nextbyte += sizeof(v);
+  w->used += sizeof(v);
   return 1;
 }
 static int bw_write_i64(BC_Writer *w, int64_t v) {
-  if (!bw_ensure(w, 8)) return 0;
-  memcpy(w->out->nextbyte, &v, 8);
-  w->out->nextbyte += 8;
-  w->used += 8;
-  return 1;
+  uint64_t payload;
+  memcpy(&payload, &v, sizeof(payload));
+  return bw_write_u64_payload(w, payload);
 }
 static int bw_write_bytes(BC_Writer *w, const void *src, size_t n) {
   if (!bw_ensure(w, n)) return 0;
@@ -216,7 +228,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
           compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "jump offset out of range: %ld", diff);
           return errnum;
         }
-        if (!bw_write_u16(&w, (uint16_t)(int16_t)diff)) goto oom;
+        if (!bw_write_i16(&w, (int16_t)diff)) goto oom;
         break;
       }
       case IR_OP_ITEM_PUSH_LAYER: {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -47,6 +47,38 @@ static inline bool require_bytes(uint8_t *nextop, size_t bytes, const char *opna
 #define REQUIRE_BYTES(nextop, n, opname) \
   do { if (!require_bytes((nextop), (n), (opname))) return NULL; } while (0)
 
+static uint8_t *bc_read_u8(uint8_t *nextop, uint8_t *out, const char *opname) {
+  REQUIRE_BYTES(nextop, sizeof(*out), opname);
+  memcpy(out, nextop, sizeof(*out));
+  return nextop + sizeof(*out);
+}
+
+static uint8_t *bc_read_u16(uint8_t *nextop, uint16_t *out, const char *opname) {
+  REQUIRE_BYTES(nextop, sizeof(*out), opname);
+  memcpy(out, nextop, sizeof(*out));
+  return nextop + sizeof(*out);
+}
+
+static uint8_t *bc_read_i16(uint8_t *nextop, int16_t *out, const char *opname) {
+  REQUIRE_BYTES(nextop, sizeof(*out), opname);
+  memcpy(out, nextop, sizeof(*out));
+  return nextop + sizeof(*out);
+}
+
+static uint8_t *bc_read_u64_payload(uint8_t *nextop, uint64_t *out, const char *opname) {
+  REQUIRE_BYTES(nextop, sizeof(*out), opname);
+  memcpy(out, nextop, sizeof(*out));
+  return nextop + sizeof(*out);
+}
+
+static uint8_t *bc_read_i64(uint8_t *nextop, int64_t *out, const char *opname) {
+  uint64_t payload;
+  uint8_t *after = bc_read_u64_payload(nextop, &payload, opname);
+  if (!after) return NULL;
+  memcpy(out, &payload, sizeof(*out));
+  return after;
+}
+
 static OP_t opcode[256];
 static bool interpreter_initialized = false;
 uint8_t *op_undefined(uint8_t *nextop, ITEM_t *item);
@@ -267,23 +299,25 @@ uint8_t *op_undefined(uint8_t *nextop, ITEM_t *item) {
 uint8_t *op_pushint(uint8_t *nextop, ITEM_t *item) {
   // Push an int64 onto the stack.
   // Read the next 8 bytes and make an VALUE_t
-  REQUIRE_BYTES(nextop, 8, "OP_PUSHINT");
   VALUE_t v;
   v.type = VALUE_int;
-  v.i = *(int64_t*)nextop;
+  nextop = bc_read_i64(nextop, &v.i, "OP_PUSHINT");
+  if (!nextop) return NULL;
   push_stack(VM->stack, v);
   DISASS_LOG("OP_PUSHINT: %ld\n", v.i);
-  return nextop+8;
+  return nextop;
 }
 
 uint8_t *op_pushbool(uint8_t *nextop, ITEM_t *item) {
-  REQUIRE_BYTES(nextop, 1, "OP_PUSHBOOL");
+  uint8_t raw;
+  nextop = bc_read_u8(nextop, &raw, "OP_PUSHBOOL");
+  if (!nextop) return NULL;
   VALUE_t v;
   v.type = VALUE_bool;
-  v.i = (*nextop != 0) ? 1 : 0;
+  v.i = (raw != 0) ? 1 : 0;
   push_stack(VM->stack, v);
   DISASS_LOG("OP_PUSHBOOL: %ld\n", v.i);
-  return nextop + 1;
+  return nextop;
 }
 
 uint8_t *op_inclocal(uint8_t *nextop, ITEM_t *item) {
@@ -315,11 +349,11 @@ uint8_t *op_declocal(uint8_t *nextop, ITEM_t *item) {
 uint8_t *op_jump(uint8_t *nextop, ITEM_t *item) {
   // Unconditional jump.  Interpret the next two bytes as a
   // SIGNED int, and then modify the bytecode pointer by that amount.
-  REQUIRE_BYTES(nextop, 2, "OP_JUMP");
   int16_t offset;
-  memcpy(&offset, nextop, 2);
+  nextop = bc_read_i16(nextop, &offset, "OP_JUMP");
+  if (!nextop) return NULL;
   DISASS_LOG("OP_JUMP: offset is  %d.\n", offset);
-  return nextop + offset;
+  return nextop - sizeof(offset) + offset;
 }
 
 uint8_t *op_jumpfalse(uint8_t *nextop, ITEM_t *item) {
@@ -328,7 +362,10 @@ uint8_t *op_jumpfalse(uint8_t *nextop, ITEM_t *item) {
   // by that amount.  Alternatively, if true, simply skip the next
   // two bytes and go on to the next instruction.
 
-  REQUIRE_BYTES(nextop, 2, "OP_JUMPFALSE");
+  int16_t offset;
+  uint8_t *offset_start = nextop;
+  nextop = bc_read_i16(nextop, &offset, "OP_JUMPFALSE");
+  if (!nextop) return NULL;
   VALUE_t v1;
   v1 = pop_stack(VM->stack);
   if (value_is_truthy(&v1)) {
@@ -336,13 +373,11 @@ uint8_t *op_jumpfalse(uint8_t *nextop, ITEM_t *item) {
     // the next two bytes.
     DISASS_LOG("OP_JUMPFALSE: evaluates to true (no jump).\n");
     value_free(&v1);
-    return nextop + 2;
+    return nextop;
   } else {
     // If not true then it must be false.  That's logic.
-    int16_t offset;
-    memcpy(&offset, nextop, 2);
     DISASS_LOG("OP_JUMPFALSE: evaluates to false (jump offset %d).\n", offset);
-    return nextop + offset;
+    return offset_start + offset;
   }
 }
 
@@ -384,11 +419,10 @@ uint8_t *op_pushstr(uint8_t *nextop, ITEM_t *item) {
   // Push a string literal onto the stack.
   VALUE_t v;
   v.type = VALUE_str;
-  REQUIRE_BYTES(nextop, 2, "OP_PUSHSTR length");
   uint16_t len;
   // Get the length
-  memcpy(&len, nextop, 2);
-  nextop += 2;
+  nextop = bc_read_u16(nextop, &len, "OP_PUSHSTR length");
+  if (!nextop) return NULL;
   REQUIRE_BYTES(nextop, len, "OP_PUSHSTR payload");
   v.s = GROW_ARRAY(char, NULL, 0, len+1);
   memcpy(v.s, nextop, len);
@@ -848,10 +882,9 @@ uint8_t *op_fetchitem(uint8_t *nextop, ITEM_t *item) {
   // If the item does not exist, nil is pushed onto the stack.
 
   // First, let's get the number of arguments passed to this item
-  REQUIRE_BYTES(nextop, 2, "OP_FETCHITEM arg-count");
   uint16_t arg_count;
-  memcpy(&arg_count, nextop, 2);
-  nextop += 2;
+  nextop = bc_read_u16(nextop, &arg_count, "OP_FETCHITEM arg-count");
+  if (!nextop) return NULL;
 
   // Now the item name.
   VALUE_t itemname = pop_stack(VM->stack);

--- a/tests/compiler/test_emitbc_opcode_map.c
+++ b/tests/compiler/test_emitbc_opcode_map.c
@@ -120,6 +120,47 @@ void test_emitbc_opcode_map(void) {
 }
 
 
+
+void test_emitbc_push_int_immediate_layout(void) {
+  const int64_t values[] = {
+      0,
+      42,
+      -1,
+      INT64_C(0x0102030405060708),
+      INT64_C(-9223372036854775807) - INT64_C(1),
+  };
+
+  IR_Unit *unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+  for (size_t i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+    t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = values[i]});
+  }
+
+  OUTPUT_t out = {0};
+  out.maxsize = 8;
+  out.bytecode = malloc(out.maxsize);
+  out.nextbyte = out.bytecode;
+  ASSERT_NOT_NULL(out.bytecode);
+
+  char *errdetail = NULL;
+  int8_t rc = t_emit_bytecode(unit, 0, 0, &out, &errdetail);
+  ASSERT_EQ_INT(0, rc);
+  ASSERT_TRUE(errdetail == NULL);
+
+  size_t pos = 2;
+  for (size_t i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+    uint8_t expected[sizeof(values[i])];
+    memcpy(expected, &values[i], sizeof(expected));
+    ASSERT_EQ_INT('p', out.bytecode[pos++]);
+    ASSERT_TRUE(memcmp(out.bytecode + pos, expected, sizeof(expected)) == 0);
+    pos += sizeof(expected);
+  }
+  ASSERT_EQ_INT((int)pos, (int)(out.nextbyte - out.bytecode));
+
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+}
+
 void test_emitbc_opcode_map_call_item_deref_alias_layout(void) {
   IR_Unit *unit = t_new_unit();
   ASSERT_NOT_NULL(unit);

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -87,6 +87,26 @@ void test_value_integer_arithmetic_helpers(void) {
   teardown_runtime();
 }
 
+
+void test_value_push_int_interprets_i64_immediates(void) {
+  setup_runtime();
+
+  const int64_t expected = INT64_C(-0x010203040506070);
+  uint8_t code[16] = {0};
+  size_t pos = 0;
+  code[pos++] = 0;
+  code[pos++] = 0;
+  code[pos++] = 'p';
+  emit_i64(code, &pos, expected);
+  code[pos++] = 'h';
+
+  VALUE_t result = run_code("test.value_push_int_i64", code, pos);
+  ASSERT_EQ_INT(VALUE_int, result.type);
+  ASSERT_TRUE(result.i == expected);
+  value_free(&result);
+  teardown_runtime();
+}
+
 void test_value_arithmetic_invalid_and_nil_operands(void) {
   VALUE_t int_value = {VALUE_int, {.i = 7}};
   VALUE_t nil_value = VALUE_NIL;

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -60,6 +60,7 @@ void test_relative_item_leading_dot_existing_absolute_item_unchanged(void);
 void test_relative_item_leading_dot_parse_still_rejects_bad_double_dot(void);
 void test_value_integer_arithmetic_helpers(void);
 void test_value_arithmetic_invalid_and_nil_operands(void);
+void test_value_push_int_interprets_i64_immediates(void);
 void test_value_string_concat_helpers(void);
 void test_value_bool_nil_truthiness_helpers(void);
 void test_value_string_local_load_store_clones(void);
@@ -72,6 +73,7 @@ void test_value_comparison_unsupported_ordering_is_false(void);
 /* Compiler component tests. */
 void test_emitbc_header(void);
 void test_emitbc_opcode_map(void);
+void test_emitbc_push_int_immediate_layout(void);
 void test_emitbc_opcode_map_unsupported_ir_op(void);
 void test_emitbc_opcode_map_call_item_deref_alias_layout(void);
 void test_emitbc_all_ir_ops_accounted_for(void);
@@ -168,6 +170,7 @@ static const test_case_t core_tests[] = {
     {"test_relative_item_leading_dot_parse_still_rejects_bad_double_dot", test_relative_item_leading_dot_parse_still_rejects_bad_double_dot},
     {"test_value_integer_arithmetic_helpers", test_value_integer_arithmetic_helpers},
     {"test_value_arithmetic_invalid_and_nil_operands", test_value_arithmetic_invalid_and_nil_operands},
+    {"test_value_push_int_interprets_i64_immediates", test_value_push_int_interprets_i64_immediates},
     {"test_value_string_concat_helpers", test_value_string_concat_helpers},
     {"test_value_bool_nil_truthiness_helpers", test_value_bool_nil_truthiness_helpers},
     {"test_value_string_local_load_store_clones", test_value_string_local_load_store_clones},
@@ -181,6 +184,7 @@ static const test_case_t core_tests[] = {
 static const test_case_t compiler_tests[] = {
     {"test_emitbc_header", test_emitbc_header},
     {"test_emitbc_opcode_map", test_emitbc_opcode_map},
+    {"test_emitbc_push_int_immediate_layout", test_emitbc_push_int_immediate_layout},
     {"test_emitbc_all_ir_ops_accounted_for", test_emitbc_all_ir_ops_accounted_for},
     {"test_emitbc_opcode_map_call_item_deref_alias_layout", test_emitbc_opcode_map_call_item_deref_alias_layout},
     {"test_emitbc_opcode_map_unsupported_ir_op", test_emitbc_opcode_map_unsupported_ir_op},


### PR DESCRIPTION
### Motivation
- Centralize fixed-width immediate encoding/decoding to avoid unsafe pointer casts and to make multi-byte reads/writes safe for unaligned instruction streams while preserving the existing byte-for-byte format.
- Ensure the bytecode emitter and interpreter agree on fixed-width operand layouts for `p`/`IR_OP_PUSH_INT` and jump immediates, and reserve a raw 64-bit payload helper for future non-integer payloads (e.g., binary64 bit patterns).
- Add tests and documentation updates to lock down the emitted layout and interpreter behavior so existing immediates remain unchanged.

### Description
- Added compiler writer helpers in `src/compiler/emitbc.c`: `bw_write_u16`, `bw_write_i16`, `bw_write_u64_payload`, and a safe `bw_write_i64` wrapper, and switched jump emission to use `bw_write_i16` and `IR_OP_PUSH_INT` emission to `bw_write_i64`.
- Added interpreter read helpers in `src/interpret.c`: `bc_read_u8`, `bc_read_u16`, `bc_read_i16`, `bc_read_u64_payload`, and `bc_read_i64`, and updated `op_pushint`, `op_pushbool`, `op_jump`, `op_jumpfalse`, `op_pushstr` length read, and `op_fetchitem` arg-count read to use them.
- Added tests: `tests/compiler/test_emitbc_opcode_map.c` gained `test_emitbc_push_int_immediate_layout` to verify byte-for-byte `IR_OP_PUSH_INT` emission, and `tests/core/test_value_behavior.c` gained `test_value_push_int_interprets_i64_immediates` to verify interpreter handling; both tests are registered in `tests/shared/test_compiler.c`.
- Updated documentation `docs/bytecode.md` to describe the fixed-width helpers, `memcpy`-based multi-byte handling, and the platform/endianness/representation assumptions.

### Testing
- Ran the full test suite with `make test` which built the tree and executed all tests; the test harness reported `status=PASS` with `73/73` tests passing.
- The newly added tests `test_emitbc_push_int_immediate_layout` and `test_value_push_int_interprets_i64_immediates` executed and passed as part of the suite run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fa4bc1b48832e92ea6a29ef0dcab5)