### PR TITLE
Add verifier integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ TEST_CORE_SOURCES := \
 	$(TEST_DIR)/core/test_parser_float_literals.c \
 	$(TEST_DIR)/core/test_item_cache.c \
 	$(TEST_DIR)/core/test_itemstore_io.c \
+	$(TEST_DIR)/core/test_itemstore_verifier.c \
 	$(TEST_DIR)/core/test_libcall_registry.c \
 	$(TEST_DIR)/core/test_relative_item_leading_dot.c \
 	$(TEST_DIR)/core/test_value_behavior.c

--- a/tests/compiler/test_emitbc_invariants.c
+++ b/tests/compiler/test_emitbc_invariants.c
@@ -139,6 +139,41 @@ static void test_emitbc_determinism_fixed_seed(void) {
   ir_destroy_unit(b);
 }
 
+static void test_emitbc_successful_emission_verifies(void) {
+  IR_Unit *unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+  t_emit(unit, (IR_Inst){.op = IR_OP_PUSH_INT, .imm = 42});
+  t_emit(unit, (IR_Inst){.op = IR_OP_HALT});
+
+  OUTPUT_t out = make_out(16);
+  char *errdetail = NULL;
+  int8_t rc = t_emit_bytecode(unit, 0, 0, &out, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  ASSERT_TRUE(errdetail == NULL);
+  ASSERT_EQ_INT('h', out.bytecode[(out.nextbyte - out.bytecode) - 1]);
+
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+}
+
+static void test_emitbc_invalid_post_emit_bytecode_fails(void) {
+  IR_Unit *unit = t_new_unit();
+  ASSERT_NOT_NULL(unit);
+  t_emit(unit, (IR_Inst){.op = IR_OP_HALT});
+
+  OUTPUT_t out = make_out(16);
+  char *errdetail = NULL;
+  int8_t rc = t_emit_bytecode(unit, 0, 1, &out, &errdetail);
+  ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, "emitbc: bytecode verification failed") != NULL);
+  ASSERT_TRUE(strstr(errdetail, "parameter count exceeds local count") != NULL);
+
+  free(errdetail);
+  free(out.bytecode);
+  ir_destroy_unit(unit);
+}
+
 static void test_emitbc_label_heavy_jump_targets_in_bounds(void) {
   IR_Unit *u = t_new_unit();
   ASSERT_NOT_NULL(u);
@@ -195,4 +230,6 @@ void test_emitbc_invariants(void) {
   test_emitbc_op_class_invariants();
   test_emitbc_determinism_fixed_seed();
   test_emitbc_label_heavy_jump_targets_in_bounds();
+  test_emitbc_successful_emission_verifies();
+  test_emitbc_invalid_post_emit_bytecode_fails();
 }

--- a/tests/compiler/test_sdiss_fixtures.c
+++ b/tests/compiler/test_sdiss_fixtures.c
@@ -51,6 +51,36 @@ void test_sdiss_fixture_basic(void) {
   free(expected);
 }
 
+static void run_sdiss_fixture(const char *path, char *output, size_t output_size, int *exit_code) {
+  char cmd[512];
+  int rc = snprintf(cmd, sizeof(cmd), "./sdiss --no-header -o %s 2>&1", path);
+  ASSERT_TRUE(rc > 0 && (size_t)rc < sizeof(cmd));
+  FILE *pipe = popen(cmd, "r");
+  ASSERT_NOT_NULL(pipe);
+  size_t total = fread(output, 1, output_size - 1, pipe);
+  output[total] = '\0';
+  rc = pclose(pipe);
+  ASSERT_TRUE(rc != -1);
+  ASSERT_TRUE(WIFEXITED(rc));
+  *exit_code = WEXITSTATUS(rc);
+}
+
+void test_sdiss_malformed_fixture_reports_verifier_diagnostic(void) {
+  const uint8_t bytes[] = {0x00, 0x00, 'l', 0x03, 0x00, 'a'};
+  const char *tmp_path = "tests/fixtures/sdiss/malformed.bin";
+  FILE *out = fopen(tmp_path, "wb");
+  ASSERT_NOT_NULL(out);
+  ASSERT_EQ_INT((int)sizeof(bytes), (int)fwrite(bytes, 1, sizeof(bytes), out));
+  fclose(out);
+
+  char output[4096];
+  int exit_code = 0;
+  run_sdiss_fixture(tmp_path, output, sizeof(output), &exit_code);
+  ASSERT_EQ_INT(1, exit_code);
+  ASSERT_TRUE(strstr(output, "truncated") != NULL);
+  ASSERT_TRUE(strstr(output, "Disassembly aborted due to malformed bytecode") != NULL);
+}
+
 void test_sdiss_reads_compiler_operand_widths(void) {
   const uint8_t bytes[] = {
       0x00, 0x00, /* locals/params */
@@ -77,4 +107,9 @@ void test_sdiss_reads_compiler_operand_widths(void) {
   ASSERT_TRUE(strstr(output, "LIBCALL_TOKEN 9") != NULL);
   ASSERT_TRUE(strstr(output, "CALL ARGC 2") != NULL);
   ASSERT_TRUE(strstr(output, "unknown=0") != NULL);
+
+  char output2[4096];
+  int exit_code = 0;
+  run_sdiss_fixture("tests/fixtures/sdiss/operand-widths.bin", output2, sizeof(output2), &exit_code);
+  ASSERT_EQ_INT(0, exit_code);
 }

--- a/tests/core/test_itemstore_verifier.c
+++ b/tests/core/test_itemstore_verifier.c
@@ -1,0 +1,70 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "config.h"
+#include "item.h"
+#include "test_assert.h"
+
+extern CONFIG_t config;
+
+static void put_bytes(FILE *file, const void *bytes, size_t length) {
+  ASSERT_EQ_INT((long long)length, (long long)fwrite(bytes, 1, length, file));
+}
+
+static void put_u8(FILE *file, uint8_t value) { put_bytes(file, &value, sizeof(value)); }
+
+static void put_u16_le(FILE *file, uint16_t value) {
+  uint8_t bytes[] = {(uint8_t)value, (uint8_t)(value >> 8)};
+  put_bytes(file, bytes, sizeof(bytes));
+}
+
+static void put_u32_le(FILE *file, uint32_t value) {
+  uint8_t bytes[] = {(uint8_t)value, (uint8_t)(value >> 8),
+                     (uint8_t)(value >> 16), (uint8_t)(value >> 24)};
+  put_bytes(file, bytes, sizeof(bytes));
+}
+
+static void put_header(FILE *file) {
+  static const uint8_t magic[] = {'S', 'I', 'N', 'I', 'T', 'E', 'M', 0};
+  put_bytes(file, magic, sizeof(magic));
+  put_u16_le(file, 1);
+}
+
+static void put_record_prefix(FILE *file, const char *name, uint8_t item_tag) {
+  size_t length = strlen(name);
+  ASSERT_TRUE(length <= UINT8_MAX);
+  put_u8(file, (uint8_t)length);
+  put_bytes(file, name, length);
+  put_u8(file, item_tag);
+}
+
+void test_itemstore_verifier_rejects_malformed_code_item_bytecode(void) {
+  bool previous_strict_validation = config.strict_validation;
+  config.strict_validation = true;
+
+  char path[] = "/tmp/sin-itemstore-verifier-XXXXXX";
+  int fd = mkstemp(path);
+  ASSERT_TRUE(fd >= 0);
+  FILE *file = fdopen(fd, "wb");
+  ASSERT_NOT_NULL(file);
+
+  const uint8_t malformed[] = {0, 0, 'l', 3, 0, 'a'};
+  put_header(file);
+  put_record_prefix(file, "root", 1);
+  put_u8(file, 3); /* VALUE_nil */
+  put_u32_le(file, 1);
+  put_record_prefix(file, "badcode", 2);
+  put_u32_le(file, (uint32_t)sizeof(malformed));
+  put_bytes(file, malformed, sizeof(malformed));
+  put_u32_le(file, 0);
+  ASSERT_EQ_INT(0, fclose(file));
+
+  ITEM_t *loaded = load_itemstore(path);
+  ASSERT_TRUE(loaded == NULL);
+
+  ASSERT_EQ_INT(0, unlink(path));
+  config.strict_validation = previous_strict_validation;
+}

--- a/tests/interpreter/test_interpret_semantics_golden.c
+++ b/tests/interpreter/test_interpret_semantics_golden.c
@@ -6,7 +6,15 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include "config.h"
+#include "error.h"
+#include "interpret.h"
+#include "item.h"
 #include "test_assert.h"
+#include "value.h"
+#include "vm.h"
+
+extern CONFIG_t config;
 
 typedef struct {
   const char *name;
@@ -204,4 +212,37 @@ void test_interpret_semantics_golden(void) {
   for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
     run_case(&cases[i]);
   }
+}
+
+
+void test_interpret_rejects_malformed_bytecode_before_execution(void) {
+  memset(&config, 0, sizeof(config));
+  init_errmsg();
+  config.strict_validation = true;
+  config.itemroot = make_root_item("root");
+  ASSERT_NOT_NULL(config.itemroot);
+  config.vm = make_vm();
+  ASSERT_NOT_NULL(config.vm);
+
+  uint8_t bytecode[] = {0, 0, 'l', 3, 0, 'a'};
+  uint8_t *owned = malloc(sizeof(bytecode));
+  ASSERT_NOT_NULL(owned);
+  memcpy(owned, bytecode, sizeof(bytecode));
+  ITEM_t *code = insert_code_item(config.itemroot, "malformed", sizeof(bytecode), owned);
+  ASSERT_NOT_NULL(code);
+
+  VALUE_t result = interpret(code);
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  ITEM_t *err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(ERR_RUNTIME_BYTECODE, err->value.i);
+  ITEM_t *msg = find_item(config.itemroot, "error.msg");
+  ASSERT_NOT_NULL(msg);
+  ASSERT_EQ_INT(VALUE_str, msg->value.type);
+  ASSERT_TRUE(strstr(msg->value.s, "Runtime bytecode validation failed") != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "truncated") != NULL);
+
+  destroy_vm(config.vm);
+  destroy_item(config.itemroot);
+  memset(&config, 0, sizeof(config));
 }

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -80,6 +80,7 @@ void test_load_itemstore_rejects_resource_limit_violations(void);
 void test_save_itemstore_preserves_existing_file_on_failure(void);
 void test_itemstore_durability_modes(void);
 void test_itemstore_large_load_presizes_child_storage(void);
+void test_itemstore_verifier_rejects_malformed_code_item_bytecode(void);
 void test_libcall_registry_roundtrip(void);
 void test_libcall_registry_init_failure_has_no_partial_state(void);
 void test_libcall_registry_lifecycle_reinit_sequence(void);
@@ -147,12 +148,14 @@ void test_pipeline_negative_matrix(void);
 void test_parser_examples_obj_golden(void);
 void test_sdiss_fixture_basic(void);
 void test_sdiss_reads_compiler_operand_widths(void);
+void test_sdiss_malformed_fixture_reports_verifier_diagnostic(void);
 void test_compiler_context_failures(void);
 void test_compiler_diag_pipeline(void);
 void test_sys_compile_libcall_runtime(void);
 
 /* Runtime component tests. */
 void test_interpret_semantics_golden(void);
+void test_interpret_rejects_malformed_bytecode_before_execution(void);
 void test_interpret_stress(void);
 void test_runtime_benchmark_optin(void);
 
@@ -204,6 +207,7 @@ static const test_case_t core_tests[] = {
     {"test_save_itemstore_preserves_existing_file_on_failure", test_save_itemstore_preserves_existing_file_on_failure},
     {"test_itemstore_durability_modes", test_itemstore_durability_modes},
     {"test_itemstore_large_load_presizes_child_storage", test_itemstore_large_load_presizes_child_storage},
+    {"test_itemstore_verifier_rejects_malformed_code_item_bytecode", test_itemstore_verifier_rejects_malformed_code_item_bytecode},
     {"test_relative_item_leading_dot_parse_accepts_deref_chain", test_relative_item_leading_dot_parse_accepts_deref_chain},
     {"test_relative_item_leading_dot_nested_relative_deref_layers", test_relative_item_leading_dot_nested_relative_deref_layers},
     {"test_relative_item_leading_dot_nested_deref_nil_or_empty_leading_allowed", test_relative_item_leading_dot_nested_deref_nil_or_empty_leading_allowed},
@@ -259,6 +263,7 @@ static const test_case_t compiler_tests[] = {
     {"test_pipeline_negative_matrix", test_pipeline_negative_matrix},
     {"test_parser_examples_obj_golden", test_parser_examples_obj_golden},
     {"test_sdiss_fixture_basic", test_sdiss_fixture_basic},
+    {"test_sdiss_malformed_fixture_reports_verifier_diagnostic", test_sdiss_malformed_fixture_reports_verifier_diagnostic},
     {"test_sdiss_reads_compiler_operand_widths", test_sdiss_reads_compiler_operand_widths},
     {"test_compiler_context_failures", test_compiler_context_failures},
     {"test_compiler_diag_pipeline", test_compiler_diag_pipeline},
@@ -266,6 +271,7 @@ static const test_case_t compiler_tests[] = {
 
 static const test_case_t runtime_tests[] = {
     {"test_interpret_semantics_golden", test_interpret_semantics_golden},
+    {"test_interpret_rejects_malformed_bytecode_before_execution", test_interpret_rejects_malformed_bytecode_before_execution},
     {"test_interpret_stress", test_interpret_stress},
     {"test_libcall_registry_roundtrip", test_libcall_registry_roundtrip},
     {"test_libcall_registry_init_failure_has_no_partial_state", test_libcall_registry_init_failure_has_no_partial_state},


### PR DESCRIPTION
### Motivation
- Ensure the bytecode verifier is exercised end-to-end across emit-time, disassembly, runtime interpretation, and itemstore loading paths.
- Catch regressions where verification failures could be missed or cause unsafe execution (e.g., reading past bounds at runtime).

### Description
- Added compiler-level tests in `tests/compiler/test_emitbc_invariants.c` that assert successful emission triggers verifier checks and that an intentionally invalid post-emit bytecode path returns a verification failure (new functions `test_emitbc_successful_emission_verifies` and `test_emitbc_invalid_post_emit_bytecode_fails`).
- Extended `tests/compiler/test_sdiss_fixtures.c` with `test_sdiss_malformed_fixture_reports_verifier_diagnostic` and a helper `run_sdiss_fixture()` to assert `sdiss` reports verifier diagnostics for malformed fixtures while keeping existing valid fixture checks.
- Added a runtime test `test_interpret_rejects_malformed_bytecode_before_execution` to `tests/interpreter/test_interpret_semantics_golden.c` that constructs a malformed code item and verifies `interpret()` returns `nil` and sets the `error`/`error.msg` items instead of executing past bounds.
- Added a new itemstore-focused test `tests/core/test_itemstore_verifier.c` which writes a malformed itemstore fixture and asserts `load_itemstore()` rejects it when `strict_validation` is enabled, and updated `Makefile` and `tests/shared/test_compiler.c` to register the new tests in the harness.

### Testing
- Ran the full test harness with `make test` and all suites completed successfully as shown by the harness: `status=PASS` and `tests=120/120`.
- The new tests exercise: `emitbc` post-emission verification failure, `sdiss` malformed fixture diagnostics, `interpret()` handling of malformed bytecode, and `load_itemstore()` rejection of malformed code item bytecode; all passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a417c41fe94832e84ab98c10f43fc8c)