### PR TITLE
Add libFuzzer target for sin object/itemstore loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ FUZZ_BIN := $(FUZZ_DIR)/fuzz_scomp
 FUZZ_CORPUS_DIR := $(FUZZ_DIR)/corpus/scomp
 FUZZ_SDISS_BIN := $(FUZZ_DIR)/fuzz_sdiss
 FUZZ_SDISS_CORPUS_DIR := $(FUZZ_DIR)/corpus/sdiss
+FUZZ_SIN_OBJECT_BIN := $(FUZZ_DIR)/fuzz_sin_object
+FUZZ_SIN_OBJECT_CORPUS_DIR := $(FUZZ_DIR)/corpus/sin-object
 FUZZ_SANITIZE_FLAGS := -fsanitize=fuzzer-no-link,address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined
 FUZZ_LINK_FLAGS := -fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined
 TEST_SHARED_SOURCES := \
@@ -103,6 +105,8 @@ LEXER_GENERATED := $(SRC_DIR)/lexer.c
 SCOMP_SOURCES := $(SRC_DIR)/scomp.c
 SCOMP_OBJECTS := $(SCOMP_SOURCES:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
 
+$(OBJ_DIR)/scomp.o: $(PARSER_GENERATED)
+
 # Source files for sdiss
 SDISS_SOURCES := $(SRC_DIR)/sdiss.c
 SDISS_OBJECTS := $(SDISS_SOURCES:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
@@ -119,7 +123,7 @@ $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	@mkdir -p $(@D)
 	$(CC) -c $(CFLAGS) $(DEBUG) $< -o $@
 
-.PHONY: all clean lib test teststrict test-asan test-lsan fuzz-scomp fuzz-sdiss seed-fuzz-sdiss-corpus
+.PHONY: all clean lib test teststrict test-asan test-lsan fuzz-scomp fuzz-sdiss fuzz-sin-object seed-fuzz-sdiss-corpus seed-fuzz-sin-object-corpus
 
 all: $(LIB) scomp sdiss sin
 
@@ -182,6 +186,9 @@ $(FUZZ_BIN): $(OBJ_DIR)/tests/fuzz/fuzz_scomp.o $(LIB)
 $(FUZZ_SDISS_BIN): $(OBJ_DIR)/tests/fuzz/fuzz_sdiss.o $(LIB)
 	$(CC) -o $@ $^ $(FUZZ_LINK_FLAGS) $(LIBS)
 
+$(FUZZ_SIN_OBJECT_BIN): $(OBJ_DIR)/tests/fuzz/fuzz_sin_object.o $(LIB)
+	$(CC) -o $@ $^ $(FUZZ_LINK_FLAGS) $(LIBS)
+
 seed-fuzz-sdiss-corpus:
 	@mkdir -p $(FUZZ_SDISS_CORPUS_DIR)
 	@if command -v xxd >/dev/null 2>&1; then \
@@ -203,6 +210,21 @@ fuzz-sdiss: seed-fuzz-sdiss-corpus
 	$(MAKE) CC=$(FUZZ_CC) CFLAGS="$(CFLAGS) $(FUZZ_SANITIZE_FLAGS)" LDFLAGS="$(LDFLAGS) $(FUZZ_SANITIZE_FLAGS)" seed-fuzz-sdiss-corpus $(FUZZ_SDISS_BIN)
 	@printf 'Built %s. Run with: %s %s\n' "$(FUZZ_SDISS_BIN)" "$(FUZZ_SDISS_BIN)" "$(FUZZ_SDISS_CORPUS_DIR)"
 
+seed-fuzz-sin-object-corpus: scomp
+	@mkdir -p $(FUZZ_SIN_OBJECT_CORPUS_DIR)
+	@for src in examples/chat-boot.src examples/chat-load.src examples/echo-boot.src examples/echo-load.src; do \
+		[ -e "$$src" ] || continue; \
+		obj="$(FUZZ_SIN_OBJECT_CORPUS_DIR)/$$(basename "$$src" .src).obj"; \
+		./scomp "$$src" "$$obj" >/dev/null 2>&1 || rm -f "$$obj"; \
+	done
+
+# Builds a libFuzzer harness for sin object/itemstore loading and strict bytecode validation.
+fuzz-sin-object:
+	$(MAKE) clean
+	$(MAKE) CC=$(FUZZ_CC) CFLAGS="$(CFLAGS) $(FUZZ_SANITIZE_FLAGS)" LDFLAGS="$(LDFLAGS) $(FUZZ_SANITIZE_FLAGS)" seed-fuzz-sin-object-corpus $(FUZZ_SIN_OBJECT_BIN)
+	@printf 'Built %s. Run with: %s %s\n' "$(FUZZ_SIN_OBJECT_BIN)" "$(FUZZ_SIN_OBJECT_BIN)" "$(FUZZ_SIN_OBJECT_CORPUS_DIR)"
+
 clean:
 	rm -rf $(OBJ_DIR) $(LIB) $(LIB_DIR) \
-         $(PARSER_GENERATED) $(LEXER_GENERATED) $(TEST_BIN) $(FUZZ_BIN) $(FUZZ_SDISS_BIN)
+         $(PARSER_GENERATED) $(LEXER_GENERATED) $(TEST_BIN) $(FUZZ_BIN) $(FUZZ_SDISS_BIN) $(FUZZ_SIN_OBJECT_BIN)
+

--- a/tests/fuzz/fuzz_sin_object.c
+++ b/tests/fuzz/fuzz_sin_object.c
@@ -1,0 +1,87 @@
+// libFuzzer target for sin's runtime-facing object loading path.
+//
+// Licensed under the MIT License - see LICENSE file for details.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "bytecode_verify.h"
+#include "config.h"
+#include "error.h"
+#include "item.h"
+#include "vm.h"
+
+CONFIG_t config;
+
+static const size_t kMaxFuzzObjectSize = 128 * 1024;
+static const size_t kMaxBytecodeProbeSize = 64 * 1024;
+
+static void verify_loaded_code_items(const ITEM_t *item) {
+  if (!item) return;
+
+  if (item->type == ITEM_code && item->bytecode_len <= kMaxBytecodeProbeSize) {
+    BC_VerifyOptions options = bc_verify_strict_options();
+    (void)bc_verify_bytecode(item->bytecode, item->bytecode_len, item->name,
+                             &options);
+  }
+
+  for (size_t i = 0; i < item->ordered_size; i++) {
+    verify_loaded_code_items(item->ordered_array[i]);
+  }
+}
+
+static void fuzz_load_itemstore_bytes(const uint8_t *data, size_t size) {
+  char path[] = "/tmp/sin-object-fuzz-XXXXXX";
+  int fd = mkstemp(path);
+  if (fd < 0) return;
+
+  FILE *file = fdopen(fd, "wb");
+  if (!file) {
+    close(fd);
+    unlink(path);
+    return;
+  }
+
+  if (fwrite(data, 1, size, file) != size || fclose(file) != 0) {
+    unlink(path);
+    return;
+  }
+
+  ITEM_t *loaded = load_itemstore(path);
+  if (loaded) {
+    verify_loaded_code_items(loaded);
+    destroy_item(loaded);
+  }
+  unlink(path);
+}
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+  (void)argc;
+  (void)argv;
+  init_errmsg();
+  memset(&config, 0, sizeof(config));
+  config.strict_validation = true;
+  config.itemstore_durability = ITEMSTORE_DURABLE_FAST;
+  return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (!data || size == 0 || size > kMaxFuzzObjectSize) {
+    return 0;
+  }
+
+  config.strict_validation = true;
+  fuzz_load_itemstore_bytes(data, size);
+
+  if (size <= kMaxBytecodeProbeSize) {
+    BC_VerifyOptions options = bc_verify_strict_options();
+    (void)bc_verify_bytecode(data, (uint32_t)size, "raw-fuzz-bytecode",
+                             &options);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide a fuzz harness that exercises the runtime-facing object/itemstore loading and bytecode verification path without starting networking or the event loop.
- Improve coverage for `load_itemstore()` and `bc_verify_bytecode()` reachable from the `sin` runtime to catch malformed object files and verification corner cases.

### Description
- Add `tests/fuzz/fuzz_sin_object.c`, a libFuzzer harness that writes each input to a temporary file, calls `load_itemstore()` to parse it, recursively validates loaded code items with `bc_verify_bytecode()`, and probes raw bytecode when small; the harness bounds input sizes and avoids interpreter execution. 
- Wire new fuzz targets and corpus variables into the `Makefile` via `FUZZ_SIN_OBJECT_BIN` and `FUZZ_SIN_OBJECT_CORPUS_DIR` and add the `fuzz-sin-object` and `seed-fuzz-sin-object-corpus` targets which seed the corpus from interpreter example sources. 
- Add a build dependency `$(OBJ_DIR)/scomp.o: $(PARSER_GENERATED)` so `scomp` (used when seeding the corpus) can be built from a clean tree.

### Testing
- Ran `make fuzz-sin-object` which built `tests/fuzz/fuzz_sin_object` successfully. 
- Ran the harness with seeded corpus via `./tests/fuzz/fuzz_sin_object tests/fuzz/corpus/sin-object -runs=8` which executed several runs without crashes and exercised `load_itemstore()` and bytecode verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43986766f4832e9ebb7d9b75c6d3db)