### PR TITLE
Make IEEE 754 binary64 assumptions explicit and add runtime environment test

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -2,7 +2,6 @@
 
 // Licensed under the MIT License - see LICENSE file for details.
 
-#include <float.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -12,11 +11,6 @@
 #define VALUE_INTERNAL
 #include "value.h"
 #include "floatconv.h"
-
-_Static_assert(sizeof(double) == 8, "VALUE_float requires 64-bit double");
-_Static_assert(DBL_MANT_DIG == 53, "VALUE_float requires IEEE 754 binary64 precision");
-_Static_assert(DBL_MAX_EXP == 1024, "VALUE_float requires IEEE 754 binary64 exponent range");
-_Static_assert(FLT_RADIX == 2, "VALUE_float requires binary floating-point radix");
 
 const VALUE_t VALUE_NIL = {.type = VALUE_nil, .i = 0};
 const VALUE_t VALUE_TRUE = {.type = VALUE_bool, .i = 1};

--- a/src/value.h
+++ b/src/value.h
@@ -7,6 +7,21 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <float.h>
+#include <limits.h>
+
+/*
+ * Sin serializes and interprets VALUE_float as IEEE 754 binary64. Keep these
+ * requirements at the value boundary so every user of VALUE_t gets an early
+ * compile-time failure on unsupported floating-point targets.
+ */
+_Static_assert(CHAR_BIT == 8, "VALUE_float binary64 payloads require 8-bit bytes");
+_Static_assert(sizeof(uint64_t) == 8, "VALUE_float binary64 payloads require 64-bit uint64_t");
+_Static_assert(sizeof(double) == 8, "VALUE_float requires 64-bit double");
+_Static_assert(FLT_RADIX == 2, "VALUE_float requires binary floating-point radix");
+_Static_assert(DBL_MANT_DIG == 53, "VALUE_float requires IEEE 754 binary64 precision");
+_Static_assert(DBL_MAX_EXP == 1024, "VALUE_float requires IEEE 754 binary64 exponent range");
+_Static_assert(DBL_MIN_EXP == -1021, "VALUE_float requires IEEE 754 binary64 minimum exponent");
 
 typedef enum { VALUE_int,
                VALUE_float,

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -74,6 +75,25 @@ static VALUE_t run_float_binary(uint64_t lhs, uint64_t rhs, uint8_t op, const ch
   code[pos++] = op;
   code[pos++] = 'h';
   return run_code(name, code, pos);
+}
+
+
+void test_value_ieee754_environment_contract(void) {
+  volatile double one = 1.0;
+  volatile double positive_zero = 0.0;
+  volatile double negative_zero = -0.0;
+
+  double infinity = one / positive_zero;
+  double nan = positive_zero / positive_zero;
+
+  ASSERT_TRUE(isinf(infinity));
+  ASSERT_TRUE(!signbit(infinity));
+  ASSERT_TRUE(isnan(nan));
+  ASSERT_TRUE(signbit(negative_zero));
+  ASSERT_TRUE(!signbit(positive_zero));
+  ASSERT_TRUE(positive_zero == negative_zero);
+  ASSERT_TRUE(value_float_to_bits(positive_zero) == UINT64_C(0x0000000000000000));
+  ASSERT_TRUE(value_float_to_bits(negative_zero) == UINT64_C(0x8000000000000000));
 }
 
 void test_value_integer_arithmetic_helpers(void) {

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -71,6 +71,7 @@ void test_relative_item_leading_dot_existing_absolute_item_unchanged(void);
 void test_relative_item_leading_dot_parse_still_rejects_bad_double_dot(void);
 void test_float_item_literal_layer_rejected_at_compile_time(void);
 void test_float_local_deref_layer_returns_nil_and_does_not_save_item(void);
+void test_value_ieee754_environment_contract(void);
 void test_value_integer_arithmetic_helpers(void);
 void test_value_arithmetic_invalid_and_nil_operands(void);
 void test_value_push_int_interprets_i64_immediates(void);
@@ -197,6 +198,7 @@ static const test_case_t core_tests[] = {
     {"test_relative_item_leading_dot_parse_still_rejects_bad_double_dot", test_relative_item_leading_dot_parse_still_rejects_bad_double_dot},
     {"test_float_item_literal_layer_rejected_at_compile_time", test_float_item_literal_layer_rejected_at_compile_time},
     {"test_float_local_deref_layer_returns_nil_and_does_not_save_item", test_float_local_deref_layer_returns_nil_and_does_not_save_item},
+    {"test_value_ieee754_environment_contract", test_value_ieee754_environment_contract},
     {"test_value_integer_arithmetic_helpers", test_value_integer_arithmetic_helpers},
     {"test_value_arithmetic_invalid_and_nil_operands", test_value_arithmetic_invalid_and_nil_operands},
     {"test_value_push_int_interprets_i64_immediates", test_value_push_int_interprets_i64_immediates},


### PR DESCRIPTION
### Motivation
- Ensure the codebase fails to build on platforms that do not provide IEEE 754 binary64 semantics at the VALUE_t boundary. 
- Provide an automated runtime check that the C environment behaves as expected for infinity, NaN, and signed zero so float assumptions are continuously validated. 
- Run the check as part of the existing core test suite so CI exercises the contract alongside compiler and interpreter tests. 

### Description
- Move and expand compile-time checks into `src/value.h` with `_Static_assert` for `CHAR_BIT`, `sizeof(uint64_t)`, `sizeof(double)`, `FLT_RADIX`, `DBL_MANT_DIG`, `DBL_MAX_EXP`, and `DBL_MIN_EXP`. 
- Remove duplicate/relocated compile-time asserts from `src/value.c`. 
- Add `test_value_ieee754_environment_contract` to `tests/core/test_value_behavior.c` that verifies `1.0/0.0` yields infinity, `0.0/0.0` yields NaN, `+0.0` and `-0.0` have distinct sign bits, `+0.0 == -0.0`, and the correct bit patterns via `value_float_to_bits`. 
- Register the new test in the core test suite in `tests/shared/test_compiler.c` so it runs under the existing `make test` harness. 

### Testing
- Built and ran the full test harness with `make test`. 
- All automated tests completed successfully (`tests=93/93`, test-harness summary status=PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ffdd3c3e4832e97d48eae3387b40a)