### PR TITLE
Add CI gate script for sanitizers and fuzzing

### DIFF
--- a/.github/workflows/core-compiler-gate.yml
+++ b/.github/workflows/core-compiler-gate.yml
@@ -15,15 +15,5 @@ jobs:
           sudo apt-get install -y build-essential clang bison flex libuv1-dev
       - name: Run core compiler gate
         run: ./ci/gate_ir_absyn_emitbc.sh
-      - name: Run regular tests
-        run: make test
-      - name: Run sanitizer and strict warning tests
-        env:
-          ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1:abort_on_error=1
-          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-        run: make test-sanitize
-      - name: Run deterministic fuzz smoke gate
-        env:
-          ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1:abort_on_error=1
-          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-        run: make fuzz-smoke FUZZ_RUNS=1000 FUZZ_SEED=1
+      - name: Run sanitizer and fuzz gate
+        run: ./ci/gate_sanitizers_fuzz.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,23 @@ make STRICT_WARNINGS=1 test
 
 The `test-sanitize` target also enables strict warnings automatically, so sanitizer runs use the same warning gate in addition to address/undefined-behavior sanitizers.
 
+
+## Sanitizer and fuzz gate
+
+Run the combined strict-warning, sanitizer, and fuzz smoke gate before opening a PR that touches compiler, runtime, parser, bytecode, or fuzz harness code:
+
+```bash
+./ci/gate_sanitizers_fuzz.sh
+```
+
+The script exports the same sanitizer defaults used by CI and then runs the Makefile gates in this order: `make STRICT_WARNINGS=1 test`, `make test-sanitize`, `make fuzz-build`, and `make fuzz-smoke-run` with `FUZZ_SEED=1`. Use `make fuzz-smoke` when you want the Makefile to build and run the fuzz smoke gate in one step.
+
+You can tune local or CI runs with environment variables without editing the script:
+
+```bash
+FUZZ_RUNS=5000 FUZZ_TIME=60 CC=gcc FUZZ_CC=clang ./ci/gate_sanitizers_fuzz.sh
+```
+
 ## Core language gate
 
 Run this gate when changing any code in the compiler or interpreter paths:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	@mkdir -p $(@D)
 	$(CC) -c $(CFLAGS) $(DEBUG) $< -o $@
 
-.PHONY: all clean lib test teststrict test-sanitize test-asan test-lsan fuzz-build fuzz-smoke fuzz-scomp fuzz-sdiss fuzz-sin-object seed-fuzz-sdiss-corpus seed-fuzz-sin-object-corpus
+.PHONY: all clean lib test teststrict test-sanitize test-asan test-lsan fuzz-build fuzz-smoke fuzz-smoke-run fuzz-scomp fuzz-sdiss fuzz-sin-object seed-fuzz-sdiss-corpus seed-fuzz-sin-object-corpus
 
 all: $(LIB) scomp sdiss sin
 
@@ -213,14 +213,17 @@ fuzz-build:
 	$(MAKE) clean
 	$(MAKE) CC=$(FUZZ_CC) CFLAGS="$(FUZZ_CFLAGS)" LDFLAGS="$(FUZZ_LDFLAGS)" seed-fuzz-sdiss-corpus seed-fuzz-sin-object-corpus $(FUZZ_BIN) $(FUZZ_SDISS_BIN) $(FUZZ_SIN_OBJECT_BIN)
 
-fuzz-smoke: fuzz-build
+fuzz-smoke: fuzz-build fuzz-smoke-run
+
+# Runs the already-built fuzz harnesses against seeded corpora.
+fuzz-smoke-run:
 	@set -eu; \
 	tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmp"' EXIT; \
 	mkdir -p "$$tmp/scomp" "$$tmp/sdiss" "$$tmp/sin-object"; \
-	$(FUZZ_BIN) -runs=$(FUZZ_RUNS) -seed=$(FUZZ_SEED) "$$tmp/scomp" $(FUZZ_CORPUS_DIR); \
-	$(FUZZ_SDISS_BIN) -runs=$(FUZZ_RUNS) -seed=$(FUZZ_SEED) "$$tmp/sdiss" $(FUZZ_SDISS_CORPUS_DIR); \
-	$(FUZZ_SIN_OBJECT_BIN) -runs=$(FUZZ_RUNS) -seed=$(FUZZ_SEED) "$$tmp/sin-object" $(FUZZ_SIN_OBJECT_CORPUS_DIR)
+	$(FUZZ_BIN) -runs=$(FUZZ_RUNS) -max_total_time=$(FUZZ_TIME) -seed=$(FUZZ_SEED) "$$tmp/scomp" $(FUZZ_CORPUS_DIR); \
+	$(FUZZ_SDISS_BIN) -runs=$(FUZZ_RUNS) -max_total_time=$(FUZZ_TIME) -seed=$(FUZZ_SEED) "$$tmp/sdiss" $(FUZZ_SDISS_CORPUS_DIR); \
+	$(FUZZ_SIN_OBJECT_BIN) -runs=$(FUZZ_RUNS) -max_total_time=$(FUZZ_TIME) -seed=$(FUZZ_SEED) "$$tmp/sin-object" $(FUZZ_SIN_OBJECT_CORPUS_DIR)
 
 fuzz-scomp:
 	$(MAKE) clean

--- a/ci/gate_sanitizers_fuzz.sh
+++ b/ci/gate_sanitizers_fuzz.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep sanitizer behavior consistent between local runs and CI.
+export ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=1:strict_string_checks=1:abort_on_error=1}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-print_stacktrace=1:halt_on_error=1}"
+
+# Keep gate runtime/toolchain knobs configurable for developers and CI.
+export FUZZ_RUNS="${FUZZ_RUNS:-1000}"
+export FUZZ_TIME="${FUZZ_TIME:-30}"
+export CC="${CC:-gcc}"
+export FUZZ_CC="${FUZZ_CC:-clang}"
+
+echo "==> strict warnings build/test"
+make STRICT_WARNINGS=1 CC="${CC}" test
+
+echo "==> sanitizer build/test"
+make CC="${CC}" test-sanitize
+
+echo "==> fuzz build"
+make FUZZ_CC="${FUZZ_CC}" FUZZ_RUNS="${FUZZ_RUNS}" FUZZ_TIME="${FUZZ_TIME}" fuzz-build
+
+echo "==> seeded fuzz smoke run"
+make FUZZ_CC="${FUZZ_CC}" FUZZ_RUNS="${FUZZ_RUNS}" FUZZ_TIME="${FUZZ_TIME}" FUZZ_SEED=1 fuzz-smoke-run


### PR DESCRIPTION
### Motivation
- Provide a single, reusable gate script that CI and developers can run to exercise strict-warnings, sanitizer, and fuzz gates in a consistent way.
- Ensure local runs match CI by exporting sanitizer options and keeping runtime knobs configurable via environment variables.
- Avoid rebuilding fuzz harnesses twice in CI by separating build and run steps so the harnesses can be built once and then executed with tunable runtime limits.

### Description
- Add `ci/gate_sanitizers_fuzz.sh`, an executable Bash script that sets `set -euo pipefail`, exports `ASAN_OPTIONS` and `UBSAN_OPTIONS` defaults, exposes `FUZZ_RUNS`, `FUZZ_TIME`, `CC`, and `FUZZ_CC` as configurable environment variables, and runs the Makefile gates in order: strict warnings test, sanitizer test, fuzz build, then seeded fuzz smoke run via the Makefile. 
- Update the Makefile to add a `fuzz-smoke-run` target and make `fuzz-smoke` depend on it, and ensure the seeded fuzz runs use `-max_total_time=$(FUZZ_TIME)` while still honoring `FUZZ_RUNS` and `FUZZ_SEED`.
- Update the GitHub Actions workflow `.github/workflows/core-compiler-gate.yml` to invoke the new script instead of running separate sanitizer/fuzz steps.
- Document the new gate and usage knobs in `CONTRIBUTING.md` with examples for local invocation and tuning.

### Testing
- Ran `bash -n ci/gate_sanitizers_fuzz.sh` to verify the script syntax (no errors).
- Verified Makefile changes with a dry-run using `make -n FUZZ_RUNS=1 FUZZ_TIME=1 fuzz-smoke-run` to confirm the expected commands were generated (successful dry-run).
- Executed `FUZZ_RUNS=1 FUZZ_TIME=1 ./ci/gate_sanitizers_fuzz.sh` which ran `make STRICT_WARNINGS=1 test`, `make test-sanitize`, `make fuzz-build`, and the seeded fuzz smoke run; the test harness completed with `PASS` (122/122 tests) and the fuzz smoke run completed without failing the gate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439bcfb2d8832e9ccd6f7277562752)