### PR TITLE
Add stable binary64 decimal literal parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ TEST_SOURCES := $(TEST_SHARED_SOURCES) $(TEST_CORE_SOURCES) $(TEST_COMPILER_SOUR
 
 # Library of shared functions
 LIB := $(LIB_DIR)/libsinshared.a
-LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o $(OBJ_DIR)/parser.o \
+LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o $(OBJ_DIR)/floatconv.o $(OBJ_DIR)/parser.o \
                $(OBJ_DIR)/lexer.o $(OBJ_DIR)/compiler/absyn.o $(OBJ_DIR)/compiler/semant.o \
                $(OBJ_DIR)/compiler/ir.o $(OBJ_DIR)/compiler/lower.o $(OBJ_DIR)/compiler/compiler_context.o $(OBJ_DIR)/compiler/compiler_pipeline.o $(OBJ_DIR)/compiler/emitbc.o \
                $(OBJ_DIR)/compiler/compdiag.o $(OBJ_DIR)/error.o $(OBJ_DIR)/util.o $(OBJ_DIR)/libcall.o \

--- a/src/compiler/absyn.c
+++ b/src/compiler/absyn.c
@@ -1,13 +1,13 @@
 // Abstract syntax tree
 
 // Licensed under the MIT License - see LICENSE file for details.
-#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "log.h"
 #include "memory.h"
 #include "absyn.h"
+#include "floatconv.h"
 
 AS_VALUE *as_new_value(ENUM_VALUE valtype, uint64_t ival, char *sval) {
   // Create a new AS value
@@ -36,12 +36,10 @@ AS_NODE *as_new_valnode(ENUM_VALUE valtype, char *sval) {
     newval = as_new_value(V_INT, atoll(sval), NULL);
     free(sval);
   } else if (valtype == V_FLOAT) {
-    char *end = NULL;
-    errno = 0;
-    double parsed = strtod(sval, &end);
     uint64_t bits = 0;
-    if (errno == 0 && end != NULL && *end == '\0') {
-      memcpy(&bits, &parsed, sizeof(bits));
+    char *errdetail = NULL;
+    if (!sin_parse_binary64_bits(sval, &bits, &errdetail)) {
+      free(errdetail);
     }
     newval = as_new_value(V_FLOAT, bits, NULL);
     free(sval);

--- a/src/floatconv.c
+++ b/src/floatconv.c
@@ -1,0 +1,105 @@
+#define _GNU_SOURCE
+#include "floatconv.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <locale.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static bool set_error(char **errdetail, const char *msg) {
+  if (errdetail != NULL) {
+    *errdetail = strdup(msg);
+  }
+  return false;
+}
+
+static bool is_decimal_literal_syntax(const char *text) {
+  const unsigned char *p = (const unsigned char *)text;
+  if (*p == '+' || *p == '-') p++;
+
+  bool before = false;
+  while (isdigit(*p)) {
+    before = true;
+    p++;
+  }
+
+  bool after = false;
+  if (*p == '.') {
+    p++;
+    while (isdigit(*p)) {
+      after = true;
+      p++;
+    }
+  }
+
+  if (!before || !after) return false;
+
+  if (*p == 'e' || *p == 'E') {
+    p++;
+    if (*p == '+' || *p == '-') p++;
+    bool exp = false;
+    while (isdigit(*p)) {
+      exp = true;
+      p++;
+    }
+    if (!exp) return false;
+  }
+
+  return *p == '\0';
+}
+
+bool sin_parse_binary64(const char *text, double *out, char **errdetail) {
+  if (errdetail != NULL) *errdetail = NULL;
+  if (text == NULL) return set_error(errdetail, "binary64 literal is NULL");
+  if (out == NULL) return set_error(errdetail, "binary64 output pointer is NULL");
+  if (!is_decimal_literal_syntax(text)) {
+    return set_error(errdetail, "invalid decimal binary64 literal syntax");
+  }
+
+  errno = 0;
+  char *end = NULL;
+  double parsed = 0.0;
+
+#if defined(__GLIBC__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+  locale_t c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+  if (c_locale == (locale_t)0) {
+    return set_error(errdetail, "could not create C numeric locale for binary64 parsing");
+  }
+  parsed = strtod_l(text, &end, c_locale);
+  freelocale(c_locale);
+#else
+  struct lconv *lc = localeconv();
+  if (lc == NULL || lc->decimal_point == NULL || strcmp(lc->decimal_point, ".") != 0) {
+    return set_error(errdetail, "platform lacks locale-independent binary64 parsing support");
+  }
+  parsed = strtod(text, &end);
+#endif
+
+  if (end == NULL || *end != '\0') {
+    return set_error(errdetail, "binary64 parser stopped before end of literal");
+  }
+  if (errno == ERANGE) {
+    /* Correctly rounded underflow/subnormal results and overflow to infinity
+       are valid IEEE-754 outcomes for decimal literals. */
+  } else if (errno != 0) {
+    return set_error(errdetail, "binary64 literal conversion failed");
+  }
+
+  *out = parsed;
+  return true;
+}
+
+bool sin_parse_binary64_bits(const char *text, uint64_t *out_bits, char **errdetail) {
+  if (errdetail != NULL) *errdetail = NULL;
+  if (out_bits == NULL) return set_error(errdetail, "binary64 bits output pointer is NULL");
+
+  double parsed = 0.0;
+  if (!sin_parse_binary64(text, &parsed, errdetail)) return false;
+
+  uint64_t bits = 0;
+  memcpy(&bits, &parsed, sizeof(bits));
+  *out_bits = bits;
+  return true;
+}

--- a/src/floatconv.h
+++ b/src/floatconv.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+bool sin_parse_binary64(const char *text, double *out, char **errdetail);
+bool sin_parse_binary64_bits(const char *text, uint64_t *out_bits, char **errdetail);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -63,7 +63,7 @@
 local       @[a-z_][a-z0-9_]*
 layer       [a-z0-9_]+
 integer     [0-9]+
-float       [0-9]+\.[0-9]+
+float       [0-9]+\.[0-9]+([eE][+-]?[0-9]+)?
 %%
                 // Maximum length of string literal is uint16_t
                 char *strbuf, *strbuf_ptr;

--- a/tests/core/test_parser_float_literals.c
+++ b/tests/core/test_parser_float_literals.c
@@ -6,6 +6,7 @@
 #include "error.h"
 #include "parse_input.h"
 #include "parser.h"
+#include "floatconv.h"
 #include "test_assert.h"
 
 static AS_NODE *parse_ok(const char *source) {
@@ -47,10 +48,10 @@ static uint64_t bits_for_double(double value) {
 }
 
 void test_parser_float_literals_decimal_forms(void) {
-  AS_NODE *root = parse_ok("1.0; 0.5;");
+  AS_NODE *root = parse_ok("1.0; 0.5; 1.25e2;");
   ASSERT_EQ_INT(N_STMTLIST, root->nodetype);
   AS_STMTLIST *list = (AS_STMTLIST *)root->lhs;
-  ASSERT_EQ_INT(2, list->count);
+  ASSERT_EQ_INT(3, list->count);
 
   AS_NODE *stmt = list->stmts[0];
   ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
@@ -67,6 +68,14 @@ void test_parser_float_literals_decimal_forms(void) {
   value = (AS_VALUE *)value_node->lhs;
   ASSERT_EQ_INT(V_FLOAT, value->valtype);
   ASSERT_TRUE(value->value.f_bits == bits_for_double(0.5));
+
+  stmt = list->stmts[2];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  value_node = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_VALUE, value_node->nodetype);
+  value = (AS_VALUE *)value_node->lhs;
+  ASSERT_EQ_INT(V_FLOAT, value->valtype);
+  ASSERT_TRUE(value->value.f_bits == bits_for_double(125.0));
 
   as_delete(root);
 }
@@ -128,4 +137,50 @@ void test_parser_float_literals_item_layers_unchanged(void) {
 void test_parser_float_literals_malformed_rejected(void) {
   parse_fails("1.;");
   parse_fails("1.2.3;");
+}
+
+static void assert_parse_bits(const char *literal, uint64_t expected) {
+  uint64_t bits = 0;
+  char *errdetail = NULL;
+  ASSERT_TRUE(sin_parse_binary64_bits(literal, &bits, &errdetail));
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_TRUE(bits == expected);
+}
+
+static void assert_parse_rejected(const char *literal) {
+  uint64_t bits = 0;
+  char *errdetail = NULL;
+  ASSERT_TRUE(!sin_parse_binary64_bits(literal, &bits, &errdetail));
+  ASSERT_NOT_NULL(errdetail);
+  free(errdetail);
+}
+
+void test_floatconv_binary64_edge_cases(void) {
+  /* Exact integers around 2^53. */
+  assert_parse_bits("9007199254740991.0", UINT64_C(0x433fffffffffffff));
+  assert_parse_bits("9007199254740992.0", UINT64_C(0x4340000000000000));
+  assert_parse_bits("9007199254740993.0", UINT64_C(0x4340000000000000));
+  assert_parse_bits("9007199254740994.0", UINT64_C(0x4340000000000001));
+
+  /* Smallest positive subnormal and neighboring underflow cases. */
+  assert_parse_bits("4.9406564584124654e-324", UINT64_C(0x0000000000000001));
+  assert_parse_bits("2.4703282292062327e-324", UINT64_C(0x0000000000000000));
+  assert_parse_bits("-2.4703282292062327e-324", UINT64_C(0x8000000000000000));
+
+  /* Largest finite double and explicit overflow to infinity. */
+  assert_parse_bits("1.7976931348623157e308", UINT64_C(0x7fefffffffffffff));
+  assert_parse_bits("1.7976931348623159e308", UINT64_C(0x7ff0000000000000));
+
+  /* Halfway/tie-to-even rounding cases. */
+  assert_parse_bits("1.00000000000000011102230246251565404236316680908203125", UINT64_C(0x3ff0000000000000));
+  assert_parse_bits("1.00000000000000033306690738754696212708950042724609375", UINT64_C(0x3ff0000000000002));
+
+  /* Negative zero literal. */
+  assert_parse_bits("-0.0", UINT64_C(0x8000000000000000));
+
+  /* Special spellings and locale-specific decimal commas are rejected. */
+  assert_parse_rejected("nan");
+  assert_parse_rejected("inf");
+  assert_parse_rejected("infinity");
+  assert_parse_rejected("1,5");
 }

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -43,6 +43,7 @@ void test_parser_float_literals_decimal_forms(void);
 void test_parser_float_literals_integer_still_int(void);
 void test_parser_float_literals_item_layers_unchanged(void);
 void test_parser_float_literals_malformed_rejected(void);
+void test_floatconv_binary64_edge_cases(void);
 void test_fixture_policy_declared_goldens_exist(void);
 void test_find_item_cached_hit_and_negative_cache(void);
 void test_find_item_cached_invalidation_on_delete_and_reinsert(void);
@@ -171,6 +172,7 @@ static const test_case_t core_tests[] = {
     {"test_parser_float_literals_integer_still_int", test_parser_float_literals_integer_still_int},
     {"test_parser_float_literals_item_layers_unchanged", test_parser_float_literals_item_layers_unchanged},
     {"test_parser_float_literals_malformed_rejected", test_parser_float_literals_malformed_rejected},
+    {"test_floatconv_binary64_edge_cases", test_floatconv_binary64_edge_cases},
     {"test_fixture_policy_declared_goldens_exist", test_fixture_policy_declared_goldens_exist},
     {"test_find_item_cached_hit_and_negative_cache", test_find_item_cached_hit_and_negative_cache},
     {"test_find_item_cached_invalidation_on_delete_and_reinsert", test_find_item_cached_invalidation_on_delete_and_reinsert},


### PR DESCRIPTION
### Motivation
- Provide a stable, locale-independent API for parsing decimal string literals into IEEE-754 binary64 values and/or their raw payload bits. 
- Avoid relying on ad-hoc `strtod` usage in the AST construction so edge cases (subnormals, halfway rounding, overflow/underflow, negative zero) are handled deterministically. 
- Reject non-decimal or special spellings (e.g. `nan`, `inf`, `infinity`) and locale comma forms rather than accepting platform-dependent behavior. 

### Description
- Added `src/floatconv.h` and `src/floatconv.c` with a public API: `sin_parse_binary64(const char *text, double *out, char **errdetail)` and `sin_parse_binary64_bits(const char *text, uint64_t *out_bits, char **errdetail)`. 
- Implemented syntax validation for decimal literals (optional sign, digits, decimal point, optional exponent), explicit rejection of special spellings/commas, and locale-independent parsing using `strtod_l` where available (fallback checks `localeconv`). 
- Implemented `sin_parse_binary64_bits` to preserve the binary64 payload bits via `memcpy` of the parsed `double`. 
- Replaced direct `strtod` use in `src/compiler/absyn.c` to construct float AST nodes via `sin_parse_binary64_bits`. 
- Extended lexer (`src/lexer.l`) to accept exponent-form float literals and wired `floatconv.o` into the shared library build in `Makefile`. 
- Added exhaustive edge-case tests in `tests/core/test_parser_float_literals.c` and registered the test in `tests/shared/test_compiler.c` covering integers around `2^53`, smallest positive subnormal, largest finite double, overflow to infinity, underflow to signed zero/subnormal, halfway tie-to-even rounding cases, negative zero, and rejected special/locale spellings. 

### Testing
- Ran `make test`, which compiles the project and executes the test harness, and all tests passed (`82/82`).
- The test run exercised the new parsing code via the existing parser tests and the new `test_floatconv_binary64_edge_cases` unit cases, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fb8d0d6bc832e8103662f9d2d4a95)