### PR TITLE
Expose float literals in parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ TEST_CORE_SOURCES := \
 	$(TEST_DIR)/core/test_ir_validate.c \
 	$(TEST_DIR)/core/test_opcode_schema.c \
 	$(TEST_DIR)/core/test_parser_input_api.c \
+	$(TEST_DIR)/core/test_parser_float_literals.c \
 	$(TEST_DIR)/core/test_item_cache.c \
 	$(TEST_DIR)/core/test_libcall_registry.c \
 	$(TEST_DIR)/core/test_relative_item_leading_dot.c \

--- a/src/compiler/absyn.c
+++ b/src/compiler/absyn.c
@@ -1,7 +1,9 @@
 // Abstract syntax tree
 
 // Licensed under the MIT License - see LICENSE file for details.
+#include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "log.h"
 #include "memory.h"
@@ -32,6 +34,16 @@ AS_NODE *as_new_valnode(ENUM_VALUE valtype, char *sval) {
   AS_VALUE *newval;
   if (valtype == V_INT) {
     newval = as_new_value(V_INT, atoll(sval), NULL);
+    free(sval);
+  } else if (valtype == V_FLOAT) {
+    char *end = NULL;
+    errno = 0;
+    double parsed = strtod(sval, &end);
+    uint64_t bits = 0;
+    if (errno == 0 && end != NULL && *end == '\0') {
+      memcpy(&bits, &parsed, sizeof(bits));
+    }
+    newval = as_new_value(V_FLOAT, bits, NULL);
     free(sval);
   } else if (valtype == V_BOOLTRUE) {
     newval = as_new_value(V_BOOLTRUE, 1, NULL);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -63,6 +63,7 @@
 local       @[a-z_][a-z0-9_]*
 layer       [a-z0-9_]+
 integer     [0-9]+
+float       [0-9]+\.[0-9]+
 %%
                 // Maximum length of string literal is uint16_t
                 char *strbuf, *strbuf_ptr;
@@ -121,6 +122,7 @@ integer     [0-9]+
                   BEGIN(STRINGLIT);
                 }
   [ \t\n]+      ; // Inline whitespace handling
+  {float}       { yylval->TSTRINGLIT = strdup(yytext); return TFLOAT; }
   {integer}     { yylval->TSTRINGLIT = strdup(yytext); return TINTEGER; }
   {local}       { yylval->TSTRINGLIT = strdup_lc(yytext); return TLOCAL; }
   {layer}       { yylval->TSTRINGLIT = strdup_lc(yytext); return TLAYER; }

--- a/src/parser.y
+++ b/src/parser.y
@@ -117,6 +117,7 @@ int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail) 
 
 %define api.value.type union /* Generate YYSTYPE from these types:  */
 %token <char *> TINTEGER
+%token <char *> TFLOAT
 %token <char *> TSTRINGLIT
 %token <char *> TLOCAL
 %token <char *> TLAYER
@@ -150,7 +151,7 @@ int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail) 
 
 // Free lexer-allocated token strings when symbols are discarded by error
 // recovery or parser teardown.
-%destructor { free ($$); } TINTEGER TSTRINGLIT TLOCAL TLAYER TLIBNAME TCODEBODY TUNKNOWNCHAR
+%destructor { free ($$); } TINTEGER TFLOAT TSTRINGLIT TLOCAL TLAYER TLIBNAME TCODEBODY TUNKNOWNCHAR
 %destructor { as_delete($$); } <AS_NODE*>
 %destructor { as_delete_if($$); } <AS_IF*>
 
@@ -186,6 +187,7 @@ stmt:   TWHILE expr TDO stmtlist TENDWHILE { $$ = as_new_node(N_WHILESTMT, $2, $
 
 expr:     TLOCAL { $$ = as_new_valnode(V_LOCAL, $1); }
         |	TINTEGER { $$ = as_new_valnode(V_INT, $1); }
+        | TFLOAT { $$ = as_new_valnode(V_FLOAT, $1); }
         |	TSTRINGLIT { $$ = as_new_valnode(V_STR, $1); }
         | TTRUE { $$ = as_new_valnode(V_BOOLTRUE, NULL); }
         | TFALSE { $$ = as_new_valnode(V_BOOLFALSE, NULL); }

--- a/tests/core/test_parser_float_literals.c
+++ b/tests/core/test_parser_float_literals.c
@@ -1,0 +1,131 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "absyn.h"
+#include "error.h"
+#include "parse_input.h"
+#include "parser.h"
+#include "test_assert.h"
+
+static AS_NODE *parse_ok(const char *source) {
+  AS_NODE *absyn = NULL;
+  char *errdetail = NULL;
+  ParseInput input = {source, strlen(source), "float-literal-test.src"};
+  int8_t rc = parse_source(&input, &absyn, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(absyn);
+  return absyn;
+}
+
+static void parse_fails(const char *source) {
+  AS_NODE *absyn = NULL;
+  char *errdetail = NULL;
+  ParseInput input = {source, strlen(source), "float-literal-test.src"};
+  int8_t rc = parse_source(&input, &absyn, &errdetail);
+  ASSERT_TRUE(rc != ERR_NOERROR);
+  ASSERT_TRUE(errdetail != NULL);
+  free(errdetail);
+  if (absyn != NULL) {
+    as_delete(absyn);
+  }
+}
+
+static AS_NODE *single_stmt(AS_NODE *root) {
+  ASSERT_EQ_INT(N_STMTLIST, root->nodetype);
+  AS_STMTLIST *list = (AS_STMTLIST *)root->lhs;
+  ASSERT_EQ_INT(1, list->count);
+  ASSERT_NOT_NULL(list->stmts[0]);
+  return list->stmts[0];
+}
+
+static uint64_t bits_for_double(double value) {
+  uint64_t bits = 0;
+  memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+void test_parser_float_literals_decimal_forms(void) {
+  AS_NODE *root = parse_ok("1.0; 0.5;");
+  ASSERT_EQ_INT(N_STMTLIST, root->nodetype);
+  AS_STMTLIST *list = (AS_STMTLIST *)root->lhs;
+  ASSERT_EQ_INT(2, list->count);
+
+  AS_NODE *stmt = list->stmts[0];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  AS_NODE *value_node = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_VALUE, value_node->nodetype);
+  AS_VALUE *value = (AS_VALUE *)value_node->lhs;
+  ASSERT_EQ_INT(V_FLOAT, value->valtype);
+  ASSERT_TRUE(value->value.f_bits == bits_for_double(1.0));
+
+  stmt = list->stmts[1];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  value_node = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_VALUE, value_node->nodetype);
+  value = (AS_VALUE *)value_node->lhs;
+  ASSERT_EQ_INT(V_FLOAT, value->valtype);
+  ASSERT_TRUE(value->value.f_bits == bits_for_double(0.5));
+
+  as_delete(root);
+}
+
+void test_parser_float_literals_integer_still_int(void) {
+  AS_NODE *root = parse_ok("42;");
+  AS_NODE *stmt = single_stmt(root);
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  AS_NODE *value_node = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_VALUE, value_node->nodetype);
+  AS_VALUE *value = (AS_VALUE *)value_node->lhs;
+  ASSERT_EQ_INT(V_INT, value->valtype);
+  ASSERT_EQ_INT(42, value->value.i);
+  as_delete(root);
+}
+
+void test_parser_float_literals_item_layers_unchanged(void) {
+  AS_NODE *root = parse_ok("foo.bar; .relative; foo.12;");
+  ASSERT_EQ_INT(N_STMTLIST, root->nodetype);
+  AS_STMTLIST *list = (AS_STMTLIST *)root->lhs;
+  ASSERT_EQ_INT(3, list->count);
+
+  AS_NODE *stmt = list->stmts[0];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  AS_NODE *call = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_CALL, call->nodetype);
+  AS_NODE *item = (AS_NODE *)call->lhs;
+  ASSERT_EQ_INT(N_ITEM, item->nodetype);
+  AS_VALUE *first = (AS_VALUE *)((AS_NODE *)item->lhs)->lhs;
+  AS_VALUE *second = (AS_VALUE *)((AS_NODE *)((AS_NODE *)item->rhs)->lhs)->lhs;
+  ASSERT_EQ_INT(V_LAYER, first->valtype);
+  ASSERT_EQ_INT(V_LAYER, second->valtype);
+  ASSERT_TRUE(strcmp("foo", first->value.s) == 0);
+  ASSERT_TRUE(strcmp("bar", second->value.s) == 0);
+
+  stmt = list->stmts[1];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  call = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_CALL, call->nodetype);
+  AS_NODE *relitem = (AS_NODE *)call->lhs;
+  ASSERT_EQ_INT(N_RELITEM, relitem->nodetype);
+  item = (AS_NODE *)relitem->lhs;
+  first = (AS_VALUE *)((AS_NODE *)item->lhs)->lhs;
+  ASSERT_EQ_INT(V_LAYER, first->valtype);
+  ASSERT_TRUE(strcmp("relative", first->value.s) == 0);
+
+  stmt = list->stmts[2];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  call = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_CALL, call->nodetype);
+  item = (AS_NODE *)call->lhs;
+  second = (AS_VALUE *)((AS_NODE *)((AS_NODE *)item->rhs)->lhs)->lhs;
+  ASSERT_EQ_INT(V_INT, second->valtype);
+  ASSERT_EQ_INT(12, second->value.i);
+
+  as_delete(root);
+}
+
+void test_parser_float_literals_malformed_rejected(void) {
+  parse_fails("1.;");
+  parse_fails("1.2.3;");
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -39,6 +39,10 @@ void test_sem_local_limit_over_255_fails_deterministically(void);
 void test_ir_validate(void);
 void test_opcode_schema_consistency(void);
 void test_parser_input_api(void);
+void test_parser_float_literals_decimal_forms(void);
+void test_parser_float_literals_integer_still_int(void);
+void test_parser_float_literals_item_layers_unchanged(void);
+void test_parser_float_literals_malformed_rejected(void);
 void test_fixture_policy_declared_goldens_exist(void);
 void test_find_item_cached_hit_and_negative_cache(void);
 void test_find_item_cached_invalidation_on_delete_and_reinsert(void);
@@ -163,6 +167,10 @@ static const test_case_t core_tests[] = {
     {"test_ir_validate", test_ir_validate},
     {"test_opcode_schema_consistency", test_opcode_schema_consistency},
     {"test_parser_input_api", test_parser_input_api},
+    {"test_parser_float_literals_decimal_forms", test_parser_float_literals_decimal_forms},
+    {"test_parser_float_literals_integer_still_int", test_parser_float_literals_integer_still_int},
+    {"test_parser_float_literals_item_layers_unchanged", test_parser_float_literals_item_layers_unchanged},
+    {"test_parser_float_literals_malformed_rejected", test_parser_float_literals_malformed_rejected},
     {"test_fixture_policy_declared_goldens_exist", test_fixture_policy_declared_goldens_exist},
     {"test_find_item_cached_hit_and_negative_cache", test_find_item_cached_hit_and_negative_cache},
     {"test_find_item_cached_invalidation_on_delete_and_reinsert", test_find_item_cached_invalidation_on_delete_and_reinsert},


### PR DESCRIPTION
### Motivation
- Add explicit support for decimal float literals so expressions like `1.0` and `0.5` are tokenized and represented as `V_FLOAT` in the AST while preserving existing integer and item/layer semantics.

### Description
- Add a `float` lexer pattern (`[0-9]+\.[0-9]+`) and emit `TFLOAT` before the integer rule so `1.0`/`0.5` become floats while `foo.bar`, `.relative`, and layer parsing remain unchanged (`src/lexer.l`).
- Declare `TFLOAT` in the parser and free its string payload via the existing `%destructor` list (`src/parser.y`).
- Add `expr: TFLOAT` production that creates a `V_FLOAT` AST node (`src/parser.y`).
- Convert the float literal text into an IEEE-754 binary64 payload using `strtod` and `memcpy` and store the payload in `V_FLOAT` values (`src/compiler/absyn.c`).
- Add unit tests exercising ordinary decimal floats, confirming integers still produce `V_INT`, verifying item names and layer separators are unchanged, and rejecting malformed literals like `1.` and `1.2.3` (`tests/core/test_parser_float_literals.c`).
- Register the new tests in the test runner and test harness (`Makefile`, `tests/shared/test_compiler.c`).

### Testing
- Ran `make test`; all automated tests passed: test harness summary `suites=3 tests=81/81 status=PASS`.
- New parser tests validate accepted decimal floats, integer preservation, item/layer tokenization, and rejection of malformed float-like input (`tests/core/test_parser_float_literals.c`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fb5315dc0832e853136d88bce0690)