### PR TITLE
Validate bytecode verifier jump targets

### DIFF
--- a/src/bytecode_verify.c
+++ b/src/bytecode_verify.c
@@ -1,6 +1,7 @@
 #include "bytecode_verify.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 typedef enum {
@@ -10,6 +11,12 @@ typedef enum {
 } BC_DecodeContext;
 
 typedef struct {
+  uint32_t offset;
+  int16_t relative;
+  uint8_t opcode;
+} BC_JumpRef;
+
+typedef struct {
   const uint8_t *base;
   const uint8_t *end;
   const char *label;
@@ -17,6 +24,11 @@ typedef struct {
   BC_VerifyResult result;
   uint8_t local_count;
   bool validate_local_indices;
+  bool *top_level_instruction_starts;
+  uint32_t top_level_instruction_start_capacity;
+  BC_JumpRef *jumps;
+  uint32_t jump_count;
+  uint32_t jump_capacity;
 } BC_Decoder;
 
 BC_VerifyOptions bc_verify_default_options(void) {
@@ -109,6 +121,46 @@ static int bc_validate_local_index(BC_Decoder *d, const uint8_t *p,
   return bc_fail(d, p, opcode, msg);
 }
 
+static int bc_record_jump(BC_Decoder *d, const uint8_t *operand_start,
+                          uint8_t opcode) {
+  if (d->jump_count == d->jump_capacity) {
+    uint32_t new_capacity = d->jump_capacity == 0 ? 8 : d->jump_capacity * 2;
+    BC_JumpRef *new_jumps = realloc(d->jumps, new_capacity * sizeof(*new_jumps));
+    if (!new_jumps) return bc_fail(d, operand_start, opcode, "out of memory recording jump target");
+    d->jumps = new_jumps;
+    d->jump_capacity = new_capacity;
+  }
+  uint16_t raw = (uint16_t)operand_start[0] | ((uint16_t)operand_start[1] << 8);
+  d->jumps[d->jump_count++] = (BC_JumpRef){
+      .offset = bc_offset(d, operand_start),
+      .relative = (int16_t)raw,
+      .opcode = opcode,
+  };
+  return 1;
+}
+
+static int bc_validate_recorded_jumps(BC_Decoder *d) {
+  uint32_t bytecode_len = (uint32_t)(d->end - d->base);
+  for (uint32_t i = 0; i < d->jump_count; i++) {
+    const BC_JumpRef *jump = &d->jumps[i];
+    int64_t target = (int64_t)jump->offset + (int64_t)jump->relative;
+    const uint8_t *jump_p = d->base + jump->offset - 1;
+    if (target < 2) {
+      return bc_fail(d, jump_p, jump->opcode, "jump target before bytecode body");
+    }
+    if (target >= (int64_t)bytecode_len) {
+      return bc_fail(d, jump_p, jump->opcode, "jump target past bytecode body");
+    }
+    if ((uint32_t)target == d->result.halt_offset) continue;
+    if ((uint32_t)target >= d->top_level_instruction_start_capacity ||
+        !d->top_level_instruction_starts[target]) {
+      return bc_fail(d, jump_p, jump->opcode,
+                     "jump target is not a top-level instruction boundary");
+    }
+  }
+  return 1;
+}
+
 static int bc_decode_item(BC_Decoder *d, const uint8_t **cursor) {
   while (*cursor < d->end) {
     uint8_t op = **cursor;
@@ -170,10 +222,16 @@ static int bc_decode_one(BC_Decoder *d, const uint8_t **cursor,
       return bc_validate_local_index(d, index_p, op, index);
     }
     case IR_OP_CALL:
-    case IR_OP_JUMP: case IR_OP_JUMP_IF_FALSE:
       if (!bc_need(d, *cursor, 2, op, schema->name)) return 0;
       *cursor += 2;
       return 1;
+    case IR_OP_JUMP: case IR_OP_JUMP_IF_FALSE: {
+      if (!bc_need(d, *cursor, 2, op, schema->name)) return 0;
+      const uint8_t *operand_start = *cursor;
+      if (ctx == BC_CTX_STMT && !bc_record_jump(d, operand_start, op)) return 0;
+      *cursor += 2;
+      return 1;
+    }
     case IR_OP_PUSH_INT:
     case IR_OP_PUSH_FLOAT:
       if (!bc_need(d, *cursor, 8, op, schema->name)) return 0;
@@ -263,12 +321,29 @@ BC_VerifyResult bc_verify_bytecode(const uint8_t *bytecode,
     return d.result;
   }
 
+  d.top_level_instruction_starts = calloc((size_t)bytecode_len + 1, sizeof(bool));
+  d.top_level_instruction_start_capacity = bytecode_len + 1;
+  if (!d.top_level_instruction_starts) {
+    bc_fail(&d, d.base, 0, "out of memory recording instruction starts");
+    return d.result;
+  }
+
   const uint8_t *cursor = bytecode + 2;
   while (cursor < d.end) {
     const uint8_t *start = cursor;
-    if (!bc_decode_one(&d, &cursor, BC_CTX_STMT)) return d.result;
+    d.top_level_instruction_starts[bc_offset(&d, start)] = true;
+    if (!bc_decode_one(&d, &cursor, BC_CTX_STMT)) {
+      free(d.top_level_instruction_starts);
+      free(d.jumps);
+      return d.result;
+    }
     if (*start == 'h') {
       d.result.halt_offset = bc_offset(&d, start);
+      if (!bc_validate_recorded_jumps(&d)) {
+        free(d.top_level_instruction_starts);
+        free(d.jumps);
+        return d.result;
+      }
       if (cursor < d.end) {
         if (d.options.strict_trailing_bytes || d.options.mode != BC_VERIFY_MODE_DISASSEMBLY) {
           bc_fail(&d, cursor, *cursor, "trailing bytes after HALT");
@@ -276,10 +351,14 @@ BC_VerifyResult bc_verify_bytecode(const uint8_t *bytecode,
           bc_warn(&d, cursor, *cursor, "trailing bytes after HALT");
         }
       }
+      free(d.top_level_instruction_starts);
+      free(d.jumps);
       return d.result;
     }
   }
 
   bc_fail(&d, d.end, 0, "missing terminating HALT opcode");
+  free(d.top_level_instruction_starts);
+  free(d.jumps);
   return d.result;
 }

--- a/tests/core/test_opcode_schema.c
+++ b/tests/core/test_opcode_schema.c
@@ -102,3 +102,47 @@ void test_bytecode_verify_item_expression_streams(void) {
   ASSERT_EQ_INT(BC_VERIFY_ERROR, result.status);
   ASSERT_TRUE(strstr(result.diagnostic.message, "unknown item-layer opcode") != NULL);
 }
+
+void test_bytecode_verify_jump_targets(void) {
+  const uint8_t before_start[] = {0, 0, 'j', 0xFE, 0xFF, 'h'};
+  BC_VerifyResult result = bc_verify_bytecode(before_start, sizeof(before_start),
+                                              "before_start", NULL);
+  ASSERT_EQ_INT(BC_VERIFY_ERROR, result.status);
+  ASSERT_TRUE(strstr(result.diagnostic.message, "before bytecode body") != NULL);
+
+  const uint8_t past_end[] = {0, 0, 'j', 0x04, 0x00, 'h'};
+  result = bc_verify_bytecode(past_end, sizeof(past_end), "past_end", NULL);
+  ASSERT_EQ_INT(BC_VERIFY_ERROR, result.status);
+  ASSERT_TRUE(strstr(result.diagnostic.message, "past bytecode body") != NULL);
+
+  const uint8_t into_string_payload[] = {
+      0, 0, 'l', 3, 0, 'a', 'b', 'c', 'j', 0xFD, 0xFF, 'h'};
+  result = bc_verify_bytecode(into_string_payload, sizeof(into_string_payload),
+                              "into_string_payload", NULL);
+  ASSERT_EQ_INT(BC_VERIFY_ERROR, result.status);
+  ASSERT_TRUE(strstr(result.diagnostic.message, "not a top-level instruction boundary") != NULL);
+
+  const uint8_t into_item_payload[] = {
+      0, 0, 'I', 'L', 3, 'a', 'b', 'c', 'E', 'j', 0xFC, 0xFF, 'h'};
+  result = bc_verify_bytecode(into_item_payload, sizeof(into_item_payload),
+                              "into_item_payload", NULL);
+  ASSERT_EQ_INT(BC_VERIFY_ERROR, result.status);
+  ASSERT_TRUE(strstr(result.diagnostic.message, "not a top-level instruction boundary") != NULL);
+
+  const uint8_t directly_to_halt[] = {0, 0, 'j', 0x02, 0x00, 'h'};
+  result = bc_verify_bytecode(directly_to_halt, sizeof(directly_to_halt),
+                              "directly_to_halt", NULL);
+  ASSERT_EQ_INT(BC_VERIFY_OK, result.status);
+
+  const uint8_t forward_jump[] = {0, 0, 'j', 0x02, 0x00, 'b', 1, 'h'};
+  result = bc_verify_bytecode(forward_jump, sizeof(forward_jump),
+                              "forward_jump", NULL);
+  ASSERT_EQ_INT(BC_VERIFY_OK, result.status);
+
+  const uint8_t backward_conditional_jump[] = {
+      0, 0, 'b', 1, 'k', 0xFD, 0xFF, 'h'};
+  result = bc_verify_bytecode(backward_conditional_jump,
+                              sizeof(backward_conditional_jump),
+                              "backward_conditional_jump", NULL);
+  ASSERT_EQ_INT(BC_VERIFY_OK, result.status);
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -53,6 +53,7 @@ void test_ir_validate(void);
 void test_opcode_schema_consistency(void);
 void test_bytecode_verify_item_expression_streams(void);
 void test_bytecode_verify_local_index_bounds(void);
+void test_bytecode_verify_jump_targets(void);
 void test_parser_input_api(void);
 void test_parser_float_literals_decimal_forms(void);
 void test_parser_float_literals_integer_still_int(void);
@@ -198,6 +199,7 @@ static const test_case_t core_tests[] = {
     {"test_opcode_schema_consistency", test_opcode_schema_consistency},
     {"test_bytecode_verify_item_expression_streams", test_bytecode_verify_item_expression_streams},
     {"test_bytecode_verify_local_index_bounds", test_bytecode_verify_local_index_bounds},
+    {"test_bytecode_verify_jump_targets", test_bytecode_verify_jump_targets},
     {"test_parser_input_api", test_parser_input_api},
     {"test_parser_float_literals_decimal_forms", test_parser_float_literals_decimal_forms},
     {"test_parser_float_literals_integer_still_int", test_parser_float_literals_integer_still_int},


### PR DESCRIPTION
### Motivation
- Ensure `j`/`k` (JUMP / JUMP_IF_FALSE) operands are present and their signed 16-bit relative targets are valid and do not land inside payload bytes or outside the bytecode body.

### Description
- Record top-level instruction start offsets while decoding into `top_level_instruction_starts` and capture `j`/`k` operands into a `jumps` list (`BC_JumpRef`) in `src/bytecode_verify.c`.
- Validate that each recorded jump has its two-byte operand present, compute the absolute target (operand offset + relative), and error if the target is before the bytecode body, past the bytecode body, or not a known top-level instruction boundary unless it equals the `HALT` offset.
- Record jumps only for statement-context decoding (`BC_CTX_STMT`) and preserve existing operand/local-index validation and decoder behavior so conditional jump handling and stack-effect-related checks remain unchanged.
- Add `test_bytecode_verify_jump_targets` in `tests/core/test_opcode_schema.c` and register it in the harness (`tests/shared/test_compiler.c`) to cover invalid and valid jump scenarios.

### Testing
- Ran `make test` and the entire test suite passed (`PASS` 99/99).
- The new `test_bytecode_verify_jump_targets` exercises jumps before start, past end, into string payloads, into item-expression payloads, direct jump-to-`HALT`, and valid forward/backward jumps, and it passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41657cd948832e986f5d6c44dd0a7f)