### PR TITLE
Add sanitizer build mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,20 @@ CC = gcc
 CFLAGS = -g -Wall -MMD -MP -Isrc -Isrc/compiler
 LDFLAGS = -g
 LIBS = -luv
+
+SANITIZE ?= 0
+STRICT_WARNINGS ?= 0
+SANITIZE_FLAGS := -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined
+STRICT_WARNING_FLAGS := -Werror
+
+ifeq ($(SANITIZE),1)
+CFLAGS += $(SANITIZE_FLAGS)
+LDFLAGS += $(SANITIZE_FLAGS)
+endif
+
+ifeq ($(STRICT_WARNINGS),1)
+CFLAGS += $(STRICT_WARNING_FLAGS)
+endif
 YACC = bison
 LEX = flex
 DEBUG = -DDEBUG=1 #-DSTRINGDEBUG=1 -DDISASS=1
@@ -92,7 +106,7 @@ $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	@mkdir -p $(@D)
 	$(CC) -c $(CFLAGS) $(DEBUG) $< -o $@
 
-.PHONY: all clean lib test teststrict
+.PHONY: all clean lib test teststrict test-sanitize
 
 all: $(LIB) scomp sdiss sin
 
@@ -134,9 +148,13 @@ test: $(TEST_BIN)
 teststrict: $(TEST_BIN)
 	SIN_STRICT_BENCH=1 ./$(TEST_BIN)
 
+test-sanitize:
+	$(MAKE) clean
+	$(MAKE) SANITIZE=1 STRICT_WARNINGS=1 test
+
 $(TEST_BIN): $(TEST_SOURCES) $(LIB) scomp sdiss sin
 	$(CC) $(CFLAGS) $(DEBUG) -Isrc -I$(TEST_DIR) -o $@ $(TEST_SOURCES) $(LIB) $(LDFLAGS) $(LIBS)
 
 clean:
-	rm -rf $(OBJ_DIR)/*.o $(OBJ_DIR)/*.d $(LIB) $(LIB_DIR) \
+	rm -rf $(OBJ_DIR) $(LIB) $(LIB_DIR) \
          $(PARSER_GENERATED) $(LEXER_GENERATED) $(TEST_BIN)


### PR DESCRIPTION
### Motivation
- Provide an opt-in sanitizer build mode for debugging memory/UB issues while keeping the default developer build unchanged. 
- Allow running the full test suite with AddressSanitizer/UndefinedBehaviorSanitizer and stricter warnings in a single convenient target. 

### Description
- Add Makefile variables `SANITIZE ?= 0` and `STRICT_WARNINGS ?= 0` and derived flag variables `SANITIZE_FLAGS` and `STRICT_WARNING_FLAGS`. 
- When `SANITIZE=1`, append `-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined` to both `CFLAGS` and `LDFLAGS`, and when `STRICT_WARNINGS=1` append `-Werror` to `CFLAGS`. 
- Ensure the shared `CFLAGS`/`LDFLAGS` flow covers object compilation, parser/lexer object rules, final links for `scomp`, `sdiss`, `sin`, and `tests/test-compiler`. 
- Add a phony `test-sanitize` target that runs `$(MAKE) clean` and then `$(MAKE) SANITIZE=1 STRICT_WARNINGS=1 test`, and update `clean` to remove the full `obj` directory so sanitizer builds cannot reuse stale nested objects. 

### Testing
- Ran `make test`, which builds and executes the test runner and completed successfully (test harness summary: status=PASS, tests=121/121). 
- Ran `make test-sanitize`, which performs a clean sanitizer build and executes the same test suite under sanitizers and strict warnings, and it completed successfully (test harness summary: status=PASS, tests=121/121).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4206cb00f4832e85f19b625af71514)