### PR TITLE
Add sdiss bytecode disassembly fuzz target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ FUZZ_CC ?= clang
 FUZZ_DIR := $(TEST_DIR)/fuzz
 FUZZ_BIN := $(FUZZ_DIR)/fuzz_scomp
 FUZZ_CORPUS_DIR := $(FUZZ_DIR)/corpus/scomp
+FUZZ_SDISS_BIN := $(FUZZ_DIR)/fuzz_sdiss
+FUZZ_SDISS_CORPUS_DIR := $(FUZZ_DIR)/corpus/sdiss
 FUZZ_SANITIZE_FLAGS := -fsanitize=fuzzer-no-link,address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined
 FUZZ_LINK_FLAGS := -fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined
 TEST_SHARED_SOURCES := \
@@ -81,7 +83,7 @@ TEST_SOURCES := $(TEST_SHARED_SOURCES) $(TEST_CORE_SOURCES) $(TEST_COMPILER_SOUR
 
 # Library of shared functions
 LIB := $(LIB_DIR)/libsinshared.a
-LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o $(OBJ_DIR)/bytecode_verify.o $(OBJ_DIR)/floatconv.o $(OBJ_DIR)/parser.o \
+LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o $(OBJ_DIR)/bytecode_verify.o $(OBJ_DIR)/sdiss_core.o $(OBJ_DIR)/floatconv.o $(OBJ_DIR)/parser.o \
                $(OBJ_DIR)/lexer.o $(OBJ_DIR)/compiler/absyn.o $(OBJ_DIR)/compiler/semant.o \
                $(OBJ_DIR)/compiler/ir.o $(OBJ_DIR)/compiler/lower.o $(OBJ_DIR)/compiler/compiler_context.o $(OBJ_DIR)/compiler/compiler_pipeline.o $(OBJ_DIR)/compiler/emitbc.o \
                $(OBJ_DIR)/compiler/compdiag.o $(OBJ_DIR)/error.o $(OBJ_DIR)/util.o $(OBJ_DIR)/libcall.o \
@@ -117,7 +119,7 @@ $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	@mkdir -p $(@D)
 	$(CC) -c $(CFLAGS) $(DEBUG) $< -o $@
 
-.PHONY: all clean lib test teststrict test-asan test-lsan fuzz-scomp
+.PHONY: all clean lib test teststrict test-asan test-lsan fuzz-scomp fuzz-sdiss seed-fuzz-sdiss-corpus
 
 all: $(LIB) scomp sdiss sin
 
@@ -177,11 +179,30 @@ $(OBJ_DIR)/tests/fuzz/%.o : $(FUZZ_DIR)/%.c $(PARSER_GENERATED)
 $(FUZZ_BIN): $(OBJ_DIR)/tests/fuzz/fuzz_scomp.o $(LIB)
 	$(CC) -o $@ $^ $(FUZZ_LINK_FLAGS) $(LIBS)
 
+$(FUZZ_SDISS_BIN): $(OBJ_DIR)/tests/fuzz/fuzz_sdiss.o $(LIB)
+	$(CC) -o $@ $^ $(FUZZ_LINK_FLAGS) $(LIBS)
+
+seed-fuzz-sdiss-corpus:
+	@mkdir -p $(FUZZ_SDISS_CORPUS_DIR)
+	@if command -v xxd >/dev/null 2>&1; then \
+		for hex in $(TEST_DIR)/fixtures/sdiss/*.hex; do \
+			[ -e "$$hex" ] || continue; \
+			xxd -r -p "$$hex" "$(FUZZ_SDISS_CORPUS_DIR)/$$(basename "$$hex" .hex).obj"; \
+		done; \
+	else \
+		printf 'xxd not found; skipping sdiss fixture corpus seeding\n'; \
+	fi
+
 fuzz-scomp:
 	$(MAKE) clean
 	$(MAKE) CC=$(FUZZ_CC) CFLAGS="$(CFLAGS) $(FUZZ_SANITIZE_FLAGS)" LDFLAGS="$(LDFLAGS) $(FUZZ_SANITIZE_FLAGS)" $(FUZZ_BIN)
 	@printf 'Built %s. Run with: %s %s\n' "$(FUZZ_BIN)" "$(FUZZ_BIN)" "$(FUZZ_CORPUS_DIR)"
 
+fuzz-sdiss: seed-fuzz-sdiss-corpus
+	$(MAKE) clean
+	$(MAKE) CC=$(FUZZ_CC) CFLAGS="$(CFLAGS) $(FUZZ_SANITIZE_FLAGS)" LDFLAGS="$(LDFLAGS) $(FUZZ_SANITIZE_FLAGS)" seed-fuzz-sdiss-corpus $(FUZZ_SDISS_BIN)
+	@printf 'Built %s. Run with: %s %s\n' "$(FUZZ_SDISS_BIN)" "$(FUZZ_SDISS_BIN)" "$(FUZZ_SDISS_CORPUS_DIR)"
+
 clean:
 	rm -rf $(OBJ_DIR) $(LIB) $(LIB_DIR) \
-         $(PARSER_GENERATED) $(LEXER_GENERATED) $(TEST_BIN) $(FUZZ_BIN)
+         $(PARSER_GENERATED) $(LEXER_GENERATED) $(TEST_BIN) $(FUZZ_BIN) $(FUZZ_SDISS_BIN)

--- a/src/sdiss.c
+++ b/src/sdiss.c
@@ -3,58 +3,20 @@
 // Licensed under the MIT License - see LICENSE file for details.
 
 #include <getopt.h>
-#include <math.h>
-#include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
-#include "bytecode_verify.h"
 #include "config.h"
-#include "floatconv.h"
 #include "log.h"
 #include "memory.h"
+#include "sdiss_core.h"
 #include "version.h"
 
 CONFIG_t config;
 
 static uint8_t *bytecode;
 static int opt_raw = 0, opt_no_header = 0;
-
-typedef struct {
-  BC_BytecodeMetadata *metadata;
-  int header_printed;
-  int instruction_count;
-  int unknown_opcode_count;
-  int warning_count;
-} SDissState;
-
-static void outln(const char *fmt, ...) {
-  va_list args;
-  va_start(args, fmt);
-  vprintf(fmt, args);
-  va_end(args);
-}
-
-static void print_raw(const BC_Instruction *inst) {
-  if (!opt_raw) return;
-  outln(" [raw:");
-  for (uint32_t i = 0; i < inst->raw_len; i++) outln(" %02X", inst->raw[i]);
-  outln("]");
-}
-
-static void print_escaped_bytes(const uint8_t *data, size_t len) {
-  for (size_t i = 0; i < len; i++) {
-    uint8_t c = data[i];
-    if (c == '\n') outln("\\n");
-    else if (c == '\r') outln("\\r");
-    else if (c == '\t') outln("\\t");
-    else if (c == '\\') outln("\\\\");
-    else if (c >= 32 && c <= 126) outln("%c", c);
-    else outln("\\x%02X", c);
-  }
-}
 
 void usage() {
   logmsg("Sinistra disassembler version %s.\nSyntax: sdiss <options>\n", SINVERSION);
@@ -65,97 +27,9 @@ void usage() {
   logmsg("     --no-header\tSkip locals/params header output.\n");
 }
 
-static void print_operand_line(const BC_Instruction *inst) {
-  switch (inst->schema->op) {
-    case IR_OP_PUSH_INT: {
-      int64_t v;
-      memcpy(&v, &inst->operand.value.u64, sizeof(v));
-      outln("INTEGER %ld\n", (long)v);
-      break;
-    }
-    case IR_OP_PUSH_FLOAT: {
-      double value;
-      uint64_t bits = inst->operand.value.u64;
-      memcpy(&value, &bits, sizeof(value));
-      const char *class_name = "finite";
-      if (isnan(value)) class_name = "nan";
-      else if (isinf(value)) class_name = signbit(value) ? "-inf" : "+inf";
-      else if (value == 0.0) class_name = signbit(value) ? "-0.0" : "+0.0";
-      char fbuffer[64];
-      if (!sin_format_binary64_buf(value, fbuffer, sizeof(fbuffer))) {
-        snprintf(fbuffer, sizeof(fbuffer), "<float-format-error>");
-      }
-      outln("FLOAT %s (%s bits=0x%016llx)\n", fbuffer, class_name,
-            (unsigned long long)bits);
-      break;
-    }
-    case IR_OP_PUSH_BOOL:
-      outln("BOOLEAN %u\n", (unsigned int)(inst->operand.value.u8 ? 1 : 0));
-      break;
-    case IR_OP_PUSH_STRING:
-      outln("STRINGLIT: ");
-      print_escaped_bytes(inst->operand.value.bytes.data, inst->operand.value.bytes.len);
-      outln("\n");
-      break;
-    case IR_OP_LOAD_LOCAL:
-    case IR_OP_STORE_LOCAL:
-    case IR_OP_INC_LOCAL:
-    case IR_OP_DEC_LOCAL:
-      outln("%s %u\n", inst->mnemonic, (unsigned int)inst->operand.value.u8);
-      break;
-    case IR_OP_LIBCALL_TOKEN:
-      outln("LIBCALL_TOKEN %u\n", (unsigned int)inst->operand.value.u8);
-      break;
-    case IR_OP_CALL:
-      outln("CALL ARGC %u\n", (unsigned int)inst->operand.value.u16);
-      break;
-    case IR_OP_JUMP:
-    case IR_OP_JUMP_IF_FALSE: {
-      int16_t off = inst->operand.value.i16;
-      outln("%s rel=%d abs=%u\n", inst->mnemonic, off,
-            (unsigned int)(inst->operand.offset + 2 + off));
-      break;
-    }
-    case IR_OP_ITEM_PUSH_LAYER:
-      outln("LAYER: ");
-      print_escaped_bytes(inst->operand.value.bytes.data, inst->operand.value.bytes.len);
-      outln("\n");
-      break;
-    case IR_OP_ITEM_PUSH_DEREF_LOCAL:
-      outln("LOCALVAR %u\n", (unsigned int)inst->operand.value.u8);
-      break;
-    case IR_OP_ITEM_SAVE_CODE:
-      outln("EMBEDDED CODE (%u bytes):\n", (unsigned int)inst->operand.value.bytes.len);
-      print_escaped_bytes(inst->operand.value.bytes.data, inst->operand.value.bytes.len);
-      outln("\n");
-      break;
-    default:
-      outln("%s\n", inst->mnemonic);
-      break;
-  }
-}
-
-static void print_header_once(SDissState *state) {
-  if (state->header_printed) return;
-  state->header_printed = 1;
-  if (opt_no_header || !state->metadata) return;
-  if (state->metadata->locals > 0) logmsg("Local variables: %d\n", state->metadata->locals);
-  else logmsg("No local variables.\n");
-  if (state->metadata->params > 0) logmsg("(Of which, %d are parameters.)\n", state->metadata->params);
-  else logmsg("(No parameters.)\n");
-}
-
-static bool on_instruction(const BC_Instruction *inst, void *ctx) {
-  SDissState *state = ctx;
-  print_header_once(state);
-  if (inst->context == BC_EVENT_CONTEXT_STMT && inst->schema->op != IR_OP_HALT) {
-    state->instruction_count++;
-  }
-  outln("Byte %05u: ", inst->offset == 0 ? 0 : inst->offset - 1);
-  print_operand_line(inst);
-  print_raw(inst);
-  if (opt_raw) outln("\n");
-  return true;
+static void stdout_write(void *ctx, const char *data, size_t len) {
+  (void)ctx;
+  fwrite(data, 1, len, stdout);
 }
 
 int main(int argc, char **argv) {
@@ -210,25 +84,17 @@ int main(int argc, char **argv) {
   }
   logmsg("Beginning disassembly...\n");
 
-  BC_VerifyOptions verify_options = bc_verify_disassembly_options();
-  BC_BytecodeMetadata metadata = {0};
-  SDissState state = {0};
-  state.metadata = &metadata;
-  BC_VerifyResult result = bc_decode_bytecode_events(bytecode, (uint32_t)filesize,
-                                                     "disassembly", &verify_options,
-                                                     &metadata, on_instruction, &state);
-  print_header_once(&state);
+  SDissOptions dis_options = {.raw = opt_raw, .no_header = opt_no_header};
+  SDissResult result = sdiss_disassemble_bytes(bytecode, (uint32_t)filesize,
+                                               &dis_options, stdout_write, NULL);
 
   if (result.status == BC_VERIFY_ERROR) {
     logerr("%s\n", result.diagnostic.message);
     logerr("Disassembly aborted due to malformed bytecode.\n");
   } else if (result.status == BC_VERIFY_WARNING) {
-    state.warning_count = (int)result.warning_count;
     logerr("%s\n", result.diagnostic.message);
   }
 
-  outln("Summary: instructions=%d unknown=%d warnings=%d\n",
-        state.instruction_count, state.unknown_opcode_count, state.warning_count);
   logmsg("Shutting down.\n");
   FREE_ARRAY(unsigned char, bytecode, filesize);
   return result.status == BC_VERIFY_ERROR ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/src/sdiss_core.c
+++ b/src/sdiss_core.c
@@ -1,0 +1,179 @@
+// Shared sdiss bytecode disassembly helpers.
+//
+// Licensed under the MIT License - see LICENSE file for details.
+
+#include "sdiss_core.h"
+
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "floatconv.h"
+
+typedef struct {
+  BC_BytecodeMetadata *metadata;
+  SDissResult *result;
+  SDissOptions options;
+  SDissWriteFn write_fn;
+  void *write_ctx;
+  int header_printed;
+} SDissState;
+
+static void write_bytes(SDissState *state, const char *data, size_t len) {
+  if (state->write_fn) state->write_fn(state->write_ctx, data, len);
+}
+
+static void outln(SDissState *state, const char *fmt, ...) {
+  char buffer[512];
+  va_list args;
+  va_start(args, fmt);
+  int len = vsnprintf(buffer, sizeof(buffer), fmt, args);
+  va_end(args);
+  if (len <= 0) return;
+  if ((size_t)len < sizeof(buffer)) {
+    write_bytes(state, buffer, (size_t)len);
+    return;
+  }
+  write_bytes(state, buffer, sizeof(buffer) - 1);
+}
+
+static void print_raw(SDissState *state, const BC_Instruction *inst) {
+  if (!state->options.raw) return;
+  outln(state, " [raw:");
+  for (uint32_t i = 0; i < inst->raw_len; i++) outln(state, " %02X", inst->raw[i]);
+  outln(state, "]");
+}
+
+static void print_escaped_bytes(SDissState *state, const uint8_t *data, size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    uint8_t c = data[i];
+    if (c == '\n') outln(state, "\\n");
+    else if (c == '\r') outln(state, "\\r");
+    else if (c == '\t') outln(state, "\\t");
+    else if (c == '\\') outln(state, "\\\\");
+    else if (c >= 32 && c <= 126) outln(state, "%c", c);
+    else outln(state, "\\x%02X", c);
+  }
+}
+
+static void print_operand_line(SDissState *state, const BC_Instruction *inst) {
+  switch (inst->schema->op) {
+    case IR_OP_PUSH_INT: {
+      int64_t v;
+      memcpy(&v, &inst->operand.value.u64, sizeof(v));
+      outln(state, "INTEGER %ld\n", (long)v);
+      break;
+    }
+    case IR_OP_PUSH_FLOAT: {
+      double value;
+      uint64_t bits = inst->operand.value.u64;
+      memcpy(&value, &bits, sizeof(value));
+      const char *class_name = "finite";
+      if (isnan(value)) class_name = "nan";
+      else if (isinf(value)) class_name = signbit(value) ? "-inf" : "+inf";
+      else if (value == 0.0) class_name = signbit(value) ? "-0.0" : "+0.0";
+      char fbuffer[64];
+      if (!sin_format_binary64_buf(value, fbuffer, sizeof(fbuffer))) {
+        snprintf(fbuffer, sizeof(fbuffer), "<float-format-error>");
+      }
+      outln(state, "FLOAT %s (%s bits=0x%016llx)\n", fbuffer, class_name,
+            (unsigned long long)bits);
+      break;
+    }
+    case IR_OP_PUSH_BOOL:
+      outln(state, "BOOLEAN %u\n", (unsigned int)(inst->operand.value.u8 ? 1 : 0));
+      break;
+    case IR_OP_PUSH_STRING:
+      outln(state, "STRINGLIT: ");
+      print_escaped_bytes(state, inst->operand.value.bytes.data, inst->operand.value.bytes.len);
+      outln(state, "\n");
+      break;
+    case IR_OP_LOAD_LOCAL:
+    case IR_OP_STORE_LOCAL:
+    case IR_OP_INC_LOCAL:
+    case IR_OP_DEC_LOCAL:
+      outln(state, "%s %u\n", inst->mnemonic, (unsigned int)inst->operand.value.u8);
+      break;
+    case IR_OP_LIBCALL_TOKEN:
+      outln(state, "LIBCALL_TOKEN %u\n", (unsigned int)inst->operand.value.u8);
+      break;
+    case IR_OP_CALL:
+      outln(state, "CALL ARGC %u\n", (unsigned int)inst->operand.value.u16);
+      break;
+    case IR_OP_JUMP:
+    case IR_OP_JUMP_IF_FALSE: {
+      int16_t off = inst->operand.value.i16;
+      outln(state, "%s rel=%d abs=%u\n", inst->mnemonic, off,
+            (unsigned int)(inst->operand.offset + 2 + off));
+      break;
+    }
+    case IR_OP_ITEM_PUSH_LAYER:
+      outln(state, "LAYER: ");
+      print_escaped_bytes(state, inst->operand.value.bytes.data, inst->operand.value.bytes.len);
+      outln(state, "\n");
+      break;
+    case IR_OP_ITEM_PUSH_DEREF_LOCAL:
+      outln(state, "LOCALVAR %u\n", (unsigned int)inst->operand.value.u8);
+      break;
+    case IR_OP_ITEM_SAVE_CODE:
+      outln(state, "EMBEDDED CODE (%u bytes):\n", (unsigned int)inst->operand.value.bytes.len);
+      print_escaped_bytes(state, inst->operand.value.bytes.data, inst->operand.value.bytes.len);
+      outln(state, "\n");
+      break;
+    default:
+      outln(state, "%s\n", inst->mnemonic);
+      break;
+  }
+}
+
+static void print_header_once(SDissState *state) {
+  if (state->header_printed) return;
+  state->header_printed = 1;
+  if (state->options.no_header || !state->metadata) return;
+  if (state->metadata->locals > 0) outln(state, "Local variables: %d\n", state->metadata->locals);
+  else outln(state, "No local variables.\n");
+  if (state->metadata->params > 0) outln(state, "(Of which, %d are parameters.)\n", state->metadata->params);
+  else outln(state, "(No parameters.)\n");
+}
+
+static bool on_instruction(const BC_Instruction *inst, void *ctx) {
+  SDissState *state = ctx;
+  print_header_once(state);
+  if (inst->context == BC_EVENT_CONTEXT_STMT && inst->schema->op != IR_OP_HALT) {
+    state->result->instruction_count++;
+  }
+  outln(state, "Byte %05u: ", inst->offset == 0 ? 0 : inst->offset - 1);
+  print_operand_line(state, inst);
+  print_raw(state, inst);
+  if (state->options.raw) outln(state, "\n");
+  return true;
+}
+
+SDissResult sdiss_disassemble_bytes(const uint8_t *bytecode,
+                                    uint32_t bytecode_len,
+                                    const SDissOptions *options,
+                                    SDissWriteFn write_fn,
+                                    void *write_ctx) {
+  SDissResult sdiss_result = {0};
+  BC_VerifyOptions verify_options = bc_verify_disassembly_options();
+  BC_BytecodeMetadata metadata = {0};
+  SDissState state = {0};
+  state.metadata = &metadata;
+  state.result = &sdiss_result;
+  if (options) state.options = *options;
+  state.write_fn = write_fn;
+  state.write_ctx = write_ctx;
+
+  BC_VerifyResult result = bc_decode_bytecode_events(bytecode, bytecode_len,
+                                                     "disassembly", &verify_options,
+                                                     &metadata, on_instruction, &state);
+  print_header_once(&state);
+  sdiss_result.status = result.status;
+  sdiss_result.diagnostic = result.diagnostic;
+  if (result.status == BC_VERIFY_WARNING) sdiss_result.warning_count = (int)result.warning_count;
+  outln(&state, "Summary: instructions=%d unknown=%d warnings=%d\n",
+        sdiss_result.instruction_count, sdiss_result.unknown_opcode_count,
+        sdiss_result.warning_count);
+  return sdiss_result;
+}

--- a/src/sdiss_core.h
+++ b/src/sdiss_core.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "bytecode_verify.h"
+
+typedef struct {
+  int raw;
+  int no_header;
+} SDissOptions;
+
+typedef void (*SDissWriteFn)(void *ctx, const char *data, size_t len);
+
+typedef struct {
+  BC_VerifyStatus status;
+  BC_VerifyError diagnostic;
+  int instruction_count;
+  int unknown_opcode_count;
+  int warning_count;
+} SDissResult;
+
+SDissResult sdiss_disassemble_bytes(const uint8_t *bytecode,
+                                    uint32_t bytecode_len,
+                                    const SDissOptions *options,
+                                    SDissWriteFn write_fn,
+                                    void *write_ctx);

--- a/tests/fuzz/fuzz_sdiss.c
+++ b/tests/fuzz/fuzz_sdiss.c
@@ -1,0 +1,37 @@
+// libFuzzer target for the sdiss bytecode verification and disassembly path.
+//
+// Licensed under the MIT License - see LICENSE file for details.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "config.h"
+#include "error.h"
+#include "sdiss_core.h"
+
+CONFIG_t config;
+
+static const size_t kMaxFuzzBytecodeSize = 64 * 1024;
+
+static void discard_output(void *ctx, const char *data, size_t len) {
+  (void)ctx;
+  (void)data;
+  (void)len;
+}
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+  (void)argc;
+  (void)argv;
+  init_errmsg();
+  return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (!data || size == 0 || size > kMaxFuzzBytecodeSize) {
+    return 0;
+  }
+
+  SDissOptions options = {0};
+  (void)sdiss_disassemble_bytes(data, (uint32_t)size, &options, discard_output, NULL);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide a libFuzzer target that exercises the same bytecode verification and disassembly path used by `sdiss` to find robustness issues in decoding and formatting logic.
- Make the disassembly logic reusable so both the CLI and fuzz target can route arbitrary bytes through `bc_decode_bytecode_events` and the verification components in `bytecode_verify`.

### Description
- Extract the disassembly/formatting and event-decoding glue into a shared module by adding `src/sdiss_core.h` and `src/sdiss_core.c` and exposing `sdiss_disassemble_bytes` and related types (`SDissOptions`, `SDissResult`).
- Refactor `src/sdiss.c` to delegate to `sdiss_disassemble_bytes` while preserving CLI options, stdout behavior, verifier diagnostics, and exit codes.
- Add a libFuzzer target `tests/fuzz/fuzz_sdiss.c` that calls `sdiss_disassemble_bytes` with arbitrary bytes (output discarded) and bounds the input size.
- Update `Makefile` to build the fuzz binary (`fuzz-sdiss`), include `sdiss_core.o` in the shared library, and add a `seed-fuzz-sdiss-corpus` rule that seeds the corpus from `tests/fixtures/sdiss/*.hex`.

### Testing
- Ran `git diff --check` with no reported issues.
- Ran `make test -j2` and the test harness completed successfully (122/122 tests passed).
- Built the fuzz target with `make fuzz-sdiss` which produced `tests/fuzz/fuzz_sdiss` successfully.
- Ran the fuzzer with `./tests/fuzz/fuzz_sdiss -runs=16 tests/fuzz/corpus/sdiss` which completed the runs (16) and reported no crashes during the short run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4396645abc832e98ff915b1b209b88)