### PR TITLE
Implement runtime float values

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -312,10 +312,12 @@ uint8_t *op_pushint(uint8_t *nextop, ITEM_t *item) {
 uint8_t *op_pushfloat(uint8_t *nextop, ITEM_t *item) {
   VALUE_t v;
   v.type = VALUE_float;
-  nextop = bc_read_u64_payload(nextop, &v.f_bits, "OP_PUSHFLOAT");
+  uint64_t bits;
+  nextop = bc_read_u64_payload(nextop, &bits, "OP_PUSHFLOAT");
   if (!nextop) return NULL;
+  v.f = value_float_from_bits(bits);
   push_stack(VM->stack, v);
-  DISASS_LOG("OP_PUSHFLOAT: 0x%016llx\n", (unsigned long long)v.f_bits);
+  DISASS_LOG("OP_PUSHFLOAT: %g (0x%016llx)\n", v.f, (unsigned long long)bits);
   return nextop;
 }
 

--- a/src/libcall.c
+++ b/src/libcall.c
@@ -386,8 +386,8 @@ uint8_t *lc_net_write(uint8_t *nextop, ITEM_t *item) {
         telnet_send_text(line[linenum.i].telnet, buffer, strlen(buffer));
         break;
       case VALUE_float:
-        char fbuffer[19];
-        snprintf(fbuffer, sizeof(fbuffer), "0x%016llx", (unsigned long long)out.f_bits);
+        char fbuffer[32];
+        snprintf(fbuffer, sizeof(fbuffer), "%g", out.f);
         telnet_send_text(line[linenum.i].telnet, fbuffer, strlen(fbuffer));
         break;
       case VALUE_nil:

--- a/src/value.c
+++ b/src/value.c
@@ -2,6 +2,7 @@
 
 // Licensed under the MIT License - see LICENSE file for details.
 
+#include <float.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -10,10 +11,27 @@
 #define VALUE_INTERNAL
 #include "value.h"
 
-const VALUE_t VALUE_NIL = {VALUE_nil, {0}};
-const VALUE_t VALUE_TRUE = {VALUE_bool, {1}};
-const VALUE_t VALUE_FALSE = {VALUE_bool, {0}};
-const VALUE_t VALUE_ZERO = {VALUE_int, {0}};
+_Static_assert(sizeof(double) == 8, "VALUE_float requires 64-bit double");
+_Static_assert(DBL_MANT_DIG == 53, "VALUE_float requires IEEE 754 binary64 precision");
+_Static_assert(DBL_MAX_EXP == 1024, "VALUE_float requires IEEE 754 binary64 exponent range");
+_Static_assert(FLT_RADIX == 2, "VALUE_float requires binary floating-point radix");
+
+const VALUE_t VALUE_NIL = {.type = VALUE_nil, .i = 0};
+const VALUE_t VALUE_TRUE = {.type = VALUE_bool, .i = 1};
+const VALUE_t VALUE_FALSE = {.type = VALUE_bool, .i = 0};
+const VALUE_t VALUE_ZERO = {.type = VALUE_int, .i = 0};
+
+uint64_t value_float_to_bits(double value) {
+  uint64_t bits;
+  memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+double value_float_from_bits(uint64_t bits) {
+  double value;
+  memcpy(&value, &bits, sizeof(value));
+  return value;
+}
 
 const char *value_type_name(VALUE_e type) {
   switch (type) {
@@ -72,7 +90,7 @@ int value_is_truthy(const VALUE_t *value) {
     case VALUE_int:
       return value->i != 0;
     case VALUE_float:
-      return value->f_bits != 0;
+      return value->f != 0.0;
     case VALUE_str:
       return value->s && value->s[0] != '\0';
     case VALUE_nil:
@@ -100,7 +118,7 @@ bool value_equal(const VALUE_t *left, const VALUE_t *right) {
     case VALUE_bool:
       return left->i == right->i;
     case VALUE_float:
-      return left->f_bits == right->f_bits;
+      return left->f == right->f;
     case VALUE_str:
       return strcmp(left->s ? left->s : "", right->s ? right->s : "") == 0;
     case VALUE_nil:
@@ -259,7 +277,7 @@ const char *value_debug_string(const VALUE_t *value, char *buffer, size_t buffer
       snprintf(buffer, buffer_size, "%s", value->i ? "true" : "false");
       break;
     case VALUE_float:
-      snprintf(buffer, buffer_size, "0x%016llx", (unsigned long long)value->f_bits);
+      snprintf(buffer, buffer_size, "%g", value->f);
       break;
     case VALUE_str:
       snprintf(buffer, buffer_size, "'%s'", value->s ? value->s : "");

--- a/src/value.h
+++ b/src/value.h
@@ -23,7 +23,8 @@ typedef struct {
   VALUE_e type; // What sort of value am I?
   union {
     int64_t i;  // This is an integer value
-    uint64_t f_bits; // This is an IEEE 754 binary64 payload
+    double f; // This is a floating-point value used for arithmetic
+    uint64_t f_bits; // This is an IEEE 754 binary64 payload view
     char *s; // This is a string value
   };
 } VALUE_t;
@@ -38,11 +39,15 @@ extern VALUE_t VALUE_FALSE;
 #define FREE_STR(val) value_free(&(val))
   
 VALUE_t convert_to_bool(VALUE_t from);
+uint64_t value_float_to_bits(double value);
+double value_float_from_bits(uint64_t bits);
 
 // Truthiness contract for VM values:
 // - nil is false
 // - bool false/true preserve their value
 // - int 0 is false; any non-zero int is true
+// - float +0.0 and -0.0 are false; all other values are true.
+//   NaN is truthy because it is not equal to zero.
 // - string "" (empty) is false; any non-empty string is true
 //
 // Ownership contract:

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -174,6 +174,42 @@ void test_value_bool_nil_truthiness_helpers(void) {
   value_free(&text);
 }
 
+
+void test_value_float_construction_copy_truthiness_cleanup(void) {
+  VALUE_t zero = {.type = VALUE_float, .f = 0.0};
+  VALUE_t negative_zero = {.type = VALUE_float, .f = -0.0};
+  VALUE_t finite = {.type = VALUE_float, .f = 3.5};
+  VALUE_t negative = {.type = VALUE_float, .f = -2.25};
+  VALUE_t infinity = {.type = VALUE_float, .f = value_float_from_bits(0x7ff0000000000000ULL)};
+  VALUE_t nan = {.type = VALUE_float, .f = value_float_from_bits(0x7ff8000000000000ULL)};
+
+  ASSERT_EQ_INT(VALUE_float, finite.type);
+  ASSERT_TRUE(value_float_to_bits(value_float_from_bits(0x400c000000000000ULL)) == 0x400c000000000000ULL);
+  ASSERT_TRUE(!value_is_truthy(&zero));
+  ASSERT_TRUE(!value_is_truthy(&negative_zero));
+  ASSERT_TRUE(value_is_truthy(&finite));
+  ASSERT_TRUE(value_is_truthy(&negative));
+  ASSERT_TRUE(value_is_truthy(&infinity));
+  ASSERT_TRUE(value_is_truthy(&nan));
+
+  VALUE_t clone = value_clone(&finite);
+  ASSERT_EQ_INT(VALUE_float, clone.type);
+  ASSERT_TRUE(clone.f == finite.f);
+
+  VALUE_t dst = VALUE_NIL;
+  value_move(&dst, &clone);
+  ASSERT_EQ_INT(VALUE_float, dst.type);
+  ASSERT_TRUE(dst.f == finite.f);
+  ASSERT_EQ_INT(VALUE_nil, clone.type);
+
+  value_replace(&dst, negative);
+  ASSERT_EQ_INT(VALUE_float, dst.type);
+  ASSERT_TRUE(dst.f == negative.f);
+
+  value_free(&dst);
+  ASSERT_EQ_INT(VALUE_nil, dst.type);
+}
+
 void test_value_string_local_load_store_clones(void) {
   setup_runtime();
   uint8_t code[96] = {0};

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -64,6 +64,7 @@ void test_value_arithmetic_invalid_and_nil_operands(void);
 void test_value_push_int_interprets_i64_immediates(void);
 void test_value_string_concat_helpers(void);
 void test_value_bool_nil_truthiness_helpers(void);
+void test_value_float_construction_copy_truthiness_cleanup(void);
 void test_value_string_local_load_store_clones(void);
 void test_value_comparison_int_helpers(void);
 void test_value_comparison_bool_helpers(void);
@@ -175,6 +176,7 @@ static const test_case_t core_tests[] = {
     {"test_value_push_int_interprets_i64_immediates", test_value_push_int_interprets_i64_immediates},
     {"test_value_string_concat_helpers", test_value_string_concat_helpers},
     {"test_value_bool_nil_truthiness_helpers", test_value_bool_nil_truthiness_helpers},
+    {"test_value_float_construction_copy_truthiness_cleanup", test_value_float_construction_copy_truthiness_cleanup},
     {"test_value_string_local_load_store_clones", test_value_string_local_load_store_clones},
     {"test_value_comparison_int_helpers", test_value_comparison_int_helpers},
     {"test_value_comparison_bool_helpers", test_value_comparison_bool_helpers},


### PR DESCRIPTION
### Motivation
- Add a native runtime float kind so VM values can hold IEEE-754 binary64 values for arithmetic while preserving bytecode bit-level payloads. 
- Ensure platform assumptions about `double` size/encoding are enforced at compile time to avoid subtle portability issues.

### Description
- Add a `double f` member to the `VALUE_t` union and keep a `uint64_t f_bits` view for bit-level round-tripping in `src/value.h` and expose helpers `value_float_to_bits` and `value_float_from_bits` for safe memcpy-based conversions. 
- Add compile-time assertions (`_Static_assert`) that `sizeof(double) == 8`, `DBL_MANT_DIG == 53`, `DBL_MAX_EXP == 1024`, and `FLT_RADIX == 2` in `src/value.c`. 
- Use designated initializers for `VALUE_NIL`, `VALUE_TRUE`, `VALUE_FALSE`, and `VALUE_ZERO` to avoid union/enum ordering issues. 
- Implement float behavior changes: `value_is_truthy` treats `+0.0` and `-0.0` as false and treats nonzero finite values, infinities, and NaN as truthy (this is documented in the header). 
- Update runtime paths to use the new `double` field: decode push-float bytecode using the bit helpers in `src/interpret.c`, format float output in `src/libcall.c`, and update equality/debug output to use `double`. 
- Extend and register unit tests that cover float construction, bit-roundtripping, truthiness (including `-0.0`, infinity, NaN), `value_clone`/`value_move`/`value_replace` handling, and `value_free` no-op behavior in `tests/core/test_value_behavior.c` and `tests/shared/test_compiler.c`.

### Testing
- Ran the full test suite with `make test`, which executed all suites and reported: `status=PASS suites=3 tests=75/75`.
- New float-specific unit `test_value_float_construction_copy_truthiness_cleanup` was executed as part of the core tests and passed.
- No automated test failures observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fb284e320832ea616008931a2016c)