### PR TITLE
Add structured float test coverage

### DIFF
--- a/tests/core/test_parser_float_literals.c
+++ b/tests/core/test_parser_float_literals.c
@@ -48,10 +48,10 @@ static uint64_t bits_for_double(double value) {
 }
 
 void test_parser_float_literals_decimal_forms(void) {
-  AS_NODE *root = parse_ok("1.0; 0.5; 1.25e2;");
+  AS_NODE *root = parse_ok("1.0; 0.5; 1.25e2; 6.022E+23; 1.0e-3;");
   ASSERT_EQ_INT(N_STMTLIST, root->nodetype);
   AS_STMTLIST *list = (AS_STMTLIST *)root->lhs;
-  ASSERT_EQ_INT(3, list->count);
+  ASSERT_EQ_INT(5, list->count);
 
   AS_NODE *stmt = list->stmts[0];
   ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
@@ -76,6 +76,22 @@ void test_parser_float_literals_decimal_forms(void) {
   value = (AS_VALUE *)value_node->lhs;
   ASSERT_EQ_INT(V_FLOAT, value->valtype);
   ASSERT_TRUE(value->value.f_bits == bits_for_double(125.0));
+
+  stmt = list->stmts[3];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  value_node = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_VALUE, value_node->nodetype);
+  value = (AS_VALUE *)value_node->lhs;
+  ASSERT_EQ_INT(V_FLOAT, value->valtype);
+  ASSERT_TRUE(value->value.f_bits == bits_for_double(6.022e23));
+
+  stmt = list->stmts[4];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  value_node = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_VALUE, value_node->nodetype);
+  value = (AS_VALUE *)value_node->lhs;
+  ASSERT_EQ_INT(V_FLOAT, value->valtype);
+  ASSERT_TRUE(value->value.f_bits == bits_for_double(1.0e-3));
 
   as_delete(root);
 }
@@ -136,6 +152,8 @@ void test_parser_float_literals_item_layers_unchanged(void) {
 
 void test_parser_float_literals_malformed_rejected(void) {
   parse_fails("1.;");
+  parse_fails("1.0e;");
+  parse_fails("1.0e+;");
   parse_fails("1.2.3;");
 }
 

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -52,6 +52,30 @@ static VALUE_t run_code(const char *name, const uint8_t *template_code, size_t l
   return interpret(code);
 }
 
+
+static VALUE_t run_float_unary(uint64_t bits, uint8_t op, const char *name) {
+  uint8_t code[32] = {0};
+  size_t pos = 0;
+  code[pos++] = 0;
+  code[pos++] = 0;
+  code[pos++] = 'P'; emit_u64(code, &pos, bits);
+  code[pos++] = op;
+  code[pos++] = 'h';
+  return run_code(name, code, pos);
+}
+
+static VALUE_t run_float_binary(uint64_t lhs, uint64_t rhs, uint8_t op, const char *name) {
+  uint8_t code[64] = {0};
+  size_t pos = 0;
+  code[pos++] = 0;
+  code[pos++] = 0;
+  code[pos++] = 'P'; emit_u64(code, &pos, lhs);
+  code[pos++] = 'P'; emit_u64(code, &pos, rhs);
+  code[pos++] = op;
+  code[pos++] = 'h';
+  return run_code(name, code, pos);
+}
+
 void test_value_integer_arithmetic_helpers(void) {
   VALUE_t left = {VALUE_int, {.i = 9}};
   VALUE_t right = {VALUE_int, {.i = 4}};
@@ -230,6 +254,32 @@ void test_value_float_arithmetic_interpreter_bytecode(void) {
   ASSERT_TRUE(value_float_to_bits(result.f) == UINT64_C(0x8000000000000000));
   value_free(&result);
 
+  result = run_float_binary(UINT64_C(0x0010000000000000), UINT64_C(0x0000000000000001), 'a',
+                            "test.float_subnorm_add");
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(value_float_to_bits(result.f) == UINT64_C(0x0010000000000001));
+  value_free(&result);
+
+  result = run_float_binary(UINT64_C(0x7ff8000000000042), UINT64_C(0x3ff0000000000000), 'a',
+                            "test.float_nan_prop");
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE((value_float_to_bits(result.f) & UINT64_C(0x7ff0000000000000)) == UINT64_C(0x7ff0000000000000));
+  ASSERT_TRUE((value_float_to_bits(result.f) & UINT64_C(0x000fffffffffffff)) != 0);
+  value_free(&result);
+
+  pos = 0;
+  code[pos++] = 1;
+  code[pos++] = 0;
+  code[pos++] = 'P'; emit_u64(code, &pos, UINT64_C(0x8000000000000000)); /* -0.0 */
+  code[pos++] = 'c'; code[pos++] = 0;
+  code[pos++] = 'e'; code[pos++] = 0;
+  code[pos++] = 'h';
+
+  result = run_code("test.float_store_neg0", code, pos);
+  ASSERT_EQ_INT(VALUE_float, result.type);
+  ASSERT_TRUE(value_float_to_bits(result.f) == UINT64_C(0x8000000000000000));
+  value_free(&result);
+
   teardown_runtime();
 }
 
@@ -401,9 +451,34 @@ void test_value_comparison_float_ieee754_helpers(void) {
   ASSERT_TRUE(value_not_equal(&quiet_nan, &negative_nan));
   ASSERT_TRUE(value_not_equal(&quiet_nan, &one));
   ASSERT_TRUE(!value_less_than(&quiet_nan, &one));
+  ASSERT_TRUE(!value_less_than(&one, &quiet_nan));
   ASSERT_TRUE(!value_less_equal(&quiet_nan, &quiet_nan));
+  ASSERT_TRUE(!value_greater_than(&quiet_nan, &one));
   ASSERT_TRUE(!value_greater_than(&one, &quiet_nan));
   ASSERT_TRUE(!value_greater_equal(&quiet_nan, &negative_nan));
+
+  setup_runtime();
+  VALUE_t cmp = run_float_binary(UINT64_C(0x7ff8000000000042), UINT64_C(0x7ff8000000000042), 'o',
+                                 "test.float_nan_eq");
+  ASSERT_EQ_INT(VALUE_bool, cmp.type);
+  ASSERT_TRUE(cmp.i == 0);
+  value_free(&cmp);
+  cmp = run_float_binary(UINT64_C(0x7ff8000000000042), UINT64_C(0x7ff8000000000042), 'q',
+                         "test.float_nan_neq");
+  ASSERT_EQ_INT(VALUE_bool, cmp.type);
+  ASSERT_TRUE(cmp.i == 1);
+  value_free(&cmp);
+  cmp = run_float_binary(UINT64_C(0x0000000000000000), UINT64_C(0x8000000000000000), 'o',
+                         "test.float_zero_eq");
+  ASSERT_EQ_INT(VALUE_bool, cmp.type);
+  ASSERT_TRUE(cmp.i == 1);
+  value_free(&cmp);
+  VALUE_t neg = run_float_unary(UINT64_C(0x8000000000000000), 'n',
+                                "test.float_neg_neg0");
+  ASSERT_EQ_INT(VALUE_float, neg.type);
+  ASSERT_TRUE(value_float_to_bits(neg.f) == UINT64_C(0x0000000000000000));
+  value_free(&neg);
+  teardown_runtime();
 }
 
 void test_value_comparison_bool_helpers(void) {

--- a/tests/fixtures/float_literal.hex
+++ b/tests/fixtures/float_literal.hex
@@ -1,0 +1,4 @@
+00 00          # header: locals=0 params=0
+50             # P: push float
+00 00 00 00 00 00 f8 3f  # binary64 1.5 (LE)
+68             # h: halt

--- a/tests/fixtures/mixed_float_arithmetic.hex
+++ b/tests/fixtures/mixed_float_arithmetic.hex
@@ -1,0 +1,7 @@
+00 00          # header: locals=0 params=0
+70             # p: push int
+02 00 00 00 00 00 00 00  # int64 2
+50             # P: push float
+00 00 00 00 00 00 e0 3f  # binary64 0.5 (LE)
+61             # a: add
+68             # h: halt

--- a/tests/shared/test_pipeline_cases.c
+++ b/tests/shared/test_pipeline_cases.c
@@ -8,6 +8,7 @@
 
 static AS_NODE *v_int(int64_t n) { return t_int(n); }
 static AS_NODE *v_str(const char *s) { return as_new_valnode(V_STR, strdup(s)); }
+static AS_NODE *v_float_bits(uint64_t bits) { return t_node(N_VALUE, as_new_value(V_FLOAT, bits, NULL), NULL); }
 
 static AS_NODE *build_int_literal_program(void) {
   AS_NODE *stmt = t_node(N_EXPRSTMT, v_int(42), NULL);
@@ -28,6 +29,17 @@ static AS_NODE *build_locals_store_load_program(void) {
 
 static AS_NODE *build_arithmetic_program(void) {
   AS_NODE *add = t_node(N_ADD, v_int(2), v_int(3));
+  AS_NODE *stmt = t_node(N_EXPRSTMT, add, NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_float_literal_program(void) {
+  AS_NODE *stmt = t_node(N_EXPRSTMT, v_float_bits(UINT64_C(0x3ff8000000000000)), NULL);
+  return t_stmtlist_with_one(stmt);
+}
+
+static AS_NODE *build_mixed_float_arithmetic_program(void) {
+  AS_NODE *add = t_node(N_ADD, v_int(2), v_float_bits(UINT64_C(0x3fe0000000000000)));
   AS_NODE *stmt = t_node(N_EXPRSTMT, add, NULL);
   return t_stmtlist_with_one(stmt);
 }
@@ -56,6 +68,10 @@ static const PipelineGoldenCase PIPELINE_CASES[] = {
      PIPELINE_LAYER_AST | PIPELINE_LAYER_SOURCE},
     {"arithmetic_add", build_arithmetic_program, "2 + 3;", "tests/fixtures/arithmetic_add.hex",
      PIPELINE_LAYER_AST | PIPELINE_LAYER_SOURCE},
+    {"float_literal", build_float_literal_program, "1.5;", "tests/fixtures/float_literal.hex",
+     PIPELINE_LAYER_AST | PIPELINE_LAYER_SOURCE},
+    {"mixed_float_arithmetic", build_mixed_float_arithmetic_program, "2 + 0.5;",
+     "tests/fixtures/mixed_float_arithmetic.hex", PIPELINE_LAYER_AST | PIPELINE_LAYER_SOURCE},
     {"boolean_compare", build_boolean_compare_program, NULL, "tests/fixtures/boolean_compare.hex",
      PIPELINE_LAYER_AST},
     {"simple_if", build_simple_if_program, NULL, "tests/fixtures/simple_if.hex", PIPELINE_LAYER_AST},


### PR DESCRIPTION
### Motivation
- Improve confidence in IEEE-754 binary64 support across the compiler and VM by exercising parsing, bytecode emission, interpreter semantics, comparison rules, and formatting/roundtrip behavior for common and edge-case float values.
- Capture exact `IR_OP_PUSH_FLOAT` payload semantics in pipeline/golden fixtures so byte-for-byte binary64 immediates are verified by compiler pipeline tests.
- Verify runtime numeric semantics (subnormals, infinities, NaNs, signed zero, and mixed int/float promotion) with focused interpreter tests.

### Description
- Expanded parser tests in `tests/core/test_parser_float_literals.c` to include uppercase signed exponent forms and negative exponents and to reject malformed exponent spellings.
- Added bytecode helper functions and interpreter tests in `tests/core/test_value_behavior.c` (`run_float_unary`/`run_float_binary`) that exercise subnormal arithmetic, NaN propagation, signed-zero storage/negation, and exact `push float` payload behavior.
- Added AST/golden pipeline cases in `tests/shared/test_pipeline_cases.c` and new bytecode fixtures `tests/fixtures/float_literal.hex` and `tests/fixtures/mixed_float_arithmetic.hex` to assert exact 8-byte binary64 payload layouts emitted for float immediates.
- Small test harness/test-case wiring updates to include the new cases and ensure they run under the existing test harness.

### Testing
- Ran the full test suite with `make test` and the harness completed with all tests passing (`tests=92/92`).
- New and modified tests exercised parser, emitter/bytecode, and interpreter float behavior and succeeded under the CI-style test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ffcacb538832eadd32ec6854936ff)