### PR TITLE
IEEE 754-aware float comparisons (int-to-float promotion, NaN, signed-zero)

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -3,6 +3,7 @@
 // Licensed under the MIT License - see LICENSE file for details.
 
 #include <float.h>
+#include <math.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -111,18 +112,38 @@ VALUE_t convert_to_bool(VALUE_t from) {
   return from;
 }
 
+static bool value_as_comparison_float(const VALUE_t *value, double *out) {
+  if (!value || !out) return false;
+  if (value->type == VALUE_int) {
+    *out = (double)value->i;
+    return true;
+  }
+  if (value->type == VALUE_float) {
+    *out = value->f;
+    return true;
+  }
+  return false;
+}
+
 bool value_equal(const VALUE_t *left, const VALUE_t *right) {
-  if (!left || !right || left->type != right->type) return false;
+  if (!left || !right) return false;
+  if (left->type == VALUE_float || right->type == VALUE_float) {
+    double lhs;
+    double rhs;
+    return value_as_comparison_float(left, &lhs) &&
+           value_as_comparison_float(right, &rhs) && lhs == rhs;
+  }
+  if (left->type != right->type) return false;
   switch (left->type) {
     case VALUE_int:
     case VALUE_bool:
       return left->i == right->i;
-    case VALUE_float:
-      return left->f == right->f;
     case VALUE_str:
       return strcmp(left->s ? left->s : "", right->s ? right->s : "") == 0;
     case VALUE_nil:
       return true;
+    case VALUE_float:
+      return false;
   }
   return false;
 }
@@ -293,7 +314,18 @@ bool value_neg(VALUE_t *value) {
 }
 
 bool value_order(const VALUE_t *left, const VALUE_t *right, int *comparison) {
-  if (!left || !right || left->type != right->type) return false;
+  if (!left || !right || !comparison) return false;
+  if (left->type == VALUE_float || right->type == VALUE_float) {
+    double lhs;
+    double rhs;
+    if (!value_as_comparison_float(left, &lhs) ||
+        !value_as_comparison_float(right, &rhs) || isnan(lhs) || isnan(rhs)) {
+      return false;
+    }
+    *comparison = (lhs > rhs) - (lhs < rhs);
+    return true;
+  }
+  if (left->type != right->type) return false;
   switch (left->type) {
     case VALUE_int:
     case VALUE_bool:

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -371,6 +371,41 @@ void test_value_comparison_int_helpers(void) {
   ASSERT_TRUE(!value_less_than(&nine, &four));
 }
 
+
+void test_value_comparison_float_ieee754_helpers(void) {
+  VALUE_t one = {VALUE_int, {.i = 1}};
+  VALUE_t one_point_zero = {VALUE_float, {.f = value_float_from_bits(UINT64_C(0x3ff0000000000000))}};
+  VALUE_t one_point_five = {VALUE_float, {.f = value_float_from_bits(UINT64_C(0x3ff8000000000000))}};
+  VALUE_t positive_zero = {VALUE_float, {.f = value_float_from_bits(UINT64_C(0x0000000000000000))}};
+  VALUE_t negative_zero = {VALUE_float, {.f = value_float_from_bits(UINT64_C(0x8000000000000000))}};
+  VALUE_t quiet_nan = {VALUE_float, {.f = value_float_from_bits(UINT64_C(0x7ff8000000000042))}};
+  VALUE_t negative_nan = {VALUE_float, {.f = value_float_from_bits(UINT64_C(0xfff8000000000042))}};
+
+  ASSERT_TRUE(value_equal(&one, &one_point_zero));
+  ASSERT_TRUE(!value_not_equal(&one, &one_point_zero));
+  ASSERT_TRUE(value_less_than(&one, &one_point_five));
+  ASSERT_TRUE(value_less_equal(&one, &one_point_zero));
+  ASSERT_TRUE(value_greater_than(&one_point_five, &one));
+  ASSERT_TRUE(value_greater_equal(&one_point_zero, &one));
+
+  ASSERT_TRUE(value_equal(&positive_zero, &negative_zero));
+  ASSERT_TRUE(value_less_equal(&positive_zero, &negative_zero));
+  ASSERT_TRUE(value_greater_equal(&positive_zero, &negative_zero));
+  ASSERT_TRUE(value_float_to_bits(positive_zero.f) == UINT64_C(0x0000000000000000));
+  ASSERT_TRUE(value_float_to_bits(negative_zero.f) == UINT64_C(0x8000000000000000));
+
+  ASSERT_TRUE(!value_equal(&quiet_nan, &quiet_nan));
+  ASSERT_TRUE(!value_equal(&quiet_nan, &negative_nan));
+  ASSERT_TRUE(!value_equal(&quiet_nan, &one));
+  ASSERT_TRUE(value_not_equal(&quiet_nan, &quiet_nan));
+  ASSERT_TRUE(value_not_equal(&quiet_nan, &negative_nan));
+  ASSERT_TRUE(value_not_equal(&quiet_nan, &one));
+  ASSERT_TRUE(!value_less_than(&quiet_nan, &one));
+  ASSERT_TRUE(!value_less_equal(&quiet_nan, &quiet_nan));
+  ASSERT_TRUE(!value_greater_than(&one, &quiet_nan));
+  ASSERT_TRUE(!value_greater_equal(&quiet_nan, &negative_nan));
+}
+
 void test_value_comparison_bool_helpers(void) {
   VALUE_t false_value = VALUE_FALSE;
   VALUE_t true_value = VALUE_TRUE;

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -76,6 +76,7 @@ void test_value_float_construction_copy_truthiness_cleanup(void);
 void test_value_string_local_load_store_clones(void);
 void test_value_comparison_int_helpers(void);
 void test_value_comparison_bool_helpers(void);
+void test_value_comparison_float_ieee754_helpers(void);
 void test_value_comparison_string_helpers(void);
 void test_value_comparison_mismatched_type_equality_quirk(void);
 void test_value_comparison_unsupported_ordering_is_false(void);
@@ -197,6 +198,7 @@ static const test_case_t core_tests[] = {
     {"test_value_string_local_load_store_clones", test_value_string_local_load_store_clones},
     {"test_value_comparison_int_helpers", test_value_comparison_int_helpers},
     {"test_value_comparison_bool_helpers", test_value_comparison_bool_helpers},
+    {"test_value_comparison_float_ieee754_helpers", test_value_comparison_float_ieee754_helpers},
     {"test_value_comparison_string_helpers", test_value_comparison_string_helpers},
     {"test_value_comparison_mismatched_type_equality_quirk", test_value_comparison_mismatched_type_equality_quirk},
     {"test_value_comparison_unsupported_ordering_is_false", test_value_comparison_unsupported_ordering_is_false},


### PR DESCRIPTION
### Motivation
- Ensure numeric comparisons follow IEEE 754 binary64 semantics when `VALUE_float` is involved, while preserving existing VM quirks for other types.
- Support mixed int/float comparisons via int-to-float promotion so operations like `1 == 1.0` behave as expected.
- Make NaN and signed-zero behaviors testable and deterministic by allowing values to be constructed from exact bit patterns.

### Description
- Added `#include <math.h>` and a helper `value_as_comparison_float` to perform int-to-float promotion and extract comparison doubles from `VALUE_t`.
- Updated `value_equal` to perform mixed numeric comparisons when either operand is `VALUE_float`, using IEEE 754 double equality for floats and promoted ints, while preserving mismatched-type inequality behavior for non-numeric types.
- Updated `value_order` to handle numeric ordering with int-to-float promotion and to return false for ordered comparisons when either operand is NaN by checking `isnan(lhs)`/`isnan(rhs)`.
- Added `test_value_comparison_float_ieee754_helpers` in `tests/core/test_value_behavior.c` and registered it in `tests/shared/test_compiler.c`; tests construct floats via `value_float_from_bits` and assert bit patterns with `value_float_to_bits` to verify NaN and signed-zero storage distinctness while ensuring equality semantics match IEEE 754 rules.

### Testing
- Ran the full test suite with `make test`, which completed successfully with all tests passing (85/85).
- The new `test_value_comparison_float_ieee754_helpers` test executed and passed as part of the core suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fbbf05970832ea9914f8b928e0285)