### PR TITLE
Add opt-in strict warning build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,16 @@ Run `make teststrict` when you also want the benchmark budget checks enforced. T
 
 The harness prints the selected mode and a final summary with per-suite and total test counts, so the output should identify whether strict benchmark checks were enabled regardless of which make target launched it.
 
+### Strict warning builds
+
+Strict compiler warnings are opt-in for local development and CI gates that want warnings to fail the build. Run:
+
+```bash
+make STRICT_WARNINGS=1 test
+```
+
+The `test-sanitize` target also enables strict warnings automatically, so sanitizer runs use the same warning gate in addition to address/undefined-behavior sanitizers.
+
 ## Core language gate
 
 Run this gate when changing any code in the compiler or interpreter paths:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ LIBS = -luv
 SANITIZE ?= 0
 STRICT_WARNINGS ?= 0
 SANITIZE_FLAGS := -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined
-STRICT_WARNING_FLAGS := -Werror
+STRICT_WARNING_FLAGS := -Wextra -Wpedantic -Werror -Wshadow -Wformat=2 \
+	-Wno-error=unused-parameter -Wno-error=sign-compare \
+	-Wno-error=implicit-fallthrough -Wno-error=missing-field-initializers \
+	-Wno-error=pedantic -Wno-error=shadow -Wno-error=type-limits -Wno-error=format-nonliteral
+GENERATED_WARNING_FLAGS :=
 
 ifeq ($(SANITIZE),1)
 CFLAGS += $(SANITIZE_FLAGS)
@@ -15,6 +19,7 @@ endif
 
 ifeq ($(STRICT_WARNINGS),1)
 CFLAGS += $(STRICT_WARNING_FLAGS)
+GENERATED_WARNING_FLAGS += -Wno-error=format -Wno-error=format-nonliteral
 endif
 YACC = bison
 LEX = flex
@@ -134,10 +139,10 @@ $(LEXER_GENERATED): $(LEXER_SOURCES) $(PARSER_GENERATED)
 # Make sure parser.o and lexer.o dependences are tracked
 $(OBJ_DIR)/parser.o: $(SRC_DIR)/parser.c $(SRC_DIR)/parser.h
 	@mkdir -p $(@D)
-	$(CC) -c $(CFLAGS) $(DEBUG) $< -o $@
+	$(CC) -c $(CFLAGS) $(GENERATED_WARNING_FLAGS) $(DEBUG) $< -o $@
 $(OBJ_DIR)/lexer.o: $(SRC_DIR)/lexer.c
 	@mkdir -p $(@D)
-	$(CC) -c $(CFLAGS) $(DEBUG) $< -o $@
+	$(CC) -c $(CFLAGS) $(GENERATED_WARNING_FLAGS) $(DEBUG) $< -o $@
 
 # Include dependency files
 -include $(DEPS)


### PR DESCRIPTION
### Motivation

- Provide an opt-in strict-warning mode so developers and CI can treat warnings as failures to improve code quality.
- Enable sanitizer runs to use the same warning gate so address/UB sanitizer builds and strict warnings are consistent.

### Description

- Add `STRICT_WARNINGS ?= 0` and a `STRICT_WARNING_FLAGS` set with `-Wextra -Wpedantic -Werror -Wshadow -Wformat=2` and selective `-Wno-error=` exceptions to avoid failing the current warning debt.
- Introduce `GENERATED_WARNING_FLAGS` and apply it when compiling generated files so parser/lexer-generated diagnostics for format/other unavoidable issues are demoted instead of weakening strict flags globally.
- Update parser/lexer object build rules to include `$(GENERATED_WARNING_FLAGS)` when `STRICT_WARNINGS=1` is enabled.
- Document the accepted strict-warning command in `CONTRIBUTING.md` and ensure `test-sanitize` invokes strict warnings by calling `make SANITIZE=1 STRICT_WARNINGS=1 test`.

### Testing

- Ran `make clean && make STRICT_WARNINGS=1 test`, which completed and the test harness reported success (automated tests passed).
- Ran `make test-sanitize` (which enables `STRICT_WARNINGS=1` with sanitizers), which completed successfully (automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a426dafc33c832e906fcb54d482c857)