### PR TITLE
docs: document sanitizer and fuzzing gates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ make STRICT_WARNINGS=1 test
 The `test-sanitize` target also enables strict warnings automatically, so sanitizer runs use the same warning gate in addition to address/undefined-behavior sanitizers.
 
 
-## Sanitizer and fuzz gate
+## Sanitizer and fuzzing gates
 
-Run the combined strict-warning, sanitizer, and fuzz smoke gate before opening a PR that touches compiler, runtime, parser, bytecode, or fuzz harness code:
+Run the same P0 gates locally before opening a PR that touches compiler, runtime, parser, bytecode, or fuzz harness code. The combined CI-style entry point is:
 
 ```bash
 ./ci/gate_sanitizers_fuzz.sh
@@ -35,11 +35,69 @@ Run the combined strict-warning, sanitizer, and fuzz smoke gate before opening a
 
 The script exports the same sanitizer defaults used by CI and then runs the Makefile gates in this order: `make STRICT_WARNINGS=1 test`, `make test-sanitize`, `make fuzz-build`, and `make fuzz-smoke-run` with `FUZZ_SEED=1`. Use `make fuzz-smoke` when you want the Makefile to build and run the fuzz smoke gate in one step.
 
-You can tune local or CI runs with environment variables without editing the script:
+### Local gate commands
+
+Use these commands to run each gate directly:
+
+```bash
+make test
+make STRICT_WARNINGS=1 test
+make test-sanitize
+make fuzz-smoke
+make fuzz-scomp
+make fuzz-sdiss
+make fuzz-sin-object
+```
+
+- `make test` runs the normal test harness.
+- `make STRICT_WARNINGS=1 test` treats strict-warning regressions as build failures.
+- `make test-sanitize` rebuilds and runs tests with address/undefined-behavior sanitizers and strict warnings enabled.
+- `make fuzz-smoke` builds the fuzz harnesses and runs seeded smoke coverage for the `scomp`, `sdiss`, and `sin` object input paths.
+- `make fuzz-scomp`, `make fuzz-sdiss`, and `make fuzz-sin-object` build individual libFuzzer targets and print the command to run each target against its corpus.
+
+You can tune local or CI fuzz runs with environment variables without editing the script or Makefile:
 
 ```bash
 FUZZ_RUNS=5000 FUZZ_TIME=60 CC=gcc FUZZ_CC=clang ./ci/gate_sanitizers_fuzz.sh
+FUZZ_RUNS=5000 FUZZ_TIME=60 make fuzz-smoke
 ```
+
+### Fuzz corpora
+
+Seed corpora live under `tests/fuzz/corpus/`:
+
+- `tests/fuzz/corpus/scomp/` for compiler source-input fuzzing.
+- `tests/fuzz/corpus/sdiss/` for disassembler object-input fuzzing.
+- `tests/fuzz/corpus/sin-object/` for `sin` object/itemstore input fuzzing.
+
+The `sdiss` and `sin-object` corpora may be seeded from representative existing fixtures during the build: `make fuzz-sdiss`, `make fuzz-sin-object`, and `make fuzz-build` refresh generated corpus inputs before building or running the relevant harnesses.
+
+### Reproducing fuzz failures
+
+When libFuzzer reports a failure, save the crashing input path from its output, rebuild the matching harness, and run that harness with the saved input as the only argument. For example:
+
+```bash
+make fuzz-scomp
+tests/fuzz/fuzz_scomp path/to/crash-input
+
+make fuzz-sdiss
+tests/fuzz/fuzz_sdiss path/to/crash-input
+
+make fuzz-sin-object
+tests/fuzz/fuzz_sin_object path/to/crash-input
+```
+
+If the crash was found with non-default sanitizer, compiler, or fuzzing settings, rerun with the same environment variables, such as `FUZZ_CC`, `FUZZ_CFLAGS`, `FUZZ_LDFLAGS`, `ASAN_OPTIONS`, or `UBSAN_OPTIONS`. Keep the crashing input as a regression corpus entry whenever it is small, deterministic, and safe to commit.
+
+### P0 completion criteria
+
+The P0 sanitizer and fuzzing gates are complete when all of the following are true:
+
+- CI fails on sanitizer findings.
+- CI fails on strict-warning regressions.
+- CI runs seeded fuzz smoke targets for `scomp`, `sdiss`, and `sin` input paths.
+- Fuzz corpora include representative existing fixtures.
+- Developers can run the same gates locally with the documented commands above.
 
 ## Core language gate
 


### PR DESCRIPTION
### Motivation

- Provide clear, local developer instructions for running and debugging the new P0 sanitizer and fuzzing gates so local workflows match CI expectations.
- Surface exact Makefile targets and corpus locations used by CI to make reproducing and triaging sanitizer and fuzz findings straightforward.

### Description

- Updated `CONTRIBUTING.md` with a renamed "Sanitizer and fuzzing gates" section that documents the CI entry point and local usage.
- Added an explicit list of local commands including `make test`, `make STRICT_WARNINGS=1 test`, `make test-sanitize`, `make fuzz-smoke`, `make fuzz-scomp`, `make fuzz-sdiss`, and `make fuzz-sin-object`.
- Documented fuzz corpus locations under `tests/fuzz/corpus/` for `scomp`, `sdiss`, and `sin-object`, and described how `make fuzz-sdiss`/`make fuzz-sin-object`/`make fuzz-build` seed corpora.
- Added reproduction instructions for running a libFuzzer crashing input against the rebuilt harness and a concise P0 completion criteria checklist.

### Testing

- Ran the standard test harness with `make test`, which completed and reported all tests passing (`122/122`).
- No sanitizer or fuzz smoke runs were executed as part of this change, so those gates were not validated in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43ea1a2200832e8c54fe3461d8e457)