### PR TITLE
Share bytecode decoder with sdiss

### DIFF
--- a/src/bytecode_verify.c
+++ b/src/bytecode_verify.c
@@ -37,6 +37,9 @@ typedef struct {
   BC_JumpRef *jumps;
   uint32_t jump_count;
   uint32_t jump_capacity;
+  BC_DecodeInstructionCallback callback;
+  void *callback_ctx;
+  uint32_t event_depth;
 } BC_Decoder;
 
 BC_VerifyOptions bc_verify_default_options(void) {
@@ -125,6 +128,74 @@ static const IR_OpSchema *bc_schema_for(uint8_t opcode, BC_DecodeContext ctx) {
 
 static int bc_decode_one(BC_Decoder *d, const uint8_t **cursor,
                          BC_DecodeContext ctx);
+
+static const char *bc_disassembly_mnemonic(IR_Op op) {
+  switch (op) {
+    case IR_OP_HALT: return "HALT";
+    case IR_OP_ADD: return "ADD";
+    case IR_OP_SUB: return "SUBTRACT";
+    case IR_OP_MUL: return "MULTIPLY";
+    case IR_OP_DIV: return "DIVIDE";
+    case IR_OP_NEG: return "NEGATE";
+    case IR_OP_EQ: return "BOOL EQ";
+    case IR_OP_NEQ: return "BOOL NOTEQ";
+    case IR_OP_LT: return "BOOL LT";
+    case IR_OP_GT: return "BOOL GT";
+    case IR_OP_LE: return "BOOL LTEQ";
+    case IR_OP_GE: return "BOOL GTEQ";
+    case IR_OP_NOT: return "LOGICAL NOT";
+    case IR_OP_AND: return "LOGICAL AND";
+    case IR_OP_OR: return "LOGICAL OR";
+    case IR_OP_LOAD_LOCAL: return "RETRIEVE LOCAL";
+    case IR_OP_STORE_LOCAL: return "SAVE LOCAL";
+    case IR_OP_INC_LOCAL: return "INCREMENT LOCAL";
+    case IR_OP_DEC_LOCAL: return "DECREMENT LOCAL";
+    case IR_OP_PUSH_INT: return "INTEGER";
+    case IR_OP_PUSH_FLOAT: return "FLOAT";
+    case IR_OP_PUSH_BOOL: return "BOOLEAN";
+    case IR_OP_PUSH_STRING: return "STRINGLIT";
+    case IR_OP_JUMP: return "JUMP";
+    case IR_OP_JUMP_IF_FALSE: return "JUMP IF FALSE";
+    case IR_OP_CALL: return "CALL";
+    case IR_OP_LIBCALL_TOKEN: return "LIBCALL_TOKEN";
+    case IR_OP_ITEM_BEGIN: return "BEGIN ITEM ASSEMBLY";
+    case IR_OP_ITEM_BEGIN_REL: return "BEGIN RELATIVE ITEM ASSEMBLY";
+    case IR_OP_ITEM_PUSH_LAYER: return "LAYER";
+    case IR_OP_ITEM_PUSH_DEREF: return "BEGIN DEREFERENCE LAYER";
+    case IR_OP_ITEM_PUSH_DEREF_LOCAL: return "LOCALVAR";
+    case IR_OP_ITEM_END: return "END ITEM LAYER ASSEMBLY";
+    case IR_OP_ITEM_DEREF: return "ITEM DEREF";
+    case IR_OP_ITEM_SAVE: return "SAVE ITEM";
+    case IR_OP_ITEM_SAVE_CODE: return "EMBEDDED CODE";
+    case IR_OP_EXISTS: return "ITEM EXISTS";
+    case IR_OP_DELETE: return "DELETE ITEM";
+    case IR_OP_NTHNAME: return "NTHNAME";
+    case IR_OP_ROOTNAME: return "ROOTNAME";
+    case IR_OP_LABEL: return "LABEL";
+  }
+  return "UNKNOWN";
+}
+
+static int bc_emit_event(BC_Decoder *d, const uint8_t *start, const uint8_t *cursor,
+                         uint8_t opcode, const IR_OpSchema *schema,
+                         const BC_Operand *operand, BC_DecodeContext ctx) {
+  if (!d->callback) return 1;
+  BC_Instruction inst;
+  memset(&inst, 0, sizeof(inst));
+  inst.offset = bc_offset(d, start);
+  inst.opcode = opcode;
+  inst.mnemonic = bc_disassembly_mnemonic(schema->op);
+  inst.schema = schema;
+  if (operand) inst.operand = *operand;
+  inst.raw = start;
+  inst.raw_len = (uint32_t)(cursor - start);
+  inst.context = ctx == BC_CTX_STMT ? BC_EVENT_CONTEXT_STMT : (ctx == BC_CTX_ITEM ? BC_EVENT_CONTEXT_ITEM : BC_EVENT_CONTEXT_DEREF);
+  inst.depth = d->event_depth;
+  if (!d->callback(&inst, d->callback_ctx)) {
+    return bc_fail(d, start, opcode, "decoder callback aborted");
+  }
+  return 1;
+}
 
 static int bc_validate_local_index(BC_Decoder *d, const uint8_t *p,
                                    uint8_t opcode, uint8_t index) {
@@ -341,9 +412,22 @@ static int bc_decode_deref(BC_Decoder *d, const uint8_t **cursor) {
     if (!bc_need(d, *cursor, 1, type, "dereference local index")) return 0;
     const uint8_t *index_p = *cursor;
     uint8_t index = *(*cursor)++;
-    return bc_validate_local_index(d, index_p, type, index);
+    if (!bc_validate_local_index(d, index_p, type, index)) return 0;
+    const IR_OpSchema *schema = bc_schema_for(type, BC_CTX_DEREF);
+    if (schema) {
+      BC_Operand operand;
+      memset(&operand, 0, sizeof(operand));
+      operand.kind = BC_OPERAND_U8; operand.offset = bc_offset(d, index_p); operand.width = 1; operand.value.u8 = index;
+      if (!bc_emit_event(d, start, *cursor, type, schema, &operand, BC_CTX_DEREF)) return 0;
+    }
+    return 1;
   }
-  if (type == 'I' || type == 'R') return bc_decode_item(d, cursor);
+  if (type == 'I' || type == 'R') {
+    d->event_depth++;
+    int ok = bc_decode_item(d, cursor);
+    d->event_depth--;
+    return ok;
+  }
   return bc_fail(d, start, type, "unknown dereference type");
 }
 
@@ -360,6 +444,9 @@ static void bc_record_instruction_meta(BC_Decoder *d, const uint8_t *start,
 static int bc_decode_one(BC_Decoder *d, const uint8_t **cursor,
                          BC_DecodeContext ctx) {
   const uint8_t *start = *cursor;
+  BC_Operand operand;
+  memset(&operand, 0, sizeof(operand));
+  operand.kind = BC_OPERAND_NONE;
   uint16_t operand_u16 = 0;
   if (!bc_need(d, start, 1, 0, "opcode")) return 0;
   uint8_t op = *(*cursor)++;
@@ -375,31 +462,36 @@ static int bc_decode_one(BC_Decoder *d, const uint8_t **cursor,
     case IR_OP_ITEM_DEREF: case IR_OP_ITEM_SAVE: case IR_OP_EXISTS: case IR_OP_DELETE:
     case IR_OP_NTHNAME: case IR_OP_ROOTNAME: case IR_OP_ITEM_END:
       bc_record_instruction_meta(d, start, *cursor, op, schema->op, operand_u16);
-      return 1;
+      return bc_emit_event(d, start, *cursor, op, schema, &operand, ctx);
     case IR_OP_PUSH_BOOL:
     case IR_OP_LIBCALL_TOKEN:
       if (!bc_need(d, *cursor, 1, op, schema->name)) return 0;
+      operand.kind = BC_OPERAND_U8; operand.offset = bc_offset(d, *cursor); operand.width = 1; operand.value.u8 = **cursor;
       (*cursor)++;
       bc_record_instruction_meta(d, start, *cursor, op, schema->op, operand_u16);
-      return 1;
+      return bc_emit_event(d, start, *cursor, op, schema, &operand, ctx);
     case IR_OP_LOAD_LOCAL: case IR_OP_STORE_LOCAL: case IR_OP_INC_LOCAL:
     case IR_OP_DEC_LOCAL: case IR_OP_ITEM_PUSH_DEREF_LOCAL: {
       if (!bc_need(d, *cursor, 1, op, schema->name)) return 0;
       const uint8_t *index_p = *cursor;
-      uint8_t index = *(*cursor)++;
+      uint8_t index = **cursor;
+      operand.kind = BC_OPERAND_U8; operand.offset = bc_offset(d, *cursor); operand.width = 1; operand.value.u8 = index;
+      (*cursor)++;
       if (!bc_validate_local_index(d, index_p, op, index)) return 0;
       bc_record_instruction_meta(d, start, *cursor, op, schema->op, operand_u16);
-      return 1;
+      return bc_emit_event(d, start, *cursor, op, schema, &operand, ctx);
     }
     case IR_OP_CALL:
       if (!bc_need(d, *cursor, 2, op, schema->name)) return 0;
       operand_u16 = (uint16_t)(*cursor)[0] | ((uint16_t)(*cursor)[1] << 8);
+      operand.kind = BC_OPERAND_U16; operand.offset = bc_offset(d, *cursor); operand.width = 2; operand.value.u16 = operand_u16;
       *cursor += 2;
       break;
     case IR_OP_JUMP: case IR_OP_JUMP_IF_FALSE: {
       if (!bc_need(d, *cursor, 2, op, schema->name)) return 0;
       const uint8_t *operand_start = *cursor;
       operand_u16 = (uint16_t)(*cursor)[0] | ((uint16_t)(*cursor)[1] << 8);
+      operand.kind = BC_OPERAND_I16; operand.offset = bc_offset(d, *cursor); operand.width = 2; operand.value.i16 = (int16_t)operand_u16;
       if (ctx == BC_CTX_STMT && !bc_record_jump(d, operand_start, op)) return 0;
       *cursor += 2;
       break;
@@ -407,42 +499,54 @@ static int bc_decode_one(BC_Decoder *d, const uint8_t **cursor,
     case IR_OP_PUSH_INT:
     case IR_OP_PUSH_FLOAT:
       if (!bc_need(d, *cursor, 8, op, schema->name)) return 0;
+      operand.offset = bc_offset(d, *cursor); operand.width = 8;
+      memcpy(&operand.value.u64, *cursor, 8);
+      operand.kind = schema->op == IR_OP_PUSH_INT ? BC_OPERAND_I64 : BC_OPERAND_F64_BITS;
       *cursor += 8;
       bc_record_instruction_meta(d, start, *cursor, op, schema->op, operand_u16);
-      return 1;
+      return bc_emit_event(d, start, *cursor, op, schema, &operand, ctx);
     case IR_OP_PUSH_STRING:
     case IR_OP_ITEM_SAVE_CODE: {
       if (!bc_need(d, *cursor, 2, op, "length")) return 0;
       uint16_t len;
       memcpy(&len, *cursor, sizeof(len));
+      const uint8_t *data_start = *cursor + 2;
       *cursor += 2;
       if (!bc_need(d, *cursor, len, op, schema->name)) return 0;
+      operand.kind = schema->op == IR_OP_PUSH_STRING ? BC_OPERAND_CSTR_U16 : BC_OPERAND_EMBEDDED_SOURCE;
+      operand.offset = bc_offset(d, data_start); operand.width = len; operand.value.bytes.data = data_start; operand.value.bytes.len = len;
       *cursor += len;
       bc_record_instruction_meta(d, start, *cursor, op, schema->op, operand_u16);
-      return 1;
+      return bc_emit_event(d, start, *cursor, op, schema, &operand, ctx);
     }
     case IR_OP_ITEM_PUSH_LAYER: {
       if (!bc_need(d, *cursor, 1, op, "layer length")) return 0;
-      uint8_t len = *(*cursor)++;
+      uint8_t len = **cursor;
+      (*cursor)++;
       if (!bc_need(d, *cursor, len, op, "layer string")) return 0;
+      operand.kind = BC_OPERAND_CSTR_U8; operand.offset = bc_offset(d, *cursor); operand.width = len; operand.value.bytes.data = *cursor; operand.value.bytes.len = len;
       *cursor += len;
       bc_record_instruction_meta(d, start, *cursor, op, schema->op, operand_u16);
-      return 1;
+      return bc_emit_event(d, start, *cursor, op, schema, &operand, ctx);
     }
     case IR_OP_ITEM_PUSH_DEREF:
-      if (!bc_decode_deref(d, cursor)) return 0;
+      d->event_depth++;
+      if (!bc_decode_deref(d, cursor)) { d->event_depth--; return 0; }
+      d->event_depth--;
       bc_record_instruction_meta(d, start, *cursor, op, schema->op, operand_u16);
-      return 1;
+      return bc_emit_event(d, start, *cursor, op, schema, &operand, ctx);
     case IR_OP_ITEM_BEGIN:
     case IR_OP_ITEM_BEGIN_REL:
-      if (!bc_decode_item(d, cursor)) return 0;
+      d->event_depth++;
+      if (!bc_decode_item(d, cursor)) { d->event_depth--; return 0; }
+      d->event_depth--;
       bc_record_instruction_meta(d, start, *cursor, op, schema->op, operand_u16);
-      return 1;
+      return bc_emit_event(d, start, *cursor, op, schema, &operand, ctx);
     case IR_OP_LABEL:
       break;
   }
   bc_record_instruction_meta(d, start, *cursor, op, schema->op, operand_u16);
-  return 1;
+  return bc_emit_event(d, start, *cursor, op, schema, &operand, ctx);
 }
 
 bool bc_decode_item_expression(const uint8_t *item_payload,
@@ -470,16 +574,21 @@ bool bc_decode_item_expression(const uint8_t *item_payload,
   return true;
 }
 
-BC_VerifyResult bc_verify_bytecode(const uint8_t *bytecode,
-                                   uint32_t bytecode_len,
-                                   const char *source_label,
-                                   const BC_VerifyOptions *options) {
+BC_VerifyResult bc_decode_bytecode_events(const uint8_t *bytecode,
+                                          uint32_t bytecode_len,
+                                          const char *source_label,
+                                          const BC_VerifyOptions *options,
+                                          BC_BytecodeMetadata *metadata,
+                                          BC_DecodeInstructionCallback callback,
+                                          void *callback_ctx) {
   BC_Decoder d;
   memset(&d, 0, sizeof(d));
   d.base = bytecode;
   d.end = bytecode ? bytecode + bytecode_len : NULL;
   d.label = source_label;
   d.options = options ? *options : bc_verify_default_options();
+  d.callback = callback;
+  d.callback_ctx = callback_ctx;
   d.result.status = BC_VERIFY_OK;
   d.result.halt_offset = UINT32_MAX;
 
@@ -494,6 +603,7 @@ BC_VerifyResult bc_verify_bytecode(const uint8_t *bytecode,
 
   uint8_t locals = bytecode[0];
   uint8_t params = bytecode[1];
+  if (metadata) { metadata->locals = locals; metadata->params = params; }
   d.local_count = locals;
   d.validate_local_indices = true;
   if (params > locals) {
@@ -523,17 +633,19 @@ BC_VerifyResult bc_verify_bytecode(const uint8_t *bytecode,
     }
     if (*start == 'h') {
       d.result.halt_offset = bc_offset(&d, start);
-      if (!bc_validate_recorded_jumps(&d)) {
-        free(d.top_level_instruction_starts);
-        free(d.instructions);
-        free(d.jumps);
-        return d.result;
-      }
-      if (!bc_verify_stack_flow(&d, params)) {
-        free(d.top_level_instruction_starts);
-        free(d.instructions);
-        free(d.jumps);
-        return d.result;
+      if (d.options.mode != BC_VERIFY_MODE_DISASSEMBLY) {
+        if (!bc_validate_recorded_jumps(&d)) {
+          free(d.top_level_instruction_starts);
+          free(d.instructions);
+          free(d.jumps);
+          return d.result;
+        }
+        if (!bc_verify_stack_flow(&d, params)) {
+          free(d.top_level_instruction_starts);
+          free(d.instructions);
+          free(d.jumps);
+          return d.result;
+        }
       }
       if (cursor < d.end) {
         if (d.options.strict_trailing_bytes || d.options.mode != BC_VERIFY_MODE_DISASSEMBLY) {
@@ -554,4 +666,12 @@ BC_VerifyResult bc_verify_bytecode(const uint8_t *bytecode,
   free(d.instructions);
   free(d.jumps);
   return d.result;
+}
+
+BC_VerifyResult bc_verify_bytecode(const uint8_t *bytecode,
+                                   uint32_t bytecode_len,
+                                   const char *source_label,
+                                   const BC_VerifyOptions *options) {
+  return bc_decode_bytecode_events(bytecode, bytecode_len, source_label, options,
+                                   NULL, NULL, NULL);
 }

--- a/src/bytecode_verify.h
+++ b/src/bytecode_verify.h
@@ -36,14 +36,43 @@ typedef struct {
   BC_OperandKind kind;
   uint32_t offset;
   uint32_t width;
+  union {
+    uint8_t u8;
+    uint16_t u16;
+    int16_t i16;
+    int64_t i64;
+    uint64_t u64;
+    struct {
+      const uint8_t *data;
+      uint16_t len;
+    } bytes;
+  } value;
 } BC_Operand;
+
+typedef enum {
+  BC_EVENT_CONTEXT_STMT = 0,
+  BC_EVENT_CONTEXT_ITEM = 1,
+  BC_EVENT_CONTEXT_DEREF = 2
+} BC_EventContext;
 
 typedef struct {
   uint32_t offset;
   uint8_t opcode;
+  const char *mnemonic;
   const IR_OpSchema *schema;
   BC_Operand operand;
+  const uint8_t *raw;
+  uint32_t raw_len;
+  BC_EventContext context;
+  uint32_t depth;
 } BC_Instruction;
+
+typedef struct {
+  uint8_t locals;
+  uint8_t params;
+} BC_BytecodeMetadata;
+
+typedef bool (*BC_DecodeInstructionCallback)(const BC_Instruction *instruction, void *ctx);
 
 typedef struct {
   uint32_t offset;
@@ -76,6 +105,13 @@ BC_VerifyResult bc_verify_bytecode(const uint8_t *bytecode,
                                    uint32_t bytecode_len,
                                    const char *source_label,
                                    const BC_VerifyOptions *options);
+BC_VerifyResult bc_decode_bytecode_events(const uint8_t *bytecode,
+                                          uint32_t bytecode_len,
+                                          const char *source_label,
+                                          const BC_VerifyOptions *options,
+                                          BC_BytecodeMetadata *metadata,
+                                          BC_DecodeInstructionCallback callback,
+                                          void *callback_ctx);
 bool bc_decode_item_expression(const uint8_t *item_payload,
                                const uint8_t *bytecode_end,
                                BC_ItemExprKind kind,

--- a/src/sdiss.c
+++ b/src/sdiss.c
@@ -2,49 +2,33 @@
 
 // Licensed under the MIT License - see LICENSE file for details.
 
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
-#include <stdarg.h>
 #include <getopt.h>
 #include <math.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "version.h"
+#include "bytecode_verify.h"
 #include "config.h"
-#include "memory.h"
-#include "log.h"
 #include "floatconv.h"
-#include "value.h"
-#include "item.h"
-#include "stack.h"
+#include "log.h"
+#include "memory.h"
+#include "version.h"
 
 CONFIG_t config;
 
-uint8_t *bytecode;
-
-typedef enum { DECODE_STMT = 0,
-               DECODE_ITEM = 1,
-               DECODE_DEREF = 2 } decode_context_t;
-typedef enum { PARSE_OK = 0,
-               PARSE_EOF = 1,
-               PARSE_ERR = 2 } parse_status_t;
-typedef enum { OPERAND_NONE = 0,
-               OPERAND_U8,
-               OPERAND_I16,
-               OPERAND_I64,
-               OPERAND_F64_BITS,
-               OPERAND_BLOB_I16 } operand_kind_t;
+static uint8_t *bytecode;
+static int opt_raw = 0, opt_no_header = 0;
 
 typedef struct {
-  uint8_t opcode;
-  const char *mnemonic;
-  operand_kind_t operand;
-  uint8_t *(*handler)(uint8_t *, uint8_t *, decode_context_t);
-} opcode_desc_t;
-
-static int decode_failed = 0, unknown_opcode_count = 0, warning_count =
-  0, instruction_count = 0;
-static int opt_raw = 0, opt_no_header = 0;
+  BC_BytecodeMetadata *metadata;
+  int header_printed;
+  int instruction_count;
+  int unknown_opcode_count;
+  int warning_count;
+} SDissState;
 
 static void outln(const char *fmt, ...) {
   va_list args;
@@ -52,13 +36,15 @@ static void outln(const char *fmt, ...) {
   vprintf(fmt, args);
   va_end(args);
 }
-static void print_raw(uint8_t *start, uint8_t *end) {
+
+static void print_raw(const BC_Instruction *inst) {
   if (!opt_raw) return;
   outln(" [raw:");
-  for (uint8_t * p = start; p < end; p++) outln(" %02X", *p);
+  for (uint32_t i = 0; i < inst->raw_len; i++) outln(" %02X", inst->raw[i]);
   outln("]");
 }
-static void print_escaped_bytes(uint8_t *data, size_t len) {
+
+static void print_escaped_bytes(const uint8_t *data, size_t len) {
   for (size_t i = 0; i < len; i++) {
     uint8_t c = data[i];
     if (c == '\n') outln("\\n");
@@ -79,362 +65,110 @@ void usage() {
   logmsg("     --no-header\tSkip locals/params header output.\n");
 }
 
-static int require_bytes(uint8_t *p, uint8_t *end, size_t count,
-                         const char *what) {
-  if ((size_t) (end - p) < count) {
-    logerr
-      ("Decode error at byte %05u: insufficient bytes for %s (need %zu, have %zu)\n",
-       (unsigned int) (p - bytecode), what, count, (size_t) (end - p));
-    decode_failed = 1;
-    return 0;
-  }
-  return 1;
-}
-static parse_status_t read_u8(uint8_t **p, uint8_t *end, uint8_t *out,
-                              const char *what) {
-  if (!require_bytes(*p, end, 1, what)) return PARSE_EOF;
-  *out = *(*p)++;
-  return PARSE_OK;
-}
-static parse_status_t read_i16(uint8_t **p, uint8_t *end, int16_t *out,
-                               const char *what) {
-  if (!require_bytes(*p, end, 2, what)) return PARSE_EOF;
-  memcpy(out, *p, 2);
-  *p += 2;
-  return PARSE_OK;
-}
-static parse_status_t read_i64(uint8_t **p, uint8_t *end, int64_t *out,
-                               const char *what) {
-  if (!require_bytes(*p, end, 8, what)) return PARSE_EOF;
-  memcpy(out, *p, 8);
-  *p += 8;
-  return PARSE_OK;
-}
-static parse_status_t read_u64_payload(uint8_t **p, uint8_t *end, uint64_t *out,
-                                       const char *what) {
-  if (!require_bytes(*p, end, 8, what)) return PARSE_EOF;
-  memcpy(out, *p, 8);
-  *p += 8;
-  return PARSE_OK;
-}
-static parse_status_t read_blob(uint8_t **p, uint8_t *end, size_t len,
-                                uint8_t **out, const char *what) {
-  if (!require_bytes(*p, end, len, what)) return PARSE_EOF;
-  *out = *p;
-  *p += len;
-  return PARSE_OK;
-}
-
-static parse_status_t process_item(uint8_t ** p, uint8_t * end);
-static parse_status_t process_dereference(uint8_t ** p, uint8_t * end);
-static uint8_t *decode_opcode(uint8_t * p, uint8_t * end,
-                              decode_context_t context);
-
-static parse_status_t process_item(uint8_t **p, uint8_t *end) {
-  while (*p < end && **p != 'E') {
-    uint8_t op;
-    if (read_u8(p, end, &op, "item opcode") != PARSE_OK) return PARSE_EOF;
-    switch (op) {
-    case 'L':{
-        logmsg("Byte %05u: ", (unsigned int) (*p - bytecode - 2));
-        uint8_t len;
-        if (read_u8(p, end, &len, "layer length") !=
-            PARSE_OK) return PARSE_EOF;
-        uint8_t *bytes;
-        if (read_blob(p, end, len, &bytes, "layer string") !=
-            PARSE_OK) return PARSE_EOF;
-        char layer[256];
-        if (len >= sizeof(layer)) {
-          logerr("Decode error at byte %05u: layer name too long (%u)\n",
-                 (unsigned int) (*p - bytecode), len);
-          decode_failed = 1;
-          return PARSE_ERR;
-        }
-        memcpy(layer, bytes, len);
-        layer[len] = '\0';
-        logmsg("LAYER: %s\n", layer);
-        break;
-      }
-    case 'D':
-      logmsg("Byte %05u: ", (unsigned int) (*p - bytecode - 2));
-      logmsg("BEGIN DEREFERENCE LAYER\n");
-      if (process_dereference(p, end) != PARSE_OK) return PARSE_ERR;
+static void print_operand_line(const BC_Instruction *inst) {
+  switch (inst->schema->op) {
+    case IR_OP_PUSH_INT: {
+      int64_t v;
+      memcpy(&v, &inst->operand.value.u64, sizeof(v));
+      outln("INTEGER %ld\n", (long)v);
       break;
-    case 'F':
-      logmsg("Byte %05u: ", (unsigned int) (*p - bytecode - 2));
-      *p = decode_opcode(*p - 1, end, DECODE_ITEM);
-      if (decode_failed) return PARSE_ERR;
+    }
+    case IR_OP_PUSH_FLOAT: {
+      double value;
+      uint64_t bits = inst->operand.value.u64;
+      memcpy(&value, &bits, sizeof(value));
+      const char *class_name = "finite";
+      if (isnan(value)) class_name = "nan";
+      else if (isinf(value)) class_name = signbit(value) ? "-inf" : "+inf";
+      else if (value == 0.0) class_name = signbit(value) ? "-0.0" : "+0.0";
+      char fbuffer[64];
+      if (!sin_format_binary64_buf(value, fbuffer, sizeof(fbuffer))) {
+        snprintf(fbuffer, sizeof(fbuffer), "<float-format-error>");
+      }
+      outln("FLOAT %s (%s bits=0x%016llx)\n", fbuffer, class_name,
+            (unsigned long long)bits);
+      break;
+    }
+    case IR_OP_PUSH_BOOL:
+      outln("BOOLEAN %u\n", (unsigned int)(inst->operand.value.u8 ? 1 : 0));
+      break;
+    case IR_OP_PUSH_STRING:
+      outln("STRINGLIT: ");
+      print_escaped_bytes(inst->operand.value.bytes.data, inst->operand.value.bytes.len);
+      outln("\n");
+      break;
+    case IR_OP_LOAD_LOCAL:
+    case IR_OP_STORE_LOCAL:
+    case IR_OP_INC_LOCAL:
+    case IR_OP_DEC_LOCAL:
+      outln("%s %u\n", inst->mnemonic, (unsigned int)inst->operand.value.u8);
+      break;
+    case IR_OP_LIBCALL_TOKEN:
+      outln("LIBCALL_TOKEN %u\n", (unsigned int)inst->operand.value.u8);
+      break;
+    case IR_OP_CALL:
+      outln("CALL ARGC %u\n", (unsigned int)inst->operand.value.u16);
+      break;
+    case IR_OP_JUMP:
+    case IR_OP_JUMP_IF_FALSE: {
+      int16_t off = inst->operand.value.i16;
+      outln("%s rel=%d abs=%u\n", inst->mnemonic, off,
+            (unsigned int)(inst->operand.offset + 2 + off));
+      break;
+    }
+    case IR_OP_ITEM_PUSH_LAYER:
+      outln("LAYER: ");
+      print_escaped_bytes(inst->operand.value.bytes.data, inst->operand.value.bytes.len);
+      outln("\n");
+      break;
+    case IR_OP_ITEM_PUSH_DEREF_LOCAL:
+      outln("LOCALVAR %u\n", (unsigned int)inst->operand.value.u8);
+      break;
+    case IR_OP_ITEM_SAVE_CODE:
+      outln("EMBEDDED CODE (%u bytes):\n", (unsigned int)inst->operand.value.bytes.len);
+      print_escaped_bytes(inst->operand.value.bytes.data, inst->operand.value.bytes.len);
+      outln("\n");
       break;
     default:
-      logmsg("Unknown opcode in item assembly: 0x%02X (%c)\n", op,
-             (op >= 32 && op <= 126) ? op : '.');
-    }
+      outln("%s\n", inst->mnemonic);
+      break;
   }
-  if (*p >= end) {
-    logerr
-      ("Decode error: unterminated item stream (missing 'E' before EOF).\n");
-    decode_failed = 1;
-    return PARSE_EOF;
-  }
-  logmsg("Byte %05u: ", (unsigned int) (*p - bytecode - 1));
-  logmsg("END ITEM LAYER ASSEMBLY\n");
-  (*p)++;
-  return PARSE_OK;
-}
-static parse_status_t process_dereference(uint8_t **p, uint8_t *end) {
-  uint8_t t;
-  if (read_u8(p, end, &t, "dereference type") != PARSE_OK) return PARSE_EOF;
-  if (t == 'V') {
-    logmsg("Byte %05u: ", (unsigned int) (*p - bytecode - 2));
-    uint8_t lv;
-    if (read_u8(p, end, &lv, "local variable index") !=
-        PARSE_OK) return PARSE_EOF;
-    logmsg("LOCALVAR %d\n", lv);
-  } else if (t == 'I') {
-    logmsg("Byte %05u: ", (unsigned int) (*p - bytecode - 2));
-    logmsg("BEGIN ITEM ASSEMBLY\n");
-    return process_item(p, end);
-  } else if (t == 'R') {
-    logmsg("Byte %05u: ", (unsigned int) (*p - bytecode - 2));
-    logmsg("BEGIN RELATIVE ITEM ASSEMBLY\n");
-    return process_item(p, end);
-  } else {
-    logmsg("Byte %05u: ", (unsigned int) (*p - bytecode - 2));
-    logmsg("Unknown dereference type: %c (%d)\n", t, t);
-  } return PARSE_OK;
 }
 
-#define SIMPLE_HANDLER(name, text) static uint8_t* name(uint8_t*p,uint8_t*e,decode_context_t c){(void)e;(void)c; logmsg(text"\n"); return p;}
-SIMPLE_HANDLER(h_add, "ADD") SIMPLE_HANDLER(h_div,
-                                            "DIVIDE") SIMPLE_HANDLER(h_mul,
-                                                                     "MULTIPLY")
-SIMPLE_HANDLER(h_neg, "NEGATE") SIMPLE_HANDLER(h_eq,
-                                               "BOOL EQ")
-SIMPLE_HANDLER(h_neq, "BOOL NOTEQ") SIMPLE_HANDLER(h_lt,
-                                                   "BOOL LT")
-SIMPLE_HANDLER(h_sub, "SUBTRACT") SIMPLE_HANDLER(h_gt,
-                                                 "BOOL GT")
-SIMPLE_HANDLER(h_lte, "BOOL LTEQ") SIMPLE_HANDLER(h_gte,
-                                                  "BOOL GTEQ")
-SIMPLE_HANDLER(h_not, "LOGICAL NOT") SIMPLE_HANDLER(h_and,
-                                                    "LOGICAL AND")
-SIMPLE_HANDLER(h_or, "LOGICAL OR") SIMPLE_HANDLER(h_save_item,
-                                                  "SAVE ITEM")
-SIMPLE_HANDLER(h_delete_item, "DELETE ITEM") SIMPLE_HANDLER(h_item_exists,
-                                                            "ITEM EXISTS")
-SIMPLE_HANDLER(h_nthname, "NTHNAME") SIMPLE_HANDLER(h_rootname, "ROOTNAME")
-     static uint8_t *h_u8_local(const char *name, uint8_t *p, uint8_t *e) {
-  uint8_t v;
-  if (read_u8(&p, e, &v, name) != PARSE_OK) return p;
-  logmsg("%s %d\n", name, v);
-  return p;
-     }
-static uint8_t *h_store_local(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  return h_u8_local("SAVE LOCAL", p, e);
-}
-static uint8_t *h_load_local(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  return h_u8_local("RETRIEVE LOCAL", p, e);
-}
-static uint8_t *h_inc_local(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  return h_u8_local("INCREMENT LOCAL", p, e);
-}
-static uint8_t *h_dec_local(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  return h_u8_local("DECREMENT LOCAL", p, e);
-}
-static uint8_t *h_libcall_token(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void)c;
-  uint8_t token;
-  if (read_u8(&p, e, &token, "LIBCALL_TOKEN token") != PARSE_OK) return p;
-  logmsg("LIBCALL_TOKEN %u\n", token);
-  return p;
-}
-static uint8_t *h_jump(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  int16_t off;
-  if (read_i16(&p, e, &off, "JUMP offset") != PARSE_OK) return p;
-  outln("JUMP rel=%d abs=%u\n", off, (unsigned int) ((p - bytecode) + off));
-  return p;
-}
-static uint8_t *h_jif(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  int16_t off;
-  if (read_i16(&p, e, &off, "JUMP IF FALSE offset") != PARSE_OK) return p;
-  outln("JUMP IF FALSE rel=%d abs=%u\n", off,
-        (unsigned int) ((p - bytecode) + off));
-  return p;
-}
-static uint8_t *h_str(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  int16_t len;
-  uint8_t *b;
-  if (read_i16(&p, e, &len, "STRINGLIT length") != PARSE_OK) return p;
-  if (len < 0
-      || read_blob(&p, e, (size_t) len, &b,
-                   "STRINGLIT data") != PARSE_OK) return p;
-  outln("STRINGLIT: ");
-  print_escaped_bytes(b, (size_t) len);
-  outln("\n");
-  return p;
-}
-static uint8_t *h_int(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  int64_t v;
-  if (read_i64(&p, e, &v, "INTEGER literal") != PARSE_OK) return p;
-  logmsg("INTEGER %ld\n", v);
-  return p;
-}
-static uint8_t *h_float(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  uint64_t bits;
-  double value;
-  const char *class_name = "finite";
-  if (read_u64_payload(&p, e, &bits, "FLOAT literal") != PARSE_OK) return p;
-  memcpy(&value, &bits, sizeof(value));
-  if (isnan(value)) class_name = "nan";
-  else if (isinf(value)) class_name = signbit(value) ? "-inf" : "+inf";
-  else if (value == 0.0) class_name = signbit(value) ? "-0.0" : "+0.0";
-  char fbuffer[64];
-  if (!sin_format_binary64_buf(value, fbuffer, sizeof(fbuffer))) {
-    snprintf(fbuffer, sizeof(fbuffer), "<float-format-error>");
-  }
-  logmsg("FLOAT %s (%s bits=0x%016llx)\n", fbuffer, class_name, (unsigned long long)bits);
-  return p;
-}
-static uint8_t *h_bool(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  uint8_t v;
-  if (read_u8(&p, e, &v, "BOOLEAN literal") != PARSE_OK) return p;
-  logmsg("BOOLEAN %u\n", (unsigned int)(v ? 1 : 0));
-  return p;
-}
-static uint8_t *h_emb(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  int16_t len;
-  uint8_t *b;
-  if (read_i16(&p, e, &len, "EMBEDDED CODE length") != PARSE_OK) return p;
-  if (len < 0
-      || read_blob(&p, e, (size_t) len, &b,
-                   "EMBEDDED CODE data") != PARSE_OK) return p;
-  logmsg("EMBEDDED CODE (%d bytes):\n", len);
-  print_escaped_bytes(b, (size_t) len);
-  outln("\n");
-  return p;
-}
-static uint8_t *h_f(uint8_t *p, uint8_t *e, decode_context_t c) {
-  if (c == DECODE_ITEM || c == DECODE_DEREF) {
-    logmsg("ITEM DEREF\n");
-    return p;
-  }
-  int16_t argc;
-  if (read_i16(&p, e, &argc, "CALL arg count") != PARSE_OK) return p;
-  logmsg("CALL ARGC %d\n", argc);
-  return p;
-}
-static uint8_t *h_I(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  logmsg("BEGIN ITEM ASSEMBLY\n");
-  process_item(&p, e);
-  return p;
-}
-static uint8_t *h_R(uint8_t *p, uint8_t *e, decode_context_t c) {
-  (void) c;
-  logmsg("BEGIN RELATIVE ITEM ASSEMBLY\n");
-  process_item(&p, e);
-  return p;
+static void print_header_once(SDissState *state) {
+  if (state->header_printed) return;
+  state->header_printed = 1;
+  if (opt_no_header || !state->metadata) return;
+  if (state->metadata->locals > 0) logmsg("Local variables: %d\n", state->metadata->locals);
+  else logmsg("No local variables.\n");
+  if (state->metadata->params > 0) logmsg("(Of which, %d are parameters.)\n", state->metadata->params);
+  else logmsg("(No parameters.)\n");
 }
 
-/* Synchronization points:
- * - Keep opcode values aligned with src/emitbc.c:map_opcode.
- * - Keep mnemonics/semantics aligned with src/interpret.c VM execution. */
-static const opcode_desc_t OPCODES[] = {
-  {'a', "ADD", OPERAND_NONE, h_add}, {'c', "SAVE LOCAL", OPERAND_U8,
-                                      h_store_local}, {'d', "DIVIDE",
-                                                       OPERAND_NONE, h_div},
-    {'b', "BOOLEAN", OPERAND_U8, h_bool},
-    {'e', "RETRIEVE LOCAL", OPERAND_U8, h_load_local}, {'f',
-                                                        "INCREMENT LOCAL",
-                                                        OPERAND_U8,
-                                                        h_inc_local}, {'g',
-                                                                       "DECREMENT LOCAL",
-                                                                       OPERAND_U8,
-                                                                       h_dec_local},
-    {'j', "JUMP", OPERAND_I16, h_jump}, {'k', "JUMP IF FALSE", OPERAND_I16,
-                                         h_jif}, {'l', "STRINGLIT",
-                                                  OPERAND_BLOB_I16, h_str},
-    {'m', "MULTIPLY", OPERAND_NONE, h_mul}, {'n', "NEGATE", OPERAND_NONE,
-                                             h_neg}, {'o', "BOOL EQ",
-                                                      OPERAND_NONE, h_eq},
-    {'p', "INTEGER", OPERAND_I64, h_int}, {'P', "FLOAT", OPERAND_F64_BITS, h_float}, {'q', "BOOL NOTEQ", OPERAND_NONE,
-                                           h_neq}, {'r', "BOOL LT",
-                                                    OPERAND_NONE, h_lt}, {'s',
-                                                                          "SUBTRACT",
-                                                                          OPERAND_NONE,
-                                                                          h_sub},
-    {'t', "BOOL GT", OPERAND_NONE, h_gt}, {'u', "BOOL LTEQ", OPERAND_NONE,
-                                           h_lte}, {'v', "BOOL GTEQ",
-                                                    OPERAND_NONE, h_gte},
-    {'x', "LOGICAL NOT", OPERAND_NONE, h_not}, {'y', "LOGICAL AND",
-                                                OPERAND_NONE, h_and}, {'z',
-                                                                       "LOGICAL OR",
-                                                                       OPERAND_NONE,
-                                                                       h_or},
-    {'M', "LIBCALL TOKEN", OPERAND_U8, h_libcall_token}, {'B', "ITEM SAVE CODE",
-                                              OPERAND_BLOB_I16, h_emb}, {'C',
-                                                                         "SAVE ITEM",
-                                                                         OPERAND_NONE,
-                                                                         h_save_item},
-    {'F', "CALL/ITEM DEREF", OPERAND_U8, h_f}, {'I', "BEGIN ITEM",
-                                                OPERAND_NONE, h_I}, {'R', "BEGIN REL ITEM",
-                                                OPERAND_NONE, h_R}, {'W',
-                                                                     "DELETE ITEM",
-                                                                     OPERAND_NONE,
-                                                                     h_delete_item},
-    {'X', "ITEM EXISTS", OPERAND_NONE, h_item_exists}, {'Y', "NTHNAME",
-                                                        OPERAND_NONE,
-                                                        h_nthname}, {'Z',
-                                                                     "ROOTNAME",
-                                                                     OPERAND_NONE,
-                                                                     h_rootname},
-};
-
-static uint8_t *decode_opcode(uint8_t *p, uint8_t *end, decode_context_t c) {
-  if (!require_bytes(p, end, 1, "opcode")) return p;
-  uint8_t *start = p;
-  uint8_t op = *p++;
-  instruction_count++;
-  for (size_t i = 0; i < sizeof(OPCODES) / sizeof(OPCODES[0]); i++) {
-    if (OPCODES[i].opcode == op) {
-      p = OPCODES[i].handler(p, end, c);
-      print_raw(start, p);
-      if (opt_raw) outln("\n");
-      return p;
-    }
+static bool on_instruction(const BC_Instruction *inst, void *ctx) {
+  SDissState *state = ctx;
+  print_header_once(state);
+  if (inst->context == BC_EVENT_CONTEXT_STMT && inst->schema->op != IR_OP_HALT) {
+    state->instruction_count++;
   }
-  unknown_opcode_count++;
-  warning_count++;
-  outln("UNKNOWN OPCODE 0x%02X (%c)\n", op,
-        (op >= 32 && op <= 126) ? op : '.');
-  print_raw(start, p);
+  outln("Byte %05u: ", inst->offset == 0 ? 0 : inst->offset - 1);
+  print_operand_line(inst);
+  print_raw(inst);
   if (opt_raw) outln("\n");
-  return p;
+  return true;
 }
 
 int main(int argc, char **argv) {
-  FILE *in;
+  FILE *in = NULL;
   int filesize = 0;
-  uint8_t *opcodeptr;
   bytecode = NULL;
   if (argc < 2) {
     usage();
     exit(EXIT_FAILURE);
   }
   int opt;
-  const struct option options[] =
-    { {"help", no_argument, 0, 'h'},
+  const struct option options[] = {
+    {"help", no_argument, 0, 'h'},
     {"object", required_argument, 0, 'o'},
     {"raw", no_argument, 0, 1000},
     {"no-header", no_argument, 0, 1001},
@@ -442,32 +176,32 @@ int main(int argc, char **argv) {
   };
   while ((opt = getopt_long(argc, argv, "ho:", options, NULL)) != -1) {
     switch (opt) {
-    case 'h':
-      usage();
-      exit(EXIT_SUCCESS);
-    case 'o':
-      in = fopen(optarg, "rb");
-      if (!in) {
-        logerr("Unable to open input file: %s\n", optarg);
-        exit(EXIT_FAILURE);
-      }
-      fseek(in, 0, SEEK_END);
-      filesize = ftell(in);
-      fseek(in, 0, SEEK_SET);
-      bytecode = GROW_ARRAY(unsigned char, bytecode, 0, filesize);
-      fread(bytecode, filesize, sizeof(char), in);
-      fclose(in);
-      logmsg("Bytecode loaded: %d bytes.\n", filesize);
-      break;
-    case 1000:
-      opt_raw = 1;
-      break;
-    case 1001:
-      opt_no_header = 1;
-      break;
-    default:
-      usage();
-      return EXIT_FAILURE;
+      case 'h':
+        usage();
+        exit(EXIT_SUCCESS);
+      case 'o':
+        in = fopen(optarg, "rb");
+        if (!in) {
+          logerr("Unable to open input file: %s\n", optarg);
+          exit(EXIT_FAILURE);
+        }
+        fseek(in, 0, SEEK_END);
+        filesize = ftell(in);
+        fseek(in, 0, SEEK_SET);
+        bytecode = GROW_ARRAY(unsigned char, bytecode, 0, filesize);
+        fread(bytecode, filesize, sizeof(char), in);
+        fclose(in);
+        logmsg("Bytecode loaded: %d bytes.\n", filesize);
+        break;
+      case 1000:
+        opt_raw = 1;
+        break;
+      case 1001:
+        opt_no_header = 1;
+        break;
+      default:
+        usage();
+        return EXIT_FAILURE;
     }
   }
   if (!bytecode) {
@@ -475,34 +209,27 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
   logmsg("Beginning disassembly...\n");
-  opcodeptr = bytecode;
-  uint8_t *end = bytecode + filesize;
-  if (!require_bytes(opcodeptr, end, 2, "locals/params header")) {
-    FREE_ARRAY(unsigned char, bytecode, filesize);
-    exit(EXIT_FAILURE);
+
+  BC_VerifyOptions verify_options = bc_verify_disassembly_options();
+  BC_BytecodeMetadata metadata = {0};
+  SDissState state = {0};
+  state.metadata = &metadata;
+  BC_VerifyResult result = bc_decode_bytecode_events(bytecode, (uint32_t)filesize,
+                                                     "disassembly", &verify_options,
+                                                     &metadata, on_instruction, &state);
+  print_header_once(&state);
+
+  if (result.status == BC_VERIFY_ERROR) {
+    logerr("%s\n", result.diagnostic.message);
+    logerr("Disassembly aborted due to malformed bytecode.\n");
+  } else if (result.status == BC_VERIFY_WARNING) {
+    state.warning_count = (int)result.warning_count;
+    logerr("%s\n", result.diagnostic.message);
   }
-  uint8_t locals = *opcodeptr++;
-  uint8_t params = *opcodeptr++;
-  if (!opt_no_header && locals > 0) logmsg("Local variables: %d\n", locals);
-  else if (!opt_no_header) logmsg("No local variables.\n");
-  if (!opt_no_header
-      && params > 0) logmsg("(Of which, %d are parameters.)\n", locals);
-  else if (!opt_no_header) logmsg("(No parameters.)\n");
-  while (opcodeptr < end && *opcodeptr != 'h') {
-    outln("Byte %05u: ", opcodeptr - bytecode - 1);
-    opcodeptr = decode_opcode(opcodeptr, end, DECODE_STMT);
-    if (decode_failed) break;
-  }
-  if (decode_failed)
-      logerr("Disassembly aborted due to malformed bytecode.\n");
-  else if (opcodeptr >=
-           end)
-      logerr
-      ("Decode error: unterminated stream (missing HALT 'h' before EOF).\n");
-  else outln("Byte %05u: HALT\n", opcodeptr - bytecode - 1);
+
   outln("Summary: instructions=%d unknown=%d warnings=%d\n",
-        instruction_count, unknown_opcode_count, warning_count);
+        state.instruction_count, state.unknown_opcode_count, state.warning_count);
   logmsg("Shutting down.\n");
   FREE_ARRAY(unsigned char, bytecode, filesize);
-  return EXIT_SUCCESS;
+  return result.status == BC_VERIFY_ERROR ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
### Motivation
- Eliminate duplicated opcode table and operand/byte-parsing logic from `sdiss` by reusing the verifier/decoder implementation.
- Provide a decoder callback/iterator API so callers can receive rich decoded instruction events (operands, raw bytes, mnemonic, nested item-expression events) without duplicating parsing logic.
- Ensure disassembly prints the same information as before while using shared diagnostics for malformed bytecode and preserving `--raw`/`--no-header` behavior.

### Description
- Added a callback-driven decoder API `bc_decode_bytecode_events(...)` and `BC_Instruction`/`BC_Operand` structures to `src/bytecode_verify.h` to expose offset, opcode, mnemonic, decoded operand(s), raw byte span, context/depth and locals/params metadata.
- Implemented event emission in `src/bytecode_verify.c` via `bc_emit_event`, added canonical disassembly mnemonics, and extended the decoder to populate operand union values and nested item/deref event depth.
- Kept `bc_verify_bytecode()` as a compatibility wrapper that calls the new event API when callers do not supply a callback or metadata pointer.
- Rewrote `src/sdiss.c` to use the new shared decoder in disassembly mode (calling `bc_decode_bytecode_events`), print header from verifier metadata, format instruction output from `BC_Instruction` events, and preserve `--raw` and `--no-header` behavior while routing malformed bytecode messages through shared diagnostics.
- Removed duplicate local helpers and the local `OPCODES` table from `sdiss` and replaced in-binary operand parsing with values supplied by the shared decoder.

### Testing
- Built the disassembler with `make sdiss`, which completed successfully.
- Ran the updated disassembler against fixtures with `./sdiss --no-header -o tests/fixtures/sdiss/basic.bin` and `./sdiss --no-header -o tests/fixtures/sdiss/operand-widths.bin`, both producing expected disassembly output.
- Executed the full test suite via `make test`; all tests completed and reported PASS.
- Verified that malformed/truncated bytecode is reported via shared verifier diagnostics and that `--raw`/`--no-header` outputs remain supported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41785a567c832ea0f8c80c13d03bba)