### PR TITLE
Validate code item bytecode on load when strict_validation enabled and add tests

### DIFF
--- a/src/item.c
+++ b/src/item.c
@@ -20,6 +20,7 @@
 #include "memory.h"
 #include "log.h"
 #include "item.h"
+#include "bytecode_verify.h"
 
 static uint64_t itemstore_generation = 1;
 
@@ -1276,6 +1277,20 @@ static ITEM_t *read_item_record(FILE *file, ITEM_t *parent,
         return NULL;
       }
       if (!read_bytes(file, bytecode, bytecode_len, "bytecode payload")) {
+        goto fail_before_item;
+      }
+    }
+
+    if (config.strict_validation) {
+      BC_VerifyOptions verify_options = bc_verify_default_options();
+      verify_options.mode = BC_VERIFY_MODE_ITEMSTORE;
+      verify_options.strict_trailing_bytes = true;
+      BC_VerifyResult verify = bc_verify_bytecode(bytecode, bytecode_len,
+                                                  name, &verify_options);
+      if (verify.status != BC_VERIFY_OK) {
+        logerr("Corrupt itemstore '%s': bytecode verification failed for "
+               "'%s': %s\n", ctx->filename, name,
+               verify.diagnostic.message);
         goto fail_before_item;
       }
     }

--- a/tests/core/test_itemstore_io.c
+++ b/tests/core/test_itemstore_io.c
@@ -146,7 +146,7 @@ void test_itemstore_value_and_code_roundtrip(void) {
   ASSERT_NOT_NULL(insert_item(root, "string",
                               (VALUE_t){.type = VALUE_str, .s = text}));
 
-  static const uint8_t expected_bytecode[] = {0x00, 0xff, 0x42, 0x00};
+  static const uint8_t expected_bytecode[] = {0x00, 0x00, 'h'};
   uint8_t *bytecode = malloc(sizeof(expected_bytecode));
   ASSERT_NOT_NULL(bytecode);
   memcpy(bytecode, expected_bytecode, sizeof(expected_bytecode));
@@ -262,7 +262,7 @@ void test_itemstore_loads_generated_v1_wire_fixture(void) {
   put_bytes(file, "sin", 3);
   put_u32_le(file, 0);
 
-  static const uint8_t bytecode[] = {0x10, 0x00, 0x7f};
+  static const uint8_t bytecode[] = {0x00, 0x00, 'h'};
   put_record_prefix(file, "code", WIRE_ITEM_CODE);
   put_u32_le(file, sizeof(bytecode));
   put_bytes(file, bytecode, sizeof(bytecode));
@@ -293,6 +293,82 @@ void test_itemstore_loads_generated_v1_wire_fixture(void) {
 
   destroy_item(loaded);
   ASSERT_EQ_INT(0, unlink(path));
+}
+
+
+static void put_code_record(FILE *file, const char *name, const uint8_t *bytecode,
+                            uint32_t bytecode_len, uint32_t child_count) {
+  put_record_prefix(file, name, WIRE_ITEM_CODE);
+  put_u32_le(file, bytecode_len);
+  if (bytecode_len > 0) put_bytes(file, bytecode, bytecode_len);
+  put_u32_le(file, child_count);
+}
+
+static void assert_malformed_code_rejected(const uint8_t *bytecode,
+                                           uint32_t bytecode_len) {
+  char path[] = "/tmp/sin-itemstore-bad-code-XXXXXX";
+  FILE *file = new_fixture(path);
+  put_header(file, WIRE_VERSION);
+  put_nil_record_prefix(file, "root", 1);
+  put_code_record(file, "badcode", bytecode, bytecode_len, 0);
+  assert_fixture_rejected(file, path);
+  ASSERT_EQ_INT(0, unlink(path));
+}
+
+void test_load_itemstore_rejects_malformed_code_bytecode(void) {
+  bool previous_strict_validation = config.strict_validation;
+  config.strict_validation = true;
+
+  const uint8_t missing_header[] = {'h'};
+  assert_malformed_code_rejected(missing_header, sizeof(missing_header));
+
+  const uint8_t missing_halt[] = {0, 0, 'b', 1};
+  assert_malformed_code_rejected(missing_halt, sizeof(missing_halt));
+
+  const uint8_t truncated_string_operand[] = {0, 0, 'l', 3, 0, 'a', 'b'};
+  assert_malformed_code_rejected(truncated_string_operand,
+                                 sizeof(truncated_string_operand));
+
+  const uint8_t invalid_local_index[] = {0, 0, 'e', 0, 'h'};
+  assert_malformed_code_rejected(invalid_local_index,
+                                 sizeof(invalid_local_index));
+
+  const uint8_t invalid_jump_target[] = {0, 0, 'j', 0x04, 0x00, 'h'};
+  assert_malformed_code_rejected(invalid_jump_target,
+                                 sizeof(invalid_jump_target));
+
+  const uint8_t malformed_nested_item_expression[] = {
+    0, 0, 'I', 'L', 4, 'x', 'E', 'h'
+  };
+  assert_malformed_code_rejected(malformed_nested_item_expression,
+                                 sizeof(malformed_nested_item_expression));
+
+  config.strict_validation = previous_strict_validation;
+}
+
+void test_load_itemstore_allows_malformed_code_when_strict_validation_disabled(
+    void) {
+  bool previous_strict_validation = config.strict_validation;
+  config.strict_validation = false;
+
+  char path[] = "/tmp/sin-itemstore-bad-code-disabled-XXXXXX";
+  FILE *file = new_fixture(path);
+  const uint8_t missing_halt[] = {0, 0, 'b', 1};
+  put_header(file, WIRE_VERSION);
+  put_nil_record_prefix(file, "root", 1);
+  put_code_record(file, "badcode", missing_halt, sizeof(missing_halt), 0);
+  ASSERT_EQ_INT(0, fclose(file));
+
+  ITEM_t *loaded = load_itemstore(path);
+  ASSERT_NOT_NULL(loaded);
+  ITEM_t *badcode = find_item(loaded, "badcode");
+  ASSERT_NOT_NULL(badcode);
+  ASSERT_EQ_INT(ITEM_code, badcode->type);
+  ASSERT_EQ_INT(sizeof(missing_halt), badcode->bytecode_len);
+
+  destroy_item(loaded);
+  ASSERT_EQ_INT(0, unlink(path));
+  config.strict_validation = previous_strict_validation;
 }
 
 void test_load_itemstore_rejects_bad_headers(void) {

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -71,6 +71,9 @@ void test_itemstore_value_and_code_roundtrip(void);
 void test_itemstore_nested_depth_roundtrip(void);
 void test_itemstore_loads_generated_v1_wire_fixture(void);
 void test_load_itemstore_rejects_bad_headers(void);
+void test_load_itemstore_rejects_malformed_code_bytecode(void);
+void test_load_itemstore_allows_malformed_code_when_strict_validation_disabled(
+    void);
 void test_load_itemstore_rejects_invalid_wire_tags(void);
 void test_load_itemstore_rejects_structural_corruption(void);
 void test_load_itemstore_rejects_resource_limit_violations(void);
@@ -185,6 +188,9 @@ static const test_case_t core_tests[] = {
     {"test_itemstore_nested_depth_roundtrip", test_itemstore_nested_depth_roundtrip},
     {"test_itemstore_loads_generated_v1_wire_fixture", test_itemstore_loads_generated_v1_wire_fixture},
     {"test_load_itemstore_rejects_bad_headers", test_load_itemstore_rejects_bad_headers},
+    {"test_load_itemstore_rejects_malformed_code_bytecode", test_load_itemstore_rejects_malformed_code_bytecode},
+    {"test_load_itemstore_allows_malformed_code_when_strict_validation_disabled",
+     test_load_itemstore_allows_malformed_code_when_strict_validation_disabled},
     {"test_load_itemstore_rejects_invalid_wire_tags", test_load_itemstore_rejects_invalid_wire_tags},
     {"test_load_itemstore_rejects_structural_corruption", test_load_itemstore_rejects_structural_corruption},
     {"test_load_itemstore_rejects_resource_limit_violations", test_load_itemstore_rejects_resource_limit_violations},


### PR DESCRIPTION
### Motivation
- Prevent corrupt or malicious bytecode from being silently loaded into the itemstore by performing verification on code items when strict validation is enabled.
- Make itemstore loading behavior configurable so environments that need backward compatibility can disable strict checks.

### Description
- Added `#include "bytecode_verify.h"` and invoke `bc_verify_bytecode` for `WIRE_ITEM_CODE` records when `config.strict_validation` is true, using `BC_VERIFY_MODE_ITEMSTORE` and `strict_trailing_bytes` enabled.
- Added test helpers `put_code_record` and `assert_malformed_code_rejected` and new tests `test_load_itemstore_rejects_malformed_code_bytecode` and `test_load_itemstore_allows_malformed_code_when_strict_validation_disabled` to exercise strict and non-strict behavior.
- Updated existing test fixtures to use adjusted bytecode vectors and registered the new tests in the test list.

### Testing
- Ran the core unit test suite including the new tests via the repository test harness, and all tests passed.
- Exercised both strict and non-strict code-paths by toggling `config.strict_validation` in tests which confirmed rejection and acceptance behavior respectively.
- Existing itemstore IO roundtrip and header/malformed-file tests were re-run and remained passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4173fbd098832e9260e5d6788c5cd4)