### PR TITLE
Guard single-byte interpreter operands

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -336,27 +336,33 @@ uint8_t *op_pushbool(uint8_t *nextop, ITEM_t *item) {
 uint8_t *op_inclocal(uint8_t *nextop, ITEM_t *item) {
   // Interpret the next byte as an index into the locals.
   // If that local is an int, increment it.  Otherwise complain.
-  uint8_t index = *nextop + VM->stack->base;
+  uint8_t raw_index;
+  nextop = bc_read_u8(nextop, &raw_index, "OP_INCLOCAL");
+  if (!nextop) return NULL;
+  uint8_t index = raw_index + VM->stack->base;
   if (VM->stack->stack[index].type == VALUE_int) {
     VM->stack->stack[index].i++;
   } else {
     logerr("Trying to increment non integer local variable.\n");
   }
   DISASS_LOG("OP_INCLOCAL: index %d\n", index);
-  return nextop+1;
+  return nextop;
 }
 
 uint8_t *op_declocal(uint8_t *nextop, ITEM_t *item) {
   // Interpret the next byte as an index into the locals.
   // If that local is an int, decrement it.  Otherwise complain.
-  uint8_t index = *nextop + VM->stack->base;
+  uint8_t raw_index;
+  nextop = bc_read_u8(nextop, &raw_index, "OP_DECLOCAL");
+  if (!nextop) return NULL;
+  uint8_t index = raw_index + VM->stack->base;
   if (VM->stack->stack[index].type == VALUE_int) {
     VM->stack->stack[index].i--;
   } else {
     logerr("Trying to decrement non integer local variable.\n");
   }
   DISASS_LOG("OP_DECLOCAL: index %d\n", index);
-  return nextop+1;
+  return nextop;
 }
 
 uint8_t *op_jump(uint8_t *nextop, ITEM_t *item) {
@@ -397,18 +403,24 @@ uint8_t *op_jumpfalse(uint8_t *nextop, ITEM_t *item) {
 uint8_t *op_savelocal(uint8_t *nextop, ITEM_t *item) {
   // This is the quickest way, without extra pushes and pops.
   // Interpret the next byte as an index into the stack.
-  uint8_t index = *nextop + VM->stack->base;
+  uint8_t raw_index;
+  nextop = bc_read_u8(nextop, &raw_index, "OP_SAVELOCAL");
+  if (!nextop) return NULL;
+  uint8_t index = raw_index + VM->stack->base;
   // First check if the current value is a string.  If so, free it.
   VALUE_t top = pop_stack(VM->stack);
   value_move(&VM->stack->stack[index], &top);
   DISASS_LOG("OP_SAVELOCAL: index %d\n", index);
-  return nextop+1;
+  return nextop;
 }
 
 uint8_t *op_getlocal(uint8_t *nextop, ITEM_t *item) {
   // This is the quickest way, without extra pushes and pops.
   // Interpret the next byte as an index into the stack.
-  uint8_t index = *nextop + VM->stack->base;
+  uint8_t raw_index;
+  nextop = bc_read_u8(nextop, &raw_index, "OP_GETLOCAL");
+  if (!nextop) return NULL;
+  uint8_t index = raw_index + VM->stack->base;
 
   push_stack(VM->stack, value_clone(&VM->stack->stack[index]));
 #ifdef DISASS
@@ -425,7 +437,7 @@ uint8_t *op_getlocal(uint8_t *nextop, ITEM_t *item) {
       DISASS_LOG("OP_GETLOCAL: index %d type %d.\n", index, v.type);
   }
 #endif
-  return nextop+1;
+  return nextop;
 }
 
 uint8_t *op_pushstr(uint8_t *nextop, ITEM_t *item) {
@@ -611,7 +623,9 @@ uint8_t *op_logicalor(uint8_t *nextop, ITEM_t *item) {
 }
 
 uint8_t *op_libcall_token(uint8_t *nextop, ITEM_t *item) {
-  uint8_t token = *nextop++;
+  uint8_t token;
+  nextop = bc_read_u8(nextop, &token, "OP_LIBCALL");
+  if (!nextop) return NULL;
   DISASS_LOG("Calling libcall token %d.\n", token);
   OP_t libcall = libcall_func_token(token);
   if (!libcall) {

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "config.h"
+#include "error.h"
 #include "interpret.h"
 #include "item.h"
 #include "test_assert.h"
@@ -14,6 +15,7 @@ extern CONFIG_t config;
 
 static void setup_runtime(void) {
   memset(&config, 0, sizeof(config));
+  init_errmsg();
   config.itemroot = make_root_item("root");
   ASSERT_NOT_NULL(config.itemroot);
   config.vm = make_vm();
@@ -53,6 +55,22 @@ static VALUE_t run_code(const char *name, const uint8_t *template_code, size_t l
   return interpret(code);
 }
 
+
+static void assert_truncated_bytecode_for_opcode(const char *name, uint8_t opcode, const char *opname) {
+  uint8_t code[] = {0, 0, opcode};
+  VALUE_t result = run_code(name, code, sizeof(code));
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+
+  ITEM_t *err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(ERR_RUNTIME_TRUNCATED, err->value.i);
+
+  ITEM_t *msg = find_item(config.itemroot, "error.msg");
+  ASSERT_NOT_NULL(msg);
+  ASSERT_EQ_INT(VALUE_str, msg->value.type);
+  ASSERT_TRUE(strstr(msg->value.s, opname) != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "truncated bytecode read") != NULL);
+}
 
 static VALUE_t run_float_unary(uint64_t bits, uint8_t op, const char *name) {
   uint8_t code[32] = {0};
@@ -557,4 +575,11 @@ void test_value_comparison_unsupported_ordering_is_false(void) {
 
   value_free(&left);
   value_free(&right);
+}
+
+void test_interpreter_truncated_single_byte_operands(void) {
+  setup_runtime();
+  assert_truncated_bytecode_for_opcode("test.truncated_getlocal", 'e', "OP_GETLOCAL");
+  assert_truncated_bytecode_for_opcode("test.truncated_libcall_token", 'M', "OP_LIBCALL");
+  teardown_runtime();
 }

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -88,6 +88,7 @@ void test_value_comparison_float_ieee754_helpers(void);
 void test_value_comparison_string_helpers(void);
 void test_value_comparison_mismatched_type_equality_quirk(void);
 void test_value_comparison_unsupported_ordering_is_false(void);
+void test_interpreter_truncated_single_byte_operands(void);
 
 /* Compiler component tests. */
 void test_emitbc_header(void);
@@ -215,6 +216,7 @@ static const test_case_t core_tests[] = {
     {"test_value_comparison_string_helpers", test_value_comparison_string_helpers},
     {"test_value_comparison_mismatched_type_equality_quirk", test_value_comparison_mismatched_type_equality_quirk},
     {"test_value_comparison_unsupported_ordering_is_false", test_value_comparison_unsupported_ordering_is_false},
+    {"test_interpreter_truncated_single_byte_operands", test_interpreter_truncated_single_byte_operands},
 };
 
 static const test_case_t compiler_tests[] = {


### PR DESCRIPTION
### Motivation
- Avoid unsafe direct `*nextop` access for single-byte operands so truncated bytecode reports a proper runtime truncation error instead of causing undefined reads.
- Make local-index and libcall-token operand handling consistent with existing `bc_read_*` helpers and interpreter bounds checks.

### Description
- Replaced direct operand reads in `src/interpret.c` for `op_inclocal`, `op_declocal`, `op_savelocal`, and `op_getlocal` with `bc_read_u8(nextop, &raw_index, "OP_...")`, returning `NULL` on failure and computing `index` as `raw_index + VM->stack->base`.
- Updated `op_libcall_token` to read the libcall token via `bc_read_u8(nextop, &token, "OP_LIBCALL")` and bail on truncation.
- Adjusted these handlers to return the validated `nextop` (the value returned by `bc_read_u8`) instead of manually advancing by `+1`.
- Added a truncation regression helper and test `test_interpreter_truncated_single_byte_operands` in `tests/core/test_value_behavior.c` which asserts runtime truncation for a local opcode (`'e'` / `OP_GETLOCAL`) and a libcall-token opcode (`'M'` / `OP_LIBCALL`).
- Registered the new test in the shared test harness (`tests/shared/test_compiler.c`) and ensured error messages are initialized in the test runtime setup by calling `init_errmsg()`.

### Testing
- Ran `make test`; the full test suite passed (test harness summary: all suites passed, expected tests executed).
- The new truncation test `test_interpreter_truncated_single_byte_operands` executed and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a400038e484832e8f7c44ecf8a96185)