### PR TITLE
Allow unary minus on float literals

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -33,6 +33,7 @@
 }
 
 %{
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -52,6 +53,25 @@ int yyparse();
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 YY_BUFFER_STATE yy_scan_bytes(const char *bytes, int len, yyscan_t yyscanner);
 void yy_delete_buffer(YY_BUFFER_STATE b, yyscan_t yyscanner);
+
+
+static AS_NODE *as_new_unary_minus_node(AS_NODE *operand) {
+  if (operand && operand->nodetype == N_VALUE) {
+    AS_VALUE *value = (AS_VALUE *)operand->lhs;
+    if (value) {
+      if (value->valtype == V_INT && value->value.i > INT64_MIN) {
+        value->value.i = -value->value.i;
+        return operand;
+      }
+      if (value->valtype == V_FLOAT) {
+        value->value.f_bits ^= UINT64_C(0x8000000000000000);
+        return operand;
+      }
+    }
+  }
+
+  return as_new_node(N_SUB, as_new_intnode(0), operand);
+}
 
 void yyerror(yyscan_t locp, SCANNER_STATE_t *state, char const *s) {
   // yyerror() is called whenever there is a syntax error, so we need to
@@ -207,7 +227,7 @@ expr:     TLOCAL { $$ = as_new_valnode(V_LOCAL, $1); }
 	      |	expr TDIV expr { $$ = as_new_node(N_DIV, $1, $3); }
         | TLPAREN expr TRPAREN { $$ = $2; }
         | TNOT expr { $$ = as_new_node(N_NOT, $2, NULL); }
-        | TMINUS expr %prec UMINUS { $$ = as_new_node(N_SUB, as_new_intnode(0), $2); }
+        | TMINUS expr %prec UMINUS { $$ = as_new_unary_minus_node($2); }
         | funcop { $$ = $1; }
         | libcall { $$ = $1; }
         | TUNKNOWNCHAR { $$ = NULL;

--- a/tests/core/test_parser_float_literals.c
+++ b/tests/core/test_parser_float_literals.c
@@ -96,6 +96,31 @@ void test_parser_float_literals_decimal_forms(void) {
   as_delete(root);
 }
 
+void test_parser_float_literals_unary_minus_preserves_float_literals(void) {
+  AS_NODE *root = parse_ok("-1.5; -0.0;");
+  ASSERT_EQ_INT(N_STMTLIST, root->nodetype);
+  AS_STMTLIST *list = (AS_STMTLIST *)root->lhs;
+  ASSERT_EQ_INT(2, list->count);
+
+  AS_NODE *stmt = list->stmts[0];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  AS_NODE *value_node = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_VALUE, value_node->nodetype);
+  AS_VALUE *value = (AS_VALUE *)value_node->lhs;
+  ASSERT_EQ_INT(V_FLOAT, value->valtype);
+  ASSERT_TRUE(value->value.f_bits == bits_for_double(-1.5));
+
+  stmt = list->stmts[1];
+  ASSERT_EQ_INT(N_EXPRSTMT, stmt->nodetype);
+  value_node = (AS_NODE *)stmt->lhs;
+  ASSERT_EQ_INT(N_VALUE, value_node->nodetype);
+  value = (AS_VALUE *)value_node->lhs;
+  ASSERT_EQ_INT(V_FLOAT, value->valtype);
+  ASSERT_TRUE(value->value.f_bits == UINT64_C(0x8000000000000000));
+
+  as_delete(root);
+}
+
 void test_parser_float_literals_integer_still_int(void) {
   AS_NODE *root = parse_ok("42;");
   AS_NODE *stmt = single_stmt(root);

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -89,6 +89,7 @@ void test_bytecode_verify_stack_flow(void);
 void test_parser_input_api(void);
 void test_parser_float_literals_decimal_forms(void);
 void test_parser_float_literals_integer_still_int(void);
+void test_parser_float_literals_unary_minus_preserves_float_literals(void);
 void test_parser_float_literals_item_layers_unchanged(void);
 void test_parser_float_literals_malformed_rejected(void);
 void test_floatconv_binary64_edge_cases(void);
@@ -218,6 +219,7 @@ static const test_case_t core_tests[] = {
     {"test_parser_input_api", test_parser_input_api},
     {"test_parser_float_literals_decimal_forms", test_parser_float_literals_decimal_forms},
     {"test_parser_float_literals_integer_still_int", test_parser_float_literals_integer_still_int},
+    {"test_parser_float_literals_unary_minus_preserves_float_literals", test_parser_float_literals_unary_minus_preserves_float_literals},
     {"test_parser_float_literals_item_layers_unchanged", test_parser_float_literals_item_layers_unchanged},
     {"test_parser_float_literals_malformed_rejected", test_parser_float_literals_malformed_rejected},
     {"test_floatconv_binary64_edge_cases", test_floatconv_binary64_edge_cases},


### PR DESCRIPTION
### Motivation
- The existing UMINUS action in the parser folded unary minus only for integer literals, preventing direct negative float literals like `-1.5` and losing IEEE-754 negative-zero semantics.
- The goal is to preserve literal folding for negative integers and floats while keeping the previous subtraction fallback for non-literal operands.

### Description
- Added a helper `as_new_unary_minus_node` in `src/parser.y` that folds unary minus for literal `N_VALUE` nodes, negating `V_INT` (with `INT64_MIN` guard) and flipping the sign bit for `V_FLOAT` using `UINT64_C(0x8000000000000000)`.
- Replaced the UMINUS grammar action to call `as_new_unary_minus_node($2)` instead of always producing `as_new_node(N_SUB, as_new_intnode(0), $2)`.
- Added a parser regression test `test_parser_float_literals_unary_minus_preserves_float_literals` in `tests/core/test_parser_float_literals.c` to cover `-1.5` and `-0.0`, and registered the test in `tests/shared/test_compiler.c`.
- Included `<limits.h>` in `src/parser.y` to use `INT64_MIN` and ensure safe integer negation.

### Testing
- Ran `git diff --check` which produced no whitespace or formatting errors.
- Built and executed the full test-suite with `make tests/test-compiler && tests/test-compiler`, and all tests passed (`123/123`), including the new float-literal unary-minus test.
- Verified parser rebuild via `bison`/`flex` and compilation as part of the test build; compilation and test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43ff271968832e9a2fd9b9aa978da0)