### PR TITLE
Free JUMPFALSE condition values on branch

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -396,6 +396,7 @@ uint8_t *op_jumpfalse(uint8_t *nextop, ITEM_t *item) {
   } else {
     // If not true then it must be false.  That's logic.
     DISASS_LOG("OP_JUMPFALSE: evaluates to false (jump offset %d).\n", offset);
+    value_free(&v1);
     return offset_start + offset;
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent a memory leak when `OP_JUMPFALSE` takes the branch by ensuring the popped condition value is freed, as AddressSanitizer reported a leaked string on the false path.

### Description
- Free the popped condition `v1` in the false branch of `op_jumpfalse` in `src/interpret.c` by calling `value_free(&v1)`, matching the existing no-jump path.

### Testing
- Ran `make all`, `make test`, `make teststrict`, `./ci/gate_ir_absyn_emitbc.sh`, and a sanitizer build using ASAN/UBSAN via `make test` with appropriate `CFLAGS`/`LDFLAGS`, and all automated tests passed and the previously observed leak was resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40ae79b780832e9880b7fd00b1ffd6)