### PR TITLE
Make float item layer behavior explicit

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -19,6 +19,19 @@ Items are nominally hierarchical, although this is only an organisational strate
 `foo.bar.baz`  
 …although there is nothing can be inferred from `foo.bar` by its relationship with `foo`.
 
+Item layer names are strings. Integer layer literals and integer-valued
+dereferences are converted to canonical base-10 integer text, so `foo.1` and
+`foo.[@i]` with `@i = 1` address the same layer. Float values are not permitted
+as layer names or as dereference results used to build a layer name: a literal
+such as `foo.1.0` is parsed as layers `foo`, `1`, and `0`, not as a float layer,
+and a runtime dereference that evaluates to a float makes item assembly fail and
+produce `nil`. Consequently `1`, `1.0`, and `1.00` do not have three
+float-derived item-name spellings: only integer `1` is supported as a numeric
+layer value, while the dotted forms are normal multi-layer string names if
+written explicitly. Likewise `+0.0` and `-0.0` have no item-name mapping, and
+NaN payloads are neither preserved nor normalized for item names because NaN
+float values are rejected rather than formatted.
+
 To assign an item, use the assignment operator, `=`.  If the item does not exist, it will be created (as will all of its parents, if it is a multi-layered item).  If the item exists, its value will be overwritten with the new value.  An item which does not exist has the default value of `nil`.  Thus:  
 `foo = 10;`  
 `bar = 10 * foo;`  

--- a/src/compiler/lower.c
+++ b/src/compiler/lower.c
@@ -112,6 +112,10 @@ static void lower_layer_part(LOWER_CTX *ctx, AS_NODE *part) {
                                    .imm = (int64_t)(intptr_t)layer});
       }
       return;
+    case V_FLOAT:
+      lower_set_error(ctx, ERR_COMP_SYNTAX,
+                      "float literals are not permitted as item layers");
+      return;
     default:
       lower_set_unsupported(ctx, part, "unsupported item layer value type");
       return;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -1060,6 +1060,11 @@ uint8_t *assembleitem_helper(uint8_t *nextop, ITEM_t *item, bool relative) {
                 just_processed_layer = true;
                 break;
               }
+              case VALUE_float: {
+                logerr("Float value cannot be used as an item layer name.\n");
+                invalid = true;
+                break;
+              }
               case VALUE_nil: {
                 if (!saw_non_missing_layer && !saw_missing_layer) {
                   saw_missing_layer = true;
@@ -1073,7 +1078,7 @@ uint8_t *assembleitem_helper(uint8_t *nextop, ITEM_t *item, bool relative) {
               }
               default: {
                 // Not a valid value type to convert into a layer name.
-                logerr("Layer type (%d) not int or string.\n", *nextop);
+                logerr("Layer type (%d) not int or string.\n", VM->stack->stack[idx].type);
                 invalid = true;
               }
             }
@@ -1122,6 +1127,12 @@ uint8_t *assembleitem_helper(uint8_t *nextop, ITEM_t *item, bool relative) {
                     just_processed_layer = true;
                     break;
                   }
+                  case VALUE_float: {
+                    logerr("Item dereference failed for '%s': float value cannot be used as an item layer name.\n",
+                           layername.s);
+                    invalid = true;
+                    break;
+                  }
                   case VALUE_nil: {
                     if (!saw_non_missing_layer && !saw_missing_layer) {
                       saw_missing_layer = true;
@@ -1160,6 +1171,9 @@ uint8_t *assembleitem_helper(uint8_t *nextop, ITEM_t *item, bool relative) {
         logerr("Invalid layer type '%c' (%d).\n", *nextop, *nextop);
         invalid = true;
       }
+    }
+    if (invalid) {
+      break;
     }
     if (missing_layer_possibly_leading && saw_non_missing_layer) {
       missing_layer_is_leading = true;

--- a/src/item.c
+++ b/src/item.c
@@ -78,6 +78,14 @@ extern CONFIG_t config;
 
 static bool validate_item_name(const char *item_name,
                                                const char *func_name) {
+  /*
+   * Item names are already-assembled strings, not numeric values. Integer
+   * layers may be assembled by the compiler/runtime using base-10 integer
+   * text, but float values are rejected before this API is called. Therefore
+   * this validator treats dots only as layer separators: "1.0" is the two
+   * layers "1" and "0", not the float spellings "1.0" or "1.00"; +0.0/-0.0
+   * and NaN payloads have no item-name representation.
+   */
   if (!item_name || *item_name == '\0') {
     logerr("%s called with empty item name.\n", func_name);
     return false;

--- a/tests/core/test_relative_item_leading_dot.c
+++ b/tests/core/test_relative_item_leading_dot.c
@@ -2,9 +2,16 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "config.h"
 #include "compiler_pipeline.h"
 #include "error.h"
+#include "interpret.h"
+#include "item.h"
 #include "test_assert.h"
+#include "value.h"
+#include "vm.h"
+
+extern CONFIG_t config;
 
 static void assert_compile_ok(const char *name, const char *source) {
   OUTPUT_t *out = NULL;
@@ -28,6 +35,41 @@ static void assert_compile_err(const char *source, int8_t expected_code,
   ASSERT_NOT_NULL(errdetail);
   ASSERT_TRUE(strstr(errdetail, expected_substr) != NULL);
   free(errdetail);
+}
+
+static VALUE_t compile_and_run(const char *name, const char *source) {
+  OUTPUT_t *out = NULL;
+  char *errdetail = NULL;
+  int8_t rc = compile_source_to_bytecode(source, strlen(source), &out, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_NOT_NULL(out);
+
+  uint32_t len = (uint32_t)(out->nextbyte - out->bytecode);
+  uint8_t *bytecode = malloc(len);
+  ASSERT_NOT_NULL(bytecode);
+  memcpy(bytecode, out->bytecode, len);
+  ITEM_t *code = insert_code_item(config.itemroot, name, len, bytecode);
+  ASSERT_NOT_NULL(code);
+  VALUE_t result = interpret(code);
+
+  free(out->bytecode);
+  free(out);
+  return result;
+}
+
+static void setup_runtime(void) {
+  memset(&config, 0, sizeof(config));
+  config.itemroot = make_root_item("root");
+  ASSERT_NOT_NULL(config.itemroot);
+  config.vm = make_vm();
+  ASSERT_NOT_NULL(config.vm);
+}
+
+static void teardown_runtime(void) {
+  destroy_vm(config.vm);
+  destroy_item(config.itemroot);
+  memset(&config, 0, sizeof(config));
 }
 
 void test_relative_item_leading_dot_parse_accepts_deref_chain(void) {
@@ -63,4 +105,17 @@ void test_relative_item_leading_dot_existing_absolute_item_unchanged(void) {
 
 void test_relative_item_leading_dot_parse_still_rejects_bad_double_dot(void) {
   assert_compile_err("foo..bar = 1;", ERR_COMP_SYNTAX, "syntax error");
+}
+
+void test_float_item_literal_layer_rejected_at_compile_time(void) {
+  assert_compile_err("foo.1.0 = 1;", ERR_COMP_SYNTAX, "syntax");
+}
+
+void test_float_local_deref_layer_returns_nil_and_does_not_save_item(void) {
+  setup_runtime();
+  VALUE_t result = compile_and_run("test.floatlocal",
+                                   "@layer = 1.0; foo.[@layer] = 7; foo;");
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  ASSERT_TRUE(find_item(config.itemroot, "foo") == NULL);
+  teardown_runtime();
 }

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -66,6 +66,8 @@ void test_relative_item_leading_dot_nil_or_empty_non_leading_rejected(void);
 void test_relative_item_leading_dot_boundary_max_name_after_prefix_expansion_compiles(void);
 void test_relative_item_leading_dot_existing_absolute_item_unchanged(void);
 void test_relative_item_leading_dot_parse_still_rejects_bad_double_dot(void);
+void test_float_item_literal_layer_rejected_at_compile_time(void);
+void test_float_local_deref_layer_returns_nil_and_does_not_save_item(void);
 void test_value_integer_arithmetic_helpers(void);
 void test_value_arithmetic_invalid_and_nil_operands(void);
 void test_value_push_int_interprets_i64_immediates(void);
@@ -190,6 +192,8 @@ static const test_case_t core_tests[] = {
     {"test_relative_item_leading_dot_boundary_max_name_after_prefix_expansion_compiles", test_relative_item_leading_dot_boundary_max_name_after_prefix_expansion_compiles},
     {"test_relative_item_leading_dot_existing_absolute_item_unchanged", test_relative_item_leading_dot_existing_absolute_item_unchanged},
     {"test_relative_item_leading_dot_parse_still_rejects_bad_double_dot", test_relative_item_leading_dot_parse_still_rejects_bad_double_dot},
+    {"test_float_item_literal_layer_rejected_at_compile_time", test_float_item_literal_layer_rejected_at_compile_time},
+    {"test_float_local_deref_layer_returns_nil_and_does_not_save_item", test_float_local_deref_layer_returns_nil_and_does_not_save_item},
     {"test_value_integer_arithmetic_helpers", test_value_integer_arithmetic_helpers},
     {"test_value_arithmetic_invalid_and_nil_operands", test_value_arithmetic_invalid_and_nil_operands},
     {"test_value_push_int_interprets_i64_immediates", test_value_push_int_interprets_i64_immediates},


### PR DESCRIPTION
### Motivation

- Clarify and enforce that floating-point values are not valid item layer names or dereference results to avoid ambiguous name construction and surprising runtime behavior.

### Description

- In the compiler lowering (`lower_layer_part` in `src/compiler/lower.c`) reject `V_FLOAT` layers with a clear syntax diagnostic (`"float literals are not permitted as item layers"`).
- In the runtime (`assembleitem_helper` in `src/interpret.c`) reject `VALUE_float` when assembling a layer from a local or from an item dereference, log an error, mark the assembly invalid, and produce `nil` instead of formatting a float as a name.
- Stop invalid assembly from continuing to consume following bytecode by breaking out when `invalid` is set during item assembly in `src/interpret.c`.
- Document item-name semantics in `docs/concepts.md` and add a clarifying note to `src/item.c` explaining that assembled item names are strings, dots separate layers, integer layers are canonicalized as base-10 text, and floats (including +0.0/-0.0 and NaN payloads) have no item-name mapping and are rejected.
- Add tests in `tests/core/test_relative_item_leading_dot.c` and register them in `tests/shared/test_compiler.c` that assert a float-like literal item layer is rejected at compile time and that a runtime local dereference evaluating to a float yields `nil` and does not save an item.

### Testing

- Ran the full test suite with `make test`; all tests passed (suites: core, compiler, runtime; total tests: 89) and the new tests exercise the compile-time and runtime rejection paths for float-derived layers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fefebcc78832ebcaa474c44a86783)