### PR TITLE
Add opt-in runtime bytecode validation (--strict-validation)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -29,4 +29,5 @@ typedef struct {
   uint8_t maxconns;     // Maximum number of connected players
   uint8_t lastconn;     // Last connection processed by net.input
   bool safe_shutdown;   // Determins how to shut down.
+  bool strict_validation; // Verify bytecode at runtime before execution.
 } CONFIG_t;

--- a/src/error.c
+++ b/src/error.c
@@ -24,4 +24,5 @@ void init_errmsg() {
   errmsg[ERR_RUNTIME_NOSUCHITEM] = "Item does not exist.";
   errmsg[ERR_RUNTIME_TRUNCATED] = "Truncated bytecode.";
   errmsg[ERR_RUNTIME_INVLIB] = "Invalid libcall.";
+  errmsg[ERR_RUNTIME_BYTECODE] = "Invalid bytecode.";
 }

--- a/src/error.h
+++ b/src/error.h
@@ -5,7 +5,7 @@
 #pragma once
 
 // How big should the error message table be?
-#define MAXERRORS                 31
+#define MAXERRORS                 32
 
 #define ERR_NOERROR               0
 
@@ -26,6 +26,7 @@
 #define ERR_RUNTIME_NOSUCHITEM    22
 #define ERR_RUNTIME_TRUNCATED     23
 #define ERR_RUNTIME_INVLIB        24
+#define ERR_RUNTIME_BYTECODE      25
 
 extern const char *errmsg[];
 

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -33,6 +33,45 @@ static uint8_t *current_frame_end = NULL;
 static ITEM_t *current_item = NULL;
 static ITEM_t *pending_call_item = NULL;
 
+static const char *runtime_item_label(ITEM_t *item, char *buffer, size_t size) {
+  if (!item) return "<null>";
+  if (item->parent && item->parent->parent && size >= MAX_ITEM_NAME) {
+    buffer[0] = '\0';
+    get_itemname(item, buffer);
+    return buffer;
+  }
+  return item->name;
+}
+
+static bool verify_runtime_bytecode(ITEM_t *item) {
+  if (!config.strict_validation || !item || item->type != ITEM_code) return true;
+
+  char item_name[MAX_ITEM_NAME] = {0};
+  const char *label = runtime_item_label(item, item_name, sizeof(item_name));
+  if (!item->bytecode) {
+    char detail[320];
+    snprintf(detail, sizeof(detail),
+             "Runtime bytecode validation failed for item '%s' at offset 0: null bytecode pointer",
+             label);
+    logerr("%s.\n", detail);
+    set_error_item(ERR_RUNTIME_BYTECODE, detail);
+    return false;
+  }
+  BC_VerifyOptions options = bc_verify_default_options();
+  options.mode = BC_VERIFY_MODE_RUNTIME;
+  BC_VerifyResult result = bc_verify_bytecode(item->bytecode,
+      (uint32_t)item->bytecode_len, label, &options);
+  if (result.status == BC_VERIFY_OK) return true;
+
+  char detail[320];
+  snprintf(detail, sizeof(detail),
+           "Runtime bytecode validation failed for item '%s' at offset %u: %s",
+           label, result.diagnostic.offset, result.diagnostic.message);
+  logerr("%s.\n", detail);
+  set_error_item(ERR_RUNTIME_BYTECODE, detail);
+  return false;
+}
+
 static inline bool require_bytes(uint8_t *nextop, size_t bytes, const char *opname) {
   if (!current_frame_start || !current_frame_end) return true;
   if (nextop > current_frame_end || (size_t)(current_frame_end - nextop) < bytes) {
@@ -940,6 +979,10 @@ uint8_t *op_fetchitem(uint8_t *nextop, ITEM_t *item) {
         VALUE_t v = value_clone(&i->value);
         push_stack(VM->stack, v);
       } else {
+        if (!verify_runtime_bytecode(i)) {
+          FREE_STR(itemname);
+          return NULL;
+        }
         // Are there any arguments in excess of what this item takes?
         // If so, lose 'em.
         while (arg_count > i->bytecode[1]) {
@@ -1388,6 +1431,13 @@ VALUE_t interpret(ITEM_t *item) {
 
   current_item = item;
   pending_call_item = NULL;
+
+  if (!verify_runtime_bytecode(current_item)) {
+    current_item = NULL;
+    current_frame_start = NULL;
+    current_frame_end = NULL;
+    return VALUE_NIL;
+  }
 
   // Enter initial frame.
   current_item->inuse = true;

--- a/src/sin.c
+++ b/src/sin.c
@@ -72,6 +72,8 @@ void usage() {
   logmsg("\t\t\t  './srcroot' is used, which will be created if it does\n");
   logmsg("\t\t\t  not exist.  If this option is supplied the directory\n");
   logmsg("\t\t\t  given must exist or the interpreter will not run.\n");
+  logmsg("     --strict-validation\n");
+  logmsg("\t\t\t  Verify bytecode before runtime execution.\n");
 }
 
 static ITEM_t *load_or_create_itemstore(const char *filename) {
@@ -118,6 +120,7 @@ int main(int argc, char **argv) {
   sprintf(config.inputline, "%s.line", config.input);
   sprintf(config.inputtext, "%s.text", config.input);
   config.safe_shutdown = true;
+  config.strict_validation = false;
 
   // Do the very early preparations, for things which are needed
   // before even the options are processed.
@@ -144,6 +147,7 @@ int main(int argc, char **argv) {
     {"object", required_argument, 0, 'o'},
     {"port", optional_argument, 0, 'p'},
     {"srcroot", required_argument, 0, 's'},
+    {"strict-validation", no_argument, 0, 1000},
     {NULL, 0, 0, '\0'}
   };
   while ((opt = getopt_long(argc, argv, "bd:hi:l::n:o:p:s:", options, NULL)) != -1) {
@@ -233,6 +237,10 @@ int main(int argc, char **argv) {
       case 's': {
         // Optional: root directory of the source tree.
         config.srcroot = strdup(optarg);
+        break;
+      }
+      case 1000: {
+        config.strict_validation = true;
         break;
       }
       default: {

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -617,3 +617,66 @@ void test_interpreter_truncated_single_byte_operands(void) {
   assert_truncated_bytecode_for_opcode("test.truncated_libcall_token", 'M', "OP_LIBCALL");
   teardown_runtime();
 }
+
+void test_strict_validation_runtime_opt_in(void) {
+  setup_runtime();
+  uint8_t code[] = {0, 0, 'e', 1, 'h'};
+  uint8_t *bytecode = malloc(sizeof(code));
+  ASSERT_NOT_NULL(bytecode);
+  memcpy(bytecode, code, sizeof(code));
+  ITEM_t *item = insert_code_item(config.itemroot, "test.strict_invalid_local", sizeof(code), bytecode);
+  ASSERT_NOT_NULL(item);
+
+  config.strict_validation = false;
+  VALUE_t result = interpret(item);
+  (void)result;
+  ITEM_t *err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(VALUE_nil, err->value.type);
+
+  teardown_runtime();
+  setup_runtime();
+  bytecode = malloc(sizeof(code));
+  ASSERT_NOT_NULL(bytecode);
+  memcpy(bytecode, code, sizeof(code));
+  item = insert_code_item(config.itemroot, "test.strict_invalid_local", sizeof(code), bytecode);
+  ASSERT_NOT_NULL(item);
+  config.strict_validation = true;
+  int32_t before_current = config.vm->stack->current;
+  uint8_t before_locals = config.vm->stack->locals;
+  uint8_t before_params = config.vm->stack->params;
+  result = interpret(item);
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  ASSERT_TRUE(!item->inuse);
+  ASSERT_EQ_INT(before_current, config.vm->stack->current);
+  ASSERT_EQ_INT(before_locals, config.vm->stack->locals);
+  ASSERT_EQ_INT(before_params, config.vm->stack->params);
+
+  err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(ERR_RUNTIME_BYTECODE, err->value.i);
+  ITEM_t *msg = find_item(config.itemroot, "error.msg");
+  ASSERT_NOT_NULL(msg);
+  ASSERT_EQ_INT(VALUE_str, msg->value.type);
+  ASSERT_TRUE(strstr(msg->value.s, "test.strict_invalid_local") != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "offset") != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "local index") != NULL);
+  teardown_runtime();
+}
+
+void test_strict_validation_rejects_null_bytecode(void) {
+  setup_runtime();
+  ITEM_t *item = make_item("nullcode", config.itemroot, ITEM_code, VALUE_NIL, NULL, 0);
+  ASSERT_NOT_NULL(item);
+  config.strict_validation = true;
+  VALUE_t result = interpret(item);
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  ASSERT_TRUE(!item->inuse);
+  ITEM_t *err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(ERR_RUNTIME_BYTECODE, err->value.i);
+  ITEM_t *msg = find_item(config.itemroot, "error.msg");
+  ASSERT_NOT_NULL(msg);
+  ASSERT_TRUE(strstr(msg->value.s, "null bytecode") != NULL);
+  teardown_runtime();
+}

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -116,6 +116,8 @@ void test_value_comparison_string_helpers(void);
 void test_value_comparison_mismatched_type_equality_quirk(void);
 void test_value_comparison_unsupported_ordering_is_false(void);
 void test_interpreter_truncated_single_byte_operands(void);
+void test_strict_validation_runtime_opt_in(void);
+void test_strict_validation_rejects_null_bytecode(void);
 
 /* Compiler component tests. */
 void test_emitbc_header(void);
@@ -216,6 +218,8 @@ static const test_case_t core_tests[] = {
     {"test_value_comparison_mismatched_type_equality_quirk", test_value_comparison_mismatched_type_equality_quirk},
     {"test_value_comparison_unsupported_ordering_is_false", test_value_comparison_unsupported_ordering_is_false},
     {"test_interpreter_truncated_single_byte_operands", test_interpreter_truncated_single_byte_operands},
+    {"test_strict_validation_runtime_opt_in", test_strict_validation_runtime_opt_in},
+    {"test_strict_validation_rejects_null_bytecode", test_strict_validation_rejects_null_bytecode},
 };
 
 static const test_case_t compiler_tests[] = {


### PR DESCRIPTION
### Motivation

- Prevent expensive strict bytecode verification by default while allowing an opt-in runtime mode that rejects malformed or unsafe code before execution.

### Description

- Add a `config.strict_validation` flag and a `--strict-validation` CLI option, defaulting to disabled, and expose it in `sin` usage text.
- Implement `verify_runtime_bytecode()` in `src/interpret.c` which calls the shared `bc_verify_bytecode()` with `BC_VERIFY_MODE_RUNTIME`, rejects null bytecode, and reports verifier failures with item name and verifier offset via `set_error_item(ERR_RUNTIME_BYTECODE, ...)` and `logerr()`.
- Call `verify_runtime_bytecode()` before using `current_item->bytecode` in `interpret()` (so the interpreter never marks the item `inuse` or mutates frame state on failure) and before transferring control to a callee in `op_fetchitem` (so callee bytecode is verified before `pending_call_item` is used).
- Add a new runtime error code `ERR_RUNTIME_BYTECODE` and message, and extend the error table size accordingly.
- Add tests covering opt-in behavior and null-bytecode rejection and wire them into the test harness.

### Testing

- Ran the full test suite with `make test`, which completed and reported all tests passing (including the new tests). 
- Verified CLI help contains the new flag via `./sin --help | rg -- '--strict-validation'`.
- Ran repository checks with `git diff --check` (no whitespace/check failures).
- New/modified tests: `tests/core/test_value_behavior.c` (added `test_strict_validation_runtime_opt_in` and `test_strict_validation_rejects_null_bytecode`) and test registrations in `tests/shared/test_compiler.c`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4172bd2e18832eb89501820f158fc2)