### PR TITLE
Improve test harness reporting and deduplicate pipeline tests

### DIFF
--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -9,6 +9,8 @@ This document maps major subsystems to concrete test entry points so reviewers c
   - `tests/shared/test_compiler.c`
     - `main(...)`
     - `run_suite(...)`
+    - Per-test and per-suite elapsed-time reporting
+    - Assertion-failure suite/test context via `tests/test_assert.h`
     - Core suite registration (`core_tests[]`)
 - **Fixture contract integrity / regeneration policy**
   - `tests/shared/test_fixture_policy.c`
@@ -45,7 +47,7 @@ This document maps major subsystems to concrete test entry points so reviewers c
 
 ### Known gaps
 - No property/fuzz-style parser robustness test in-tree (seeded random corpus/replay).
-- No dedicated "core malformed-source matrix" test file; malformed-source cases are still distributed across compiler pipeline tests.
+- Malformed-source cases are centralized in the compiler pipeline negative matrix rather than split between source-golden and negative tests.
 
 ## compiler
 
@@ -71,7 +73,7 @@ This document maps major subsystems to concrete test entry points so reviewers c
   - `tests/compiler/test_pipeline_source_golden.c`
     - `test_pipeline_source_golden`
   - `tests/compiler/test_pipeline_negative_matrix.c`
-    - `test_pipeline_negative_matrix` (parser, semantic, IR-validate, emitter negative-stage checks)
+    - `test_pipeline_negative_matrix` (centralized parser, semantic, IR-validate, emitter negative-stage checks plus boolean/truthiness source nonregressions)
 - **Compiler context/diagnostics and tool parity**
   - `tests/compiler/test_compiler_context_failures.c`
     - `test_compiler_context_failures`

--- a/tests/compiler/test_pipeline_source_golden.c
+++ b/tests/compiler/test_pipeline_source_golden.c
@@ -1,10 +1,4 @@
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "error.h"
-#include "compiler_pipeline.h"
-#include "parser.h"
+#include <stddef.h>
 #include "test_assert.h"
 #include "test_helpers.h"
 #include "shared/test_pipeline_cases.h"
@@ -14,57 +8,6 @@ static void run_source_case(const PipelineGoldenCase *tc) {
   compile_source_and_assert_hex(tc->source, tc->fixture_path);
 }
 
-static void test_source_pipeline_negative_cases(void) {
-  AS_NODE *absyn = NULL;
-  char *errdetail = NULL;
-
-  const char *bad_char = "^;";
-  ParseInput input = {bad_char, strlen(bad_char), "<test>"};
-  int8_t rc = parse_source(&input, &absyn, &errdetail);
-  ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, rc);
-  ASSERT_NOT_NULL(errdetail);
-  ASSERT_TRUE(strcmp(errdetail, "^") == 0);
-  free(errdetail);
-
-  OUTPUT_t *out = NULL;
-  const char *bad_semantic = "@x;";
-  rc = compile_source_to_bytecode(bad_semantic, strlen(bad_semantic), &out, &errdetail);
-  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
-  ASSERT_NOT_NULL(errdetail);
-  ASSERT_TRUE(strstr(errdetail, "x") != NULL);
-  free(errdetail);
-
-  errdetail = NULL;
-  const char *bad_inc_semantic = "@y++;";
-  rc = compile_source_to_bytecode(bad_inc_semantic, strlen(bad_inc_semantic), &out, &errdetail);
-  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
-  ASSERT_NOT_NULL(errdetail);
-  ASSERT_TRUE(strstr(errdetail, "y") != NULL);
-  free(errdetail);
-}
-
-static void test_source_pipeline_bool_and_truthiness_nonregression(void) {
-  const char *ok_cases[] = {
-      "@l = true;",
-      "foo.bar = false;",
-      "@l = false; @l == false;",
-      "@l = false; if @l == false then sys.log{\"False\"}; endif;",
-      "if 1 then sys.log{\"int truthy\"}; endif;",
-      "if \"\" then sys.log{\"empty string truthy\"}; endif;",
-  };
-
-  for (size_t i = 0; i < sizeof(ok_cases) / sizeof(ok_cases[0]); i++) {
-    OUTPUT_t *out = NULL;
-    char *errdetail = NULL;
-    int8_t rc = compile_source_to_bytecode(ok_cases[i], strlen(ok_cases[i]), &out, &errdetail);
-    ASSERT_EQ_INT(ERR_NOERROR, rc);
-    ASSERT_TRUE(errdetail == NULL);
-    ASSERT_NOT_NULL(out);
-    free(out->bytecode);
-    free(out);
-  }
-}
-
 void test_pipeline_source_golden(void) {
   size_t case_count = 0;
   const PipelineGoldenCase *cases = pipeline_cases_for_layers(PIPELINE_LAYER_SOURCE, &case_count);
@@ -72,7 +15,4 @@ void test_pipeline_source_golden(void) {
   for (size_t i = 0; i < case_count; i++) {
     run_source_case(&cases[i]);
   }
-
-  test_source_pipeline_negative_cases();
-  test_source_pipeline_bool_and_truthiness_nonregression();
 }

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "ir.h"
 #include "test_assert.h"
@@ -18,7 +19,18 @@ typedef struct {
 typedef struct {
   const char *name;
   size_t count;
+  double elapsed_ms;
 } test_suite_summary_t;
+
+static const char *current_suite_name = "<startup>";
+static const char *current_test_name = "<startup>";
+
+const char *test_harness_current_suite(void) { return current_suite_name; }
+const char *test_harness_current_test(void) { return current_test_name; }
+
+static double elapsed_ms_since(clock_t start) {
+  return ((double)(clock() - start) * 1000.0) / (double)CLOCKS_PER_SEC;
+}
 
 /* Shared/core component tests. */
 void test_absyn_nested_binary_expressions(void);
@@ -282,20 +294,27 @@ static int env_flag_enabled(const char *name) {
   return strcmp(value, "1") == 0 || strcmp(value, "true") == 0 || strcmp(value, "TRUE") == 0;
 }
 
-static size_t run_suite(const char *suite_name, const test_case_t *cases, size_t count) {
-  size_t suite_ran = 0;
+static test_suite_summary_t run_suite(const char *suite_name, const test_case_t *cases, size_t count) {
+  test_suite_summary_t summary = {suite_name, 0, 0.0};
+  clock_t suite_start = clock();
   harness_printf("\n[test-harness][%s][START] total=%zu\n", suite_name, count);
   for (size_t i = 0; i < count; ++i) {
+    current_suite_name = suite_name;
+    current_test_name = cases[i].name;
+    clock_t test_start = clock();
     harness_printf("[test-harness][%s][START] index=%zu/%zu test=%s\n", suite_name, i + 1,
                    count, cases[i].name);
     cases[i].fn();
-    harness_printf("[test-harness][%s][PASS] index=%zu/%zu test=%s\n", suite_name, i + 1,
-                   count, cases[i].name);
-    suite_ran++;
+    harness_printf("[test-harness][%s][PASS] index=%zu/%zu test=%s elapsed_ms=%.2f\n", suite_name, i + 1,
+                   count, cases[i].name, elapsed_ms_since(test_start));
+    summary.count++;
   }
-  harness_printf("[test-harness][%s][COMPLETE] executed=%zu expected=%zu status=PASS\n",
-                 suite_name, suite_ran, count);
-  return suite_ran;
+  summary.elapsed_ms = elapsed_ms_since(suite_start);
+  current_suite_name = "<idle>";
+  current_test_name = "<idle>";
+  harness_printf("[test-harness][%s][COMPLETE] executed=%zu expected=%zu status=PASS elapsed_ms=%.2f\n",
+                 suite_name, summary.count, count, summary.elapsed_ms);
+  return summary;
 }
 
 int main(void) {
@@ -316,11 +335,11 @@ int main(void) {
                  strict_bench ? "strict" : "standard",
                  strict_bench ? "enabled" : "disabled", suite_count, total_expected);
 
-  suites[0].count = run_suite("core", core_tests, sizeof(core_tests) / sizeof(core_tests[0]));
-  suites[1].count = run_suite("compiler", compiler_tests,
-                              sizeof(compiler_tests) / sizeof(compiler_tests[0]));
-  suites[2].count = run_suite("runtime", runtime_tests,
-                              sizeof(runtime_tests) / sizeof(runtime_tests[0]));
+  suites[0] = run_suite("core", core_tests, sizeof(core_tests) / sizeof(core_tests[0]));
+  suites[1] = run_suite("compiler", compiler_tests,
+                        sizeof(compiler_tests) / sizeof(compiler_tests[0]));
+  suites[2] = run_suite("runtime", runtime_tests,
+                        sizeof(runtime_tests) / sizeof(runtime_tests[0]));
 
   size_t total_ran = 0;
   for (size_t i = 0; i < suite_count; ++i) {
@@ -334,7 +353,7 @@ int main(void) {
                  total_expected);
   harness_printf("[test-harness] suite summary:");
   for (size_t i = 0; i < suite_count; ++i) {
-    harness_printf(" %s=%zu", suites[i].name, suites[i].count);
+    harness_printf(" %s=%zu(%.2fms)", suites[i].name, suites[i].count, suites[i].elapsed_ms);
   }
   harness_printf("\n");
   return 0;

--- a/tests/test_assert.h
+++ b/tests/test_assert.h
@@ -3,9 +3,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+const char *test_harness_current_suite(void);
+const char *test_harness_current_test(void);
+
 #define TEST_FAILF(fmt, ...) \
   do { \
-    fprintf(stderr, "ASSERTION FAILED at %s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+    fprintf(stderr, "ASSERTION FAILED in [%s] %s at %s:%d: " fmt "\n", test_harness_current_suite(), test_harness_current_test(), __FILE__, __LINE__, ##__VA_ARGS__); \
     exit(1); \
   } while (0)
 


### PR DESCRIPTION
### Motivation
- Make test failures easier to triage by surfacing the active suite and test in assertion output and improve observability of test runtime by reporting per-test and per-suite elapsed time. 
- Remove duplicated coverage between the source golden tests and the negative matrix to centralize malformed-source and truthiness non-regressions in a single negative-matrix file. 

### Description
- Add active-suite/test tracking and elapsed-time reporting to the harness in `tests/shared/test_compiler.c`, including `clock()`-based per-test and per-suite timing and updated suite summary output. 
- Surface suite/test context in assertion failures by declaring and using `test_harness_current_suite()` and `test_harness_current_test()` in `tests/test_assert.h`. 
- Deduplicate pipeline checks by removing local negative/bool/truthiness checks from `tests/compiler/test_pipeline_source_golden.c` and relying on the centralized cases in `tests/compiler/test_pipeline_negative_matrix.c`. 
- Update `tests/TEST_COVERAGE.md` to document the harness improvements and the centralized malformed-source coverage approach. 

### Testing
- Ran the full test runner via `make test` which builds and executes `tests/test-compiler`. 
- All automated tests passed (`96/96`) and the harness emitted per-test elapsed times and per-suite elapsed totals. 
- No test regressions were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a400a45a778832eb29da49441635b1d)