### PR TITLE
Validate bytecode local indices

### DIFF
--- a/src/bytecode_verify.c
+++ b/src/bytecode_verify.c
@@ -15,6 +15,8 @@ typedef struct {
   const char *label;
   BC_VerifyOptions options;
   BC_VerifyResult result;
+  uint8_t local_count;
+  bool validate_local_indices;
 } BC_Decoder;
 
 BC_VerifyOptions bc_verify_default_options(void) {
@@ -97,6 +99,16 @@ static const IR_OpSchema *bc_schema_for(uint8_t opcode, BC_DecodeContext ctx) {
 static int bc_decode_one(BC_Decoder *d, const uint8_t **cursor,
                          BC_DecodeContext ctx);
 
+static int bc_validate_local_index(BC_Decoder *d, const uint8_t *p,
+                                   uint8_t opcode, uint8_t index) {
+  if (!d->validate_local_indices || index < d->local_count) return 1;
+  char msg[96];
+  snprintf(msg, sizeof(msg),
+           "local index %u out of range for local count %u",
+           (unsigned)index, (unsigned)d->local_count);
+  return bc_fail(d, p, opcode, msg);
+}
+
 static int bc_decode_item(BC_Decoder *d, const uint8_t **cursor) {
   while (*cursor < d->end) {
     uint8_t op = **cursor;
@@ -121,8 +133,9 @@ static int bc_decode_deref(BC_Decoder *d, const uint8_t **cursor) {
   uint8_t type = *(*cursor)++;
   if (type == 'V') {
     if (!bc_need(d, *cursor, 1, type, "dereference local index")) return 0;
-    (*cursor)++;
-    return 1;
+    const uint8_t *index_p = *cursor;
+    uint8_t index = *(*cursor)++;
+    return bc_validate_local_index(d, index_p, type, index);
   }
   if (type == 'I' || type == 'R') return bc_decode_item(d, cursor);
   return bc_fail(d, start, type, "unknown dereference type");
@@ -146,11 +159,16 @@ static int bc_decode_one(BC_Decoder *d, const uint8_t **cursor,
     case IR_OP_NTHNAME: case IR_OP_ROOTNAME: case IR_OP_ITEM_END:
       return 1;
     case IR_OP_PUSH_BOOL:
-    case IR_OP_LOAD_LOCAL: case IR_OP_STORE_LOCAL: case IR_OP_INC_LOCAL: case IR_OP_DEC_LOCAL:
     case IR_OP_LIBCALL_TOKEN:
       if (!bc_need(d, *cursor, 1, op, schema->name)) return 0;
       (*cursor)++;
       return 1;
+    case IR_OP_LOAD_LOCAL: case IR_OP_STORE_LOCAL: case IR_OP_INC_LOCAL: case IR_OP_DEC_LOCAL: {
+      if (!bc_need(d, *cursor, 1, op, schema->name)) return 0;
+      const uint8_t *index_p = *cursor;
+      uint8_t index = *(*cursor)++;
+      return bc_validate_local_index(d, index_p, op, index);
+    }
     case IR_OP_CALL:
     case IR_OP_JUMP: case IR_OP_JUMP_IF_FALSE:
       if (!bc_need(d, *cursor, 2, op, schema->name)) return 0;
@@ -238,6 +256,8 @@ BC_VerifyResult bc_verify_bytecode(const uint8_t *bytecode,
 
   uint8_t locals = bytecode[0];
   uint8_t params = bytecode[1];
+  d.local_count = locals;
+  d.validate_local_indices = true;
   if (params > locals) {
     bc_fail(&d, bytecode + 1, params, "parameter count exceeds local count");
     return d.result;

--- a/tests/core/test_opcode_schema.c
+++ b/tests/core/test_opcode_schema.c
@@ -34,9 +34,41 @@ void test_opcode_schema_consistency(void) {
   free(err_b);
 }
 
+
+void test_bytecode_verify_local_index_bounds(void) {
+  const uint8_t top_level_opcodes[] = {'e', 'c', 'f', 'g'};
+  for (size_t i = 0; i < sizeof(top_level_opcodes); i++) {
+    const uint8_t local_zero_count_zero[] = {0, 0, top_level_opcodes[i], 0, 'h'};
+    BC_VerifyResult result = bc_verify_bytecode(local_zero_count_zero,
+                                                sizeof(local_zero_count_zero),
+                                                "top_local_zero_count_zero", NULL);
+    ASSERT_EQ_INT(BC_VERIFY_ERROR, result.status);
+    ASSERT_TRUE(strstr(result.diagnostic.message, "local index 0 out of range for local count 0") != NULL);
+
+    const uint8_t local_one_count_one[] = {1, 0, top_level_opcodes[i], 1, 'h'};
+    result = bc_verify_bytecode(local_one_count_one, sizeof(local_one_count_one),
+                                "top_local_one_count_one", NULL);
+    ASSERT_EQ_INT(BC_VERIFY_ERROR, result.status);
+    ASSERT_TRUE(strstr(result.diagnostic.message, "local index 1 out of range for local count 1") != NULL);
+  }
+
+  const uint8_t deref_zero_count_zero[] = {0, 0, 'I', 'D', 'V', 0, 'E', 'h'};
+  BC_VerifyResult result = bc_verify_bytecode(deref_zero_count_zero,
+                                              sizeof(deref_zero_count_zero),
+                                              "deref_zero_count_zero", NULL);
+  ASSERT_EQ_INT(BC_VERIFY_ERROR, result.status);
+  ASSERT_TRUE(strstr(result.diagnostic.message, "local index 0 out of range for local count 0") != NULL);
+
+  const uint8_t deref_one_count_one[] = {1, 0, 'I', 'D', 'V', 1, 'E', 'h'};
+  result = bc_verify_bytecode(deref_one_count_one, sizeof(deref_one_count_one),
+                              "deref_one_count_one", NULL);
+  ASSERT_EQ_INT(BC_VERIFY_ERROR, result.status);
+  ASSERT_TRUE(strstr(result.diagnostic.message, "local index 1 out of range for local count 1") != NULL);
+}
+
 void test_bytecode_verify_item_expression_streams(void) {
   const uint8_t valid[] = {
-      0, 0,
+      1, 0,
       'I', 'L', 3, 'f', 'o', 'o',
            'D', 'V', 0,
            'D', 'I', 'L', 3, 'b', 'a', 'r', 'E',

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -52,6 +52,7 @@ void test_sem_local_limit_over_255_fails_deterministically(void);
 void test_ir_validate(void);
 void test_opcode_schema_consistency(void);
 void test_bytecode_verify_item_expression_streams(void);
+void test_bytecode_verify_local_index_bounds(void);
 void test_parser_input_api(void);
 void test_parser_float_literals_decimal_forms(void);
 void test_parser_float_literals_integer_still_int(void);
@@ -196,6 +197,7 @@ static const test_case_t core_tests[] = {
     {"test_ir_validate", test_ir_validate},
     {"test_opcode_schema_consistency", test_opcode_schema_consistency},
     {"test_bytecode_verify_item_expression_streams", test_bytecode_verify_item_expression_streams},
+    {"test_bytecode_verify_local_index_bounds", test_bytecode_verify_local_index_bounds},
     {"test_parser_input_api", test_parser_input_api},
     {"test_parser_float_literals_decimal_forms", test_parser_float_literals_decimal_forms},
     {"test_parser_float_literals_integer_still_int", test_parser_float_literals_integer_still_int},


### PR DESCRIPTION
### Motivation
- The bytecode verifier must ensure local-index operands do not reference out-of-range local slots declared in the bytecode header for safety and correctness.
- This covers top-level local opcodes and local dereferences embedded inside item-dereference streams.

### Description
- Added `local_count` and `validate_local_indices` fields to `BC_Decoder` and set them from the bytecode header (`bytecode[0]`) in `bc_verify_bytecode`.
- Implemented a helper `bc_validate_local_index` that fails when `index >= local_count` and returns a diagnostic message indicating the offending index and header count.
- Applied validation to top-level opcodes `IR_OP_LOAD_LOCAL`, `IR_OP_STORE_LOCAL`, `IR_OP_INC_LOCAL`, and `IR_OP_DEC_LOCAL` in `bc_decode_one` and to dereference form `D V <local-index>` in `bc_decode_deref`.
- Added negative tests `test_bytecode_verify_local_index_bounds` to `tests/core/test_opcode_schema.c` and registered the test in `tests/shared/test_compiler.c`, plus adjusted an existing item-expression test header to use a valid local count.

### Testing
- Ran `make test` which built the project and executed the full test suite; all tests passed (98/98).
- The new `test_bytecode_verify_local_index_bounds` test exercised top-level local opcodes and nested dereference paths and produced the expected `BC_VERIFY_ERROR` diagnostics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4162e98d44832e84d80061507867dd)