### PR TITLE
Use value_clone when fetching item values

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -935,13 +935,7 @@ uint8_t *op_fetchitem(uint8_t *nextop, ITEM_t *item) {
       ITEMDEBUG_LOG("Fetched item %s (called with %d arguments).\n", fullname, arg_count);
       // Just push the item value onto the stack.
       if (i->type == ITEM_value) {
-        VALUE_t v;
-        v.type = i->value.type;
-        if (v.type == VALUE_str) {
-          v.s = strdup(i->value.s);
-        } else {
-          v.i = i->value.i;
-        }
+        VALUE_t v = value_clone(&i->value);
         push_stack(VM->stack, v);
       } else {
         // Are there any arguments in excess of what this item takes?

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -422,6 +423,39 @@ void test_value_float_construction_copy_truthiness_cleanup(void) {
 
   value_free(&dst);
   ASSERT_EQ_INT(VALUE_nil, dst.type);
+}
+
+void test_value_float_item_fetch_preserves_bits(void) {
+  setup_runtime();
+
+  const uint64_t expected_bits[] = {
+      UINT64_C(0x8000000000000000),
+      UINT64_C(0x7ff8000000000042),
+  };
+
+  for (size_t i = 0; i < sizeof(expected_bits) / sizeof(expected_bits[0]); i++) {
+    char item_name[32];
+    snprintf(item_name, sizeof(item_name), "float.fetch.%c", (char)('a' + i));
+    VALUE_t original = {VALUE_float, {.f = value_float_from_bits(expected_bits[i])}};
+    ASSERT_NOT_NULL(insert_item(config.itemroot, item_name, original));
+
+    uint8_t code[64] = {0};
+    size_t pos = 0;
+    code[pos++] = 0;
+    code[pos++] = 0;
+    code[pos++] = 'l'; emit_str(code, &pos, item_name);
+    code[pos++] = 'F'; code[pos++] = 0; code[pos++] = 0;
+    code[pos++] = 'h';
+
+    char code_name[32];
+    snprintf(code_name, sizeof(code_name), "float.runner.%c", (char)('a' + i));
+    VALUE_t fetched = run_code(code_name, code, pos);
+    ASSERT_EQ_INT(VALUE_float, fetched.type);
+    ASSERT_TRUE(value_float_to_bits(fetched.f) == expected_bits[i]);
+    value_free(&fetched);
+  }
+
+  teardown_runtime();
 }
 
 void test_value_string_local_load_store_clones(void) {

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -82,6 +82,7 @@ void test_value_string_concat_helpers(void);
 void test_value_bool_nil_truthiness_helpers(void);
 void test_value_float_construction_copy_truthiness_cleanup(void);
 void test_value_string_local_load_store_clones(void);
+void test_value_float_item_fetch_preserves_bits(void);
 void test_value_comparison_int_helpers(void);
 void test_value_comparison_bool_helpers(void);
 void test_value_comparison_float_ieee754_helpers(void);
@@ -210,6 +211,7 @@ static const test_case_t core_tests[] = {
     {"test_value_bool_nil_truthiness_helpers", test_value_bool_nil_truthiness_helpers},
     {"test_value_float_construction_copy_truthiness_cleanup", test_value_float_construction_copy_truthiness_cleanup},
     {"test_value_string_local_load_store_clones", test_value_string_local_load_store_clones},
+    {"test_value_float_item_fetch_preserves_bits", test_value_float_item_fetch_preserves_bits},
     {"test_value_comparison_int_helpers", test_value_comparison_int_helpers},
     {"test_value_comparison_bool_helpers", test_value_comparison_bool_helpers},
     {"test_value_comparison_float_ieee754_helpers", test_value_comparison_float_ieee754_helpers},


### PR DESCRIPTION
### Motivation
- Replace ad-hoc manual copying of stored item values with the shared value API to centralize ownership/clone semantics and avoid subtle bugs when copying complex `VALUE_t` variants.
- Ensure fetching a stored `VALUE_float` preserves the exact IEEE-754 payload bits (important for `-0.0` and NaN payloads).

### Description
- Replaced the manual field-by-field copy in `op_fetchitem` with `VALUE_t v = value_clone(&i->value);` before pushing the value onto the VM stack in `src/interpret.c`.
- Added a regression test `test_value_float_item_fetch_preserves_bits` in `tests/core/test_value_behavior.c` which stores float items and fetches them, asserting `value_float_to_bits()` matches the original bits for `-0.0` and a NaN payload.
- Registered the new test in the shared test harness `tests/shared/test_compiler.c` so it runs with the core test suite.

### Testing
- Ran the full test suite via `make test`, which compiled and executed the test harness and completed with all tests passing (`tests=95/95`, status=PASS).
- Verified the modified interpreter and new test exercised the `op_fetchitem` path that pushes cloned `VALUE_t` instances onto the VM stack.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a400217f7a8832e8038940686adedfc)