### PR TITLE
Harden float literal parsing in AST value node creation

### DIFF
--- a/src/compiler/absyn.c
+++ b/src/compiler/absyn.c
@@ -39,8 +39,12 @@ AS_NODE *as_new_valnode(ENUM_VALUE valtype, char *sval) {
     uint64_t bits = 0;
     char *errdetail = NULL;
     if (!sin_parse_binary64_bits(sval, &bits, &errdetail)) {
+      logerr("Failed to parse float literal '%s'%s%s\n", sval, errdetail ? ": " : "", errdetail ? errdetail : "");
       free(errdetail);
+      free(sval);
+      return NULL;
     }
+    free(errdetail);
     newval = as_new_value(V_FLOAT, bits, NULL);
     free(sval);
   } else if (valtype == V_BOOLTRUE) {

--- a/tests/core/test_absyn_lifecycle.c
+++ b/tests/core/test_absyn_lifecycle.c
@@ -93,7 +93,11 @@ void test_absyn_item_deref_chains(void) {
   as_delete(chain);
 }
 
+void test_absyn_malformed_float_valnode_returns_null(void) {
+  AS_NODE *node = as_new_valnode(V_FLOAT, strdup("not-a-float"));
 
+  ASSERT_TRUE(node == NULL);
+}
 
 void test_absyn_float_value_preserves_bits(void) {
   const uint64_t bits = UINT64_C(0x7ff8000000000042);

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -26,6 +26,7 @@ void test_absyn_stmtlist_multiple_statements(void);
 void test_absyn_if_elsif_else_chain(void);
 void test_absyn_item_deref_chains(void);
 void test_absyn_float_value_preserves_bits(void);
+void test_absyn_malformed_float_valnode_returns_null(void);
 void test_sem_check_locals_reusable_context(void);
 void test_sem_duplicate_local_keeps_original_index(void);
 void test_sem_code_params_are_treated_as_defined_locals(void);
@@ -168,6 +169,7 @@ static const test_case_t core_tests[] = {
     {"test_absyn_if_elsif_else_chain", test_absyn_if_elsif_else_chain},
     {"test_absyn_item_deref_chains", test_absyn_item_deref_chains},
     {"test_absyn_float_value_preserves_bits", test_absyn_float_value_preserves_bits},
+    {"test_absyn_malformed_float_valnode_returns_null", test_absyn_malformed_float_valnode_returns_null},
     {"test_sem_check_locals_reusable_context", test_sem_check_locals_reusable_context},
     {"test_sem_duplicate_local_keeps_original_index", test_sem_duplicate_local_keeps_original_index},
     {"test_sem_code_params_are_treated_as_defined_locals", test_sem_code_params_are_treated_as_defined_locals},


### PR DESCRIPTION
### Motivation
- Prevent malformed float text from silently producing a `V_FLOAT` with zero payload when `sin_parse_binary64_bits` fails, and ensure error details and string ownership are correctly cleaned up.

### Description
- In `src/compiler/absyn.c` update `as_new_valnode` so when `valtype == V_FLOAT` and `sin_parse_binary64_bits` returns false it logs the failure with `logerr`, frees `errdetail` and `sval`, and returns `NULL` instead of constructing a zero-bit float node.
- Ensure `errdetail` is freed on both success and failure paths and `sval` is freed exactly once in each path.
- Add a focused unit test `test_absyn_malformed_float_valnode_returns_null` in `tests/core/test_absyn_lifecycle.c` that calls `as_new_valnode(V_FLOAT, strdup("not-a-float"))` and asserts the result is `NULL`.
- Register the new test in `tests/shared/test_compiler.c` test list so it runs with the core suite.

### Testing
- Ran the full test suite via `make test` and all tests passed (suite summary: `tests=96/96`); the new test passed and the failing parse produced a `logerr` message during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4009253934832eb841f08d7e1f1f7f)