### PR TITLE
Add IEEE 754 float arithmetic to runtime operators

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -502,7 +502,7 @@ uint8_t *op_divide(uint8_t *nextop, ITEM_t *item) {
   v2 = pop_stack(VM->stack);
   VALUE_t result;
   if (value_div(&v2, &v1, &result)) {
-    if (v1.i == 0) {
+    if (v1.type == VALUE_int && v1.i == 0) {
       logerr("Attempt to divide by zero.  Substitute zero as result.\n");
     }
     DISASS_LOG("OP_DIV: operand types %d and %d\n", v2.type, v1.type);

--- a/src/value.c
+++ b/src/value.c
@@ -169,6 +169,8 @@ VALUE_numeric_kind_e value_numeric_kind(const VALUE_t *value) {
   switch (value->type) {
     case VALUE_int:
       return VALUE_NUMERIC_INT;
+    case VALUE_float:
+      return VALUE_NUMERIC_FLOAT;
     default:
       return VALUE_NUMERIC_NONE;
   }
@@ -187,68 +189,107 @@ static bool value_as_add_int_operand(const VALUE_t *value, int64_t *out) {
   return false;
 }
 
+static bool value_as_numeric_operand(const VALUE_t *value, double *out) {
+  if (!value || !out) return false;
+  if (value->type == VALUE_int) {
+    *out = (double)value->i;
+    return true;
+  }
+  if (value->type == VALUE_float) {
+    *out = value->f;
+    return true;
+  }
+  return false;
+}
+
 static bool value_as_int_operand(const VALUE_t *value, int64_t *out) {
   if (!value || !out || value->type != VALUE_int) return false;
   *out = value->i;
   return true;
 }
 
-bool value_add(const VALUE_t *left, const VALUE_t *right, VALUE_t *result) {
-  int64_t lhs;
-  int64_t rhs;
-  if (!result || !value_as_add_int_operand(left, &lhs) ||
-      !value_as_add_int_operand(right, &rhs)) {
+static bool value_arith_float(const VALUE_t *left, const VALUE_t *right,
+                              VALUE_t *result, double (*op)(double, double)) {
+  double lhs;
+  double rhs;
+  if (!result || !op || !value_as_numeric_operand(left, &lhs) ||
+      !value_as_numeric_operand(right, &rhs)) {
     if (result) *result = VALUE_NIL;
     return false;
   }
-  result->type = VALUE_int;
-  result->i = lhs + rhs;
+  result->type = VALUE_float;
+  result->f = op(lhs, rhs);
   return true;
+}
+
+static double float_add(double lhs, double rhs) { return lhs + rhs; }
+static double float_sub(double lhs, double rhs) { return lhs - rhs; }
+static double float_mul(double lhs, double rhs) { return lhs * rhs; }
+static double float_div(double lhs, double rhs) { return lhs / rhs; }
+
+bool value_add(const VALUE_t *left, const VALUE_t *right, VALUE_t *result) {
+  int64_t lhs;
+  int64_t rhs;
+  if (!result) return false;
+  if (value_as_add_int_operand(left, &lhs) && value_as_add_int_operand(right, &rhs)) {
+    result->type = VALUE_int;
+    result->i = lhs + rhs;
+    return true;
+  }
+  return value_arith_float(left, right, result, float_add);
 }
 
 bool value_sub(const VALUE_t *left, const VALUE_t *right, VALUE_t *result) {
   int64_t lhs;
   int64_t rhs;
-  if (!result || !value_as_int_operand(left, &lhs) ||
-      !value_as_int_operand(right, &rhs)) {
-    if (result) *result = VALUE_NIL;
-    return false;
+  if (!result) return false;
+  if (value_as_int_operand(left, &lhs) && value_as_int_operand(right, &rhs)) {
+    result->type = VALUE_int;
+    result->i = lhs - rhs;
+    return true;
   }
-  result->type = VALUE_int;
-  result->i = lhs - rhs;
-  return true;
+  return value_arith_float(left, right, result, float_sub);
 }
 
 bool value_mul(const VALUE_t *left, const VALUE_t *right, VALUE_t *result) {
   int64_t lhs;
   int64_t rhs;
-  if (!result || !value_as_int_operand(left, &lhs) ||
-      !value_as_int_operand(right, &rhs)) {
-    if (result) *result = VALUE_NIL;
-    return false;
+  if (!result) return false;
+  if (value_as_int_operand(left, &lhs) && value_as_int_operand(right, &rhs)) {
+    result->type = VALUE_int;
+    result->i = lhs * rhs;
+    return true;
   }
-  result->type = VALUE_int;
-  result->i = lhs * rhs;
-  return true;
+  return value_arith_float(left, right, result, float_mul);
 }
 
 bool value_div(const VALUE_t *left, const VALUE_t *right, VALUE_t *result) {
   int64_t lhs;
   int64_t rhs;
   if (!result) return false;
-  if (!value_as_int_operand(left, &lhs) || !value_as_int_operand(right, &rhs)) {
-    *result = VALUE_ZERO;
-    return false;
+  if (value_as_int_operand(left, &lhs) && value_as_int_operand(right, &rhs)) {
+    result->type = VALUE_int;
+    result->i = rhs == 0 ? 0 : lhs / rhs;
+    return true;
   }
-  result->type = VALUE_int;
-  result->i = rhs == 0 ? 0 : lhs / rhs;
-  return true;
+  if ((left && left->type == VALUE_float) || (right && right->type == VALUE_float)) {
+    return value_arith_float(left, right, result, float_div);
+  }
+  *result = VALUE_ZERO;
+  return false;
 }
 
 bool value_neg(VALUE_t *value) {
-  if (!value || value->type != VALUE_int) return false;
-  value->i = -value->i;
-  return true;
+  if (!value) return false;
+  if (value->type == VALUE_int) {
+    value->i = -value->i;
+    return true;
+  }
+  if (value->type == VALUE_float) {
+    value->f = -value->f;
+    return true;
+  }
+  return false;
 }
 
 bool value_order(const VALUE_t *left, const VALUE_t *right, int *comparison) {

--- a/src/value.h
+++ b/src/value.h
@@ -16,7 +16,8 @@ typedef enum { VALUE_int,
              } VALUE_e;
 
 typedef enum { VALUE_NUMERIC_NONE,
-               VALUE_NUMERIC_INT
+               VALUE_NUMERIC_INT,
+               VALUE_NUMERIC_FLOAT
              } VALUE_numeric_kind_e;
 
 typedef struct {
@@ -73,10 +74,9 @@ bool value_greater_than(const VALUE_t *left, const VALUE_t *right);
 bool value_greater_equal(const VALUE_t *left, const VALUE_t *right);
 bool value_is_numeric(const VALUE_t *value);
 VALUE_numeric_kind_e value_numeric_kind(const VALUE_t *value);
-// Arithmetic helpers currently support integer arithmetic only. OP_ADD
-// intentionally preserves the VM quirk that nil participates as integer 0;
-// the other arithmetic operators require int operands until more numeric
-// kinds are added. value_div preserves the VM invalid-operand result of int 0.
+// Arithmetic helpers support int and IEEE 754 binary64 float arithmetic.
+// OP_ADD intentionally preserves the VM quirk that nil participates as
+// integer 0. value_div preserves the VM invalid-operand result of int 0.
 bool value_add(const VALUE_t *left, const VALUE_t *right, VALUE_t *result);
 bool value_sub(const VALUE_t *left, const VALUE_t *right, VALUE_t *result);
 bool value_mul(const VALUE_t *left, const VALUE_t *right, VALUE_t *result);

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -141,6 +141,98 @@ void test_value_push_float_interprets_binary64_payloads(void) {
   teardown_runtime();
 }
 
+
+void test_value_float_arithmetic_helpers(void) {
+  VALUE_t int_value = {VALUE_int, {.i = 2}};
+  VALUE_t float_value = {VALUE_float, {.f = 0.5}};
+  VALUE_t huge = {VALUE_float, {.f = value_float_from_bits(UINT64_C(0x7fefffffffffffff))}};
+  VALUE_t tiny = {VALUE_float, {.f = value_float_from_bits(UINT64_C(0x0010000000000000))}};
+  VALUE_t nan = {VALUE_float, {.f = value_float_from_bits(UINT64_C(0x7ff8000000000042))}};
+  VALUE_t one = {VALUE_float, {.f = 1.0}};
+  VALUE_t zero = {VALUE_float, {.f = 0.0}};
+  VALUE_t negative_zero = {VALUE_float, {.f = -0.0}};
+  VALUE_t result = VALUE_NIL;
+
+  ASSERT_TRUE(value_is_numeric(&float_value));
+  ASSERT_EQ_INT(VALUE_NUMERIC_FLOAT, value_numeric_kind(&float_value));
+
+  ASSERT_TRUE(value_add(&int_value, &float_value, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(result.f == 2.5);
+  ASSERT_TRUE(value_add(&float_value, &int_value, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(result.f == 2.5);
+  ASSERT_TRUE(value_sub(&float_value, &int_value, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(result.f == -1.5);
+  ASSERT_TRUE(value_mul(&int_value, &float_value, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(result.f == 1.0);
+
+  ASSERT_TRUE(value_div(&one, &zero, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(value_float_to_bits(result.f) == UINT64_C(0x7ff0000000000000));
+  ASSERT_TRUE(value_div(&one, &negative_zero, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(value_float_to_bits(result.f) == UINT64_C(0xfff0000000000000));
+  ASSERT_TRUE(value_div(&zero, &zero, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE((value_float_to_bits(result.f) & UINT64_C(0x7ff0000000000000)) == UINT64_C(0x7ff0000000000000));
+  ASSERT_TRUE((value_float_to_bits(result.f) & UINT64_C(0x000fffffffffffff)) != 0);
+  ASSERT_TRUE(value_add(&huge, &huge, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(value_float_to_bits(result.f) == UINT64_C(0x7ff0000000000000));
+  ASSERT_TRUE(value_mul(&tiny, &tiny, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(value_float_to_bits(result.f) == UINT64_C(0x0000000000000000));
+  ASSERT_TRUE(value_add(&nan, &one, &result));
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE((value_float_to_bits(result.f) & UINT64_C(0x7ff0000000000000)) == UINT64_C(0x7ff0000000000000));
+  ASSERT_TRUE((value_float_to_bits(result.f) & UINT64_C(0x000fffffffffffff)) != 0);
+
+  ASSERT_TRUE(value_neg(&zero));
+  ASSERT_EQ_INT(VALUE_float, zero.type);
+  ASSERT_TRUE(value_float_to_bits(zero.f) == UINT64_C(0x8000000000000000));
+}
+
+void test_value_float_arithmetic_interpreter_bytecode(void) {
+  setup_runtime();
+
+  uint8_t code[96] = {0};
+  size_t pos = 0;
+  code[pos++] = 0;
+  code[pos++] = 0;
+  code[pos++] = 'p'; emit_i64(code, &pos, 2);
+  code[pos++] = 'P'; emit_u64(code, &pos, UINT64_C(0x3fe0000000000000)); /* 0.5 */
+  code[pos++] = 'a';
+  code[pos++] = 'P'; emit_u64(code, &pos, UINT64_C(0x4008000000000000)); /* 3.0 */
+  code[pos++] = 'm';
+  code[pos++] = 'P'; emit_u64(code, &pos, UINT64_C(0x3ff0000000000000)); /* 1.0 */
+  code[pos++] = 's';
+  code[pos++] = 'P'; emit_u64(code, &pos, UINT64_C(0x0000000000000000)); /* +0.0 */
+  code[pos++] = 'd';
+  code[pos++] = 'h';
+
+  VALUE_t result = run_code("test.value_float_arithmetic_bytecode", code, pos);
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(value_float_to_bits(result.f) == UINT64_C(0x7ff0000000000000));
+  value_free(&result);
+
+  pos = 0;
+  code[pos++] = 0;
+  code[pos++] = 0;
+  code[pos++] = 'P'; emit_u64(code, &pos, UINT64_C(0x0000000000000000)); /* +0.0 */
+  code[pos++] = 'n';
+  code[pos++] = 'h';
+
+  result = run_code("test.value_float_neg_zero_bytecode", code, pos);
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(value_float_to_bits(result.f) == UINT64_C(0x8000000000000000));
+  value_free(&result);
+
+  teardown_runtime();
+}
+
 void test_value_arithmetic_invalid_and_nil_operands(void) {
   VALUE_t int_value = {VALUE_int, {.i = 7}};
   VALUE_t nil_value = VALUE_NIL;

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -68,6 +68,8 @@ void test_value_integer_arithmetic_helpers(void);
 void test_value_arithmetic_invalid_and_nil_operands(void);
 void test_value_push_int_interprets_i64_immediates(void);
 void test_value_push_float_interprets_binary64_payloads(void);
+void test_value_float_arithmetic_helpers(void);
+void test_value_float_arithmetic_interpreter_bytecode(void);
 void test_value_string_concat_helpers(void);
 void test_value_bool_nil_truthiness_helpers(void);
 void test_value_float_construction_copy_truthiness_cleanup(void);
@@ -187,6 +189,8 @@ static const test_case_t core_tests[] = {
     {"test_value_arithmetic_invalid_and_nil_operands", test_value_arithmetic_invalid_and_nil_operands},
     {"test_value_push_int_interprets_i64_immediates", test_value_push_int_interprets_i64_immediates},
     {"test_value_push_float_interprets_binary64_payloads", test_value_push_float_interprets_binary64_payloads},
+    {"test_value_float_arithmetic_helpers", test_value_float_arithmetic_helpers},
+    {"test_value_float_arithmetic_interpreter_bytecode", test_value_float_arithmetic_interpreter_bytecode},
     {"test_value_string_concat_helpers", test_value_string_concat_helpers},
     {"test_value_bool_nil_truthiness_helpers", test_value_bool_nil_truthiness_helpers},
     {"test_value_float_construction_copy_truthiness_cleanup", test_value_float_construction_copy_truthiness_cleanup},


### PR DESCRIPTION
### Motivation
- Introduce IEEE 754 binary64 float arithmetic to the runtime so mixed int/float expressions and float-only operations behave like native C `double` arithmetic (infinities, NaN, signed zero, underflow/overflow).
- Preserve existing VM quirks for integer-only arithmetic (including integer divide-by-zero substituting zero) and keep invalid mixed-type behavior for non-numeric operands unchanged.

### Description
- Add `VALUE_NUMERIC_FLOAT` and update numeric-kind dispatch so `VALUE_float` is recognized as numeric in `value_numeric_kind` (`src/value.h`, `src/value.c`).
- Implement `value_as_numeric_operand` and a generic `value_arith_float` helper that performs binary64 operations via provided function pointers, and use it to implement float `+`, `-`, `*`, and `/` (`src/value.c`).
- Preserve `int + int`, `int - int`, `int * int`, and integer `div` as `VALUE_int`, while promoting mixed `int/float` operations to `VALUE_float` by converting integers to `double` first (`src/value.c`).
- Let float division and unary negation use native `double` semantics so division by ±0 produces ±inf/NaN, overflow/underflow/NaN propagate, and signed zero is preserved; extend `value_neg` to support floats (`src/value.c`).
- Restrict the divide-by-zero substitute-zero log path in the interpreter to integer divisors only by checking the operand type, so float division does not get the integer substitute-zero behavior (`src/interpret.c`).
- Add interpreter and unit tests `test_value_float_arithmetic_helpers` and `test_value_float_arithmetic_interpreter_bytecode` that exercise mixed promotion, `+inf`/`-inf`, NaN, overflow, underflow, NaN propagation, and signed-zero negation, and register them in the test harness (`tests/core/test_value_behavior.c`, `tests/shared/test_compiler.c`).

### Testing
- Ran the full test suite with `make test` and all automated tests passed successfully (test harness reported `status=PASS`, `84/84` tests executed).
- New tests `test_value_float_arithmetic_helpers` and `test_value_float_arithmetic_interpreter_bytecode` executed as part of the core suite and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fbabed6c8832eb17916dbd2bd23a9)