### PR TITLE
Add stable binary64 formatting

### DIFF
--- a/src/compiler/absyn.c
+++ b/src/compiler/absyn.c
@@ -236,7 +236,14 @@ void as_reconstruct_value(AS_NODE *node) {
   if (val->valtype == V_INT || val->valtype == V_BOOLTRUE || val->valtype == V_BOOLFALSE) {
     logmsg("%lld", val->value.i);
   } else if (val->valtype == V_FLOAT) {
-    logmsg("0x%016llx", (unsigned long long)val->value.f_bits);
+    double f = 0.0;
+    memcpy(&f, &val->value.f_bits, sizeof(f));
+    char fbuffer[64];
+    if (sin_format_binary64_buf(f, fbuffer, sizeof(fbuffer))) {
+      logmsg("%s (bits=0x%016llx)", fbuffer, (unsigned long long)val->value.f_bits);
+    } else {
+      logmsg("0x%016llx", (unsigned long long)val->value.f_bits);
+    }
   } else {
     logmsg("%s", val->value.s);
   }
@@ -256,7 +263,14 @@ void as_reconstruct_item(AS_NODE *root) {
     if (val->valtype == V_INT || val->valtype == V_BOOLTRUE || val->valtype == V_BOOLFALSE) {
       logmsg("%lld", val->value.i);
     } else if (val->valtype == V_FLOAT) {
-      logmsg("0x%016llx", (unsigned long long)val->value.f_bits);
+      double f = 0.0;
+      memcpy(&f, &val->value.f_bits, sizeof(f));
+      char fbuffer[64];
+      if (sin_format_binary64_buf(f, fbuffer, sizeof(fbuffer))) {
+        logmsg("%s (bits=0x%016llx)", fbuffer, (unsigned long long)val->value.f_bits);
+      } else {
+        logmsg("0x%016llx", (unsigned long long)val->value.f_bits);
+      }
     } else {
       logmsg("%s", val->value.s);
     }

--- a/src/floatconv.c
+++ b/src/floatconv.c
@@ -3,7 +3,10 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <float.h>
 #include <locale.h>
+#include <math.h>
+#include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -48,6 +51,106 @@ static bool is_decimal_literal_syntax(const char *text) {
   }
 
   return *p == '\0';
+}
+
+static uint64_t double_bits(double value) {
+  uint64_t bits = 0;
+  memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+static bool parse_binary64_bits_noerr(const char *text, uint64_t *out_bits) {
+  double parsed = 0.0;
+  if (!sin_parse_binary64(text, &parsed, NULL)) return false;
+  *out_bits = double_bits(parsed);
+  return true;
+}
+
+static bool c_locale_snprintf(char *buf, size_t cap, const char *fmt, double value) {
+  if (cap == 0) return false;
+#if defined(__GLIBC__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+  locale_t c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+  if (c_locale == (locale_t)0) return false;
+  locale_t old_locale = uselocale(c_locale);
+  int n = snprintf(buf, cap, fmt, value);
+  uselocale(old_locale);
+  freelocale(c_locale);
+#else
+  struct lconv *lc = localeconv();
+  if (lc == NULL || lc->decimal_point == NULL || strcmp(lc->decimal_point, ".") != 0) return false;
+  int n = snprintf(buf, cap, fmt, value);
+#endif
+  return n >= 0 && (size_t)n < cap;
+}
+
+static bool add_decimal_marker(char *buf, size_t cap) {
+  if (strchr(buf, '.') != NULL) return true;
+  char *exp = strpbrk(buf, "eE");
+  size_t len = strlen(buf);
+  if (exp != NULL) {
+    size_t pos = (size_t)(exp - buf);
+    if (len + 2 >= cap) return false;
+    memmove(buf + pos + 2, buf + pos, len - pos + 1);
+    buf[pos] = '.';
+    buf[pos + 1] = '0';
+    return true;
+  }
+  if (len + 2 >= cap) return false;
+  buf[len] = '.';
+  buf[len + 1] = '0';
+  buf[len + 2] = '\0';
+  return true;
+}
+
+bool sin_format_binary64_buf(double value, char *buf, size_t cap) {
+  if (buf == NULL || cap == 0) return false;
+  buf[0] = '\0';
+
+  if (isnan(value)) {
+    const char *s = "nan";
+    if (strlen(s) + 1 > cap) return false;
+    memcpy(buf, s, strlen(s) + 1);
+    return true;
+  }
+  if (isinf(value)) {
+    const char *s = signbit(value) ? "-inf" : "inf";
+    if (strlen(s) + 1 > cap) return false;
+    memcpy(buf, s, strlen(s) + 1);
+    return true;
+  }
+  if (value == 0.0) {
+    const char *s = signbit(value) ? "-0.0" : "0.0";
+    if (strlen(s) + 1 > cap) return false;
+    memcpy(buf, s, strlen(s) + 1);
+    return true;
+  }
+
+  char candidate[64];
+  uint64_t target = double_bits(value);
+  for (int precision = 1; precision <= DBL_DECIMAL_DIG; precision++) {
+    char fmt[16];
+    snprintf(fmt, sizeof(fmt), "%%.%dg", precision);
+    if (!c_locale_snprintf(candidate, sizeof(candidate), fmt, value)) return false;
+    if (!add_decimal_marker(candidate, sizeof(candidate))) return false;
+    uint64_t parsed = 0;
+    if (parse_binary64_bits_noerr(candidate, &parsed) && parsed == target) {
+      if (strlen(candidate) + 1 > cap) return false;
+      memcpy(buf, candidate, strlen(candidate) + 1);
+      return true;
+    }
+  }
+
+  if (!c_locale_snprintf(candidate, sizeof(candidate), "%.17g", value)) return false;
+  if (!add_decimal_marker(candidate, sizeof(candidate))) return false;
+  if (strlen(candidate) + 1 > cap) return false;
+  memcpy(buf, candidate, strlen(candidate) + 1);
+  return true;
+}
+
+char *sin_format_binary64(double value) {
+  char tmp[64];
+  if (!sin_format_binary64_buf(value, tmp, sizeof(tmp))) return NULL;
+  return strdup(tmp);
 }
 
 bool sin_parse_binary64(const char *text, double *out, char **errdetail) {

--- a/src/floatconv.h
+++ b/src/floatconv.h
@@ -2,6 +2,18 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 
 bool sin_parse_binary64(const char *text, double *out, char **errdetail);
 bool sin_parse_binary64_bits(const char *text, uint64_t *out_bits, char **errdetail);
+
+/*
+ * Locale-stable binary64 formatting for logs and runtime string conversion.
+ * Finite results always include a decimal marker (for example, 1.0).
+ * The implementation prefers short libc-generated spellings that round-trip and
+ * falls back to DBL_DECIMAL_DIG precision when needed.  C99 requires decimal
+ * input conversion to recover the same binary64 value from DBL_DECIMAL_DIG
+ * significant digits, so this is stable even where Ryū/Grisu is unavailable.
+ */
+char *sin_format_binary64(double value);
+bool sin_format_binary64_buf(double value, char *buf, size_t cap);

--- a/src/libcall.c
+++ b/src/libcall.c
@@ -19,6 +19,7 @@
 #include "item.h"
 #include "compiler_pipeline.h"
 #include "interpret.h"
+#include "floatconv.h"
 
 // Configuration object.  Defined in sin.c
 extern CONFIG_t config;
@@ -80,7 +81,15 @@ uint8_t *lc_sys_log(uint8_t *nextop, ITEM_t *item) {
       free(val.s);
       break;
     case VALUE_int:
-      logmsg("%d", val.i);
+      logmsg("%ld", val.i);
+      break;
+    case VALUE_float:
+      char fbuffer[64];
+      if (sin_format_binary64_buf(val.f, fbuffer, sizeof(fbuffer))) {
+        logmsg("%s", fbuffer);
+      } else {
+        logmsg("<float-format-error>");
+      }
       break;
     case VALUE_nil:
       // One cannot logically output nil.
@@ -223,6 +232,13 @@ void execute_task_cb(uv_timer_t *req) {
     } else if (ret.type == VALUE_str) {
       logmsg("Bytecode interpreter returned: %s\n", ret.s);
       value_free(&ret);
+    } else if (ret.type == VALUE_float) {
+      char fbuffer[64];
+      if (sin_format_binary64_buf(ret.f, fbuffer, sizeof(fbuffer))) {
+        logmsg("Bytecode interpreter returned: %s\n", fbuffer);
+      } else {
+        logmsg("Bytecode interpreter returned: <float-format-error>\n");
+      }
     } else if (ret.type == VALUE_bool) {
       logmsg("Bytecode interpreter returned: %s\n", ret.i?"true":"false");
     } else if (ret.type == VALUE_nil) {
@@ -386,9 +402,10 @@ uint8_t *lc_net_write(uint8_t *nextop, ITEM_t *item) {
         telnet_send_text(line[linenum.i].telnet, buffer, strlen(buffer));
         break;
       case VALUE_float:
-        char fbuffer[32];
-        snprintf(fbuffer, sizeof(fbuffer), "%g", out.f);
-        telnet_send_text(line[linenum.i].telnet, fbuffer, strlen(fbuffer));
+        char fbuffer[64];
+        if (sin_format_binary64_buf(out.f, fbuffer, sizeof(fbuffer))) {
+          telnet_send_text(line[linenum.i].telnet, fbuffer, strlen(fbuffer));
+        }
         break;
       case VALUE_nil:
         // Nothing to output

--- a/src/sdiss.c
+++ b/src/sdiss.c
@@ -13,6 +13,7 @@
 #include "config.h"
 #include "memory.h"
 #include "log.h"
+#include "floatconv.h"
 #include "value.h"
 #include "item.h"
 #include "stack.h"
@@ -296,7 +297,11 @@ static uint8_t *h_float(uint8_t *p, uint8_t *e, decode_context_t c) {
   if (isnan(value)) class_name = "nan";
   else if (isinf(value)) class_name = signbit(value) ? "-inf" : "+inf";
   else if (value == 0.0) class_name = signbit(value) ? "-0.0" : "+0.0";
-  logmsg("FLOAT %.17g (%s bits=0x%016llx)\n", value, class_name, (unsigned long long)bits);
+  char fbuffer[64];
+  if (!sin_format_binary64_buf(value, fbuffer, sizeof(fbuffer))) {
+    snprintf(fbuffer, sizeof(fbuffer), "<float-format-error>");
+  }
+  logmsg("FLOAT %s (%s bits=0x%016llx)\n", fbuffer, class_name, (unsigned long long)bits);
   return p;
 }
 static uint8_t *h_bool(uint8_t *p, uint8_t *e, decode_context_t c) {

--- a/src/sin.c
+++ b/src/sin.c
@@ -17,6 +17,7 @@
 #include "error.h"
 #include "memory.h"
 #include "log.h"
+#include "floatconv.h"
 #include "network.h"
 #include "task.h"
 #include "value.h"
@@ -309,6 +310,13 @@ int main(int argc, char **argv) {
   } else if (ret.type == VALUE_str) {
     logmsg("Bytecode interpreter returned: %s\n", ret.s);
     FREE_ARRAY(char, ret.s, strlen(ret.s));
+  } else if (ret.type == VALUE_float) {
+    char fbuffer[64];
+    if (sin_format_binary64_buf(ret.f, fbuffer, sizeof(fbuffer))) {
+      logmsg("Bytecode interpreter returned: %s\n", fbuffer);
+    } else {
+      logmsg("Bytecode interpreter returned: <float-format-error>\n");
+    }
   } else if (ret.type == VALUE_bool) {
     logmsg("Bytecode interpreter returned: %s\n", ret.i?"true":"false");
   } else if (ret.type == VALUE_nil) {

--- a/src/value.c
+++ b/src/value.c
@@ -11,6 +11,7 @@
 
 #define VALUE_INTERNAL
 #include "value.h"
+#include "floatconv.h"
 
 _Static_assert(sizeof(double) == 8, "VALUE_float requires 64-bit double");
 _Static_assert(DBL_MANT_DIG == 53, "VALUE_float requires IEEE 754 binary64 precision");
@@ -350,7 +351,9 @@ const char *value_debug_string(const VALUE_t *value, char *buffer, size_t buffer
       snprintf(buffer, buffer_size, "%s", value->i ? "true" : "false");
       break;
     case VALUE_float:
-      snprintf(buffer, buffer_size, "%g", value->f);
+      if (!sin_format_binary64_buf(value->f, buffer, buffer_size)) {
+        snprintf(buffer, buffer_size, "<float-format-error>");
+      }
       break;
     case VALUE_str:
       snprintf(buffer, buffer_size, "'%s'", value->s ? value->s : "");

--- a/tests/core/test_parser_float_literals.c
+++ b/tests/core/test_parser_float_literals.c
@@ -155,6 +155,61 @@ static void assert_parse_rejected(const char *literal) {
   free(errdetail);
 }
 
+static void assert_format_text(uint64_t bits, const char *expected) {
+  double value = 0.0;
+  memcpy(&value, &bits, sizeof(value));
+  char buf[64];
+  ASSERT_TRUE(sin_format_binary64_buf(value, buf, sizeof(buf)));
+  ASSERT_TRUE(strcmp(buf, expected) == 0);
+}
+
+static void assert_format_roundtrip(uint64_t bits) {
+  double value = 0.0;
+  memcpy(&value, &bits, sizeof(value));
+  char buf[64];
+  ASSERT_TRUE(sin_format_binary64_buf(value, buf, sizeof(buf)));
+  uint64_t reparsed = 0;
+  char *errdetail = NULL;
+  ASSERT_TRUE(sin_parse_binary64_bits(buf, &reparsed, &errdetail));
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_TRUE(reparsed == bits);
+}
+
+void test_floatconv_binary64_formatting(void) {
+  assert_format_text(UINT64_C(0x0000000000000000), "0.0");
+  assert_format_text(UINT64_C(0x8000000000000000), "-0.0");
+  assert_format_text(UINT64_C(0x7ff0000000000000), "inf");
+  assert_format_text(UINT64_C(0xfff0000000000000), "-inf");
+  assert_format_text(UINT64_C(0x7ff8000000000042), "nan");
+  assert_format_text(UINT64_C(0x3ff0000000000000), "1.0");
+  assert_format_text(UINT64_C(0x3ff8000000000000), "1.5");
+
+  char small[3];
+  double one = 1.0;
+  ASSERT_TRUE(!sin_format_binary64_buf(one, small, sizeof(small)));
+  char *allocated = sin_format_binary64(one);
+  ASSERT_NOT_NULL(allocated);
+  ASSERT_TRUE(strcmp(allocated, "1.0") == 0);
+  free(allocated);
+}
+
+void test_floatconv_binary64_format_roundtrip(void) {
+  const uint64_t cases[] = {
+    UINT64_C(0x3fb999999999999a), /* 0.1 */
+    UINT64_C(0x400921fb54442d18), /* pi-ish */
+    UINT64_C(0x7fefffffffffffff),
+    UINT64_C(0x0000000000000001),
+    UINT64_C(0x0010000000000000),
+    UINT64_C(0x433fffffffffffff),
+    UINT64_C(0x4340000000000001),
+    UINT64_C(0xbff0000000000000),
+    UINT64_C(0xc008000000000000),
+  };
+  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+    assert_format_roundtrip(cases[i]);
+  }
+}
+
 void test_floatconv_binary64_edge_cases(void) {
   /* Exact integers around 2^53. */
   assert_parse_bits("9007199254740991.0", UINT64_C(0x433fffffffffffff));

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -44,6 +44,8 @@ void test_parser_float_literals_integer_still_int(void);
 void test_parser_float_literals_item_layers_unchanged(void);
 void test_parser_float_literals_malformed_rejected(void);
 void test_floatconv_binary64_edge_cases(void);
+void test_floatconv_binary64_formatting(void);
+void test_floatconv_binary64_format_roundtrip(void);
 void test_fixture_policy_declared_goldens_exist(void);
 void test_find_item_cached_hit_and_negative_cache(void);
 void test_find_item_cached_invalidation_on_delete_and_reinsert(void);
@@ -176,6 +178,8 @@ static const test_case_t core_tests[] = {
     {"test_parser_float_literals_item_layers_unchanged", test_parser_float_literals_item_layers_unchanged},
     {"test_parser_float_literals_malformed_rejected", test_parser_float_literals_malformed_rejected},
     {"test_floatconv_binary64_edge_cases", test_floatconv_binary64_edge_cases},
+    {"test_floatconv_binary64_formatting", test_floatconv_binary64_formatting},
+    {"test_floatconv_binary64_format_roundtrip", test_floatconv_binary64_format_roundtrip},
     {"test_fixture_policy_declared_goldens_exist", test_fixture_policy_declared_goldens_exist},
     {"test_find_item_cached_hit_and_negative_cache", test_find_item_cached_hit_and_negative_cache},
     {"test_find_item_cached_invalidation_on_delete_and_reinsert", test_find_item_cached_invalidation_on_delete_and_reinsert},


### PR DESCRIPTION
### Motivation
- Provide a locale-stable, deterministic float formatting API for logs and runtime string conversions that preserves sign/NaN/infinity and supports roundtrip behaviour for binary64 values. 
- Ensure runtime logging and debug paths print finite whole-number floats with an explicit decimal marker so `1.0` and `1` are distinguishable.
- Add tests that verify formatting roundtrips to the identical binary64 bit pattern for finite values.

### Description
- Added APIs `sin_format_binary64(double)` and `sin_format_binary64_buf(double, char *, size_t)` in `src/floatconv.h` and implemented them in `src/floatconv.c` using a shortest-roundtrip search over libc `%g` precisions with a `DBL_DECIMAL_DIG` loop and a `%.17g` fallback, plus logic to force a decimal marker and handle `+0.0`, `-0.0`, `NaN`, `inf`, and `-inf` explicitly. 
- Integrated the new formatting into runtime/logging and debug paths including `sys.log` and related libcalls, interpreter return logging, `net.write`, disassembly (`src/sdiss.c`), AST pretty printing (`src/compiler/absyn.c`), and value debug strings (`src/value.c`). 
- Minor related fixes to formatting conventions (use of `"%ld"` for ints where appropriate) and added the convenience allocator wrapper `sin_format_binary64` which returns a `strdup`-ed string on success. 
- Added tests (`test_floatconv_binary64_formatting` and `test_floatconv_binary64_format_roundtrip`) to `tests/core/test_parser_float_literals.c` and registered them in the shared test harness in `tests/shared/test_compiler.c`.

### Testing
- Ran the full test suite via `make test`. 
- All tests completed successfully: test harness reported `status=PASS` with `suites=3` and `tests=87/87`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fbf17659c832eaba72a80f6d1f996)