### PR TITLE
Widen network line numbering

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <uv.h>
 
 #include "vm.h"
@@ -26,8 +27,8 @@ typedef struct {
   char *inputline;      // Item to receive the input line number
   char *inputtext;      // Item to receive the input data
   VM_t *input_vm;       // VM for the input task
-  uint8_t maxconns;     // Maximum number of connected players
-  uint8_t lastconn;     // Last connection processed by net.input
+  size_t maxconns;      // Maximum number of connected players
+  size_t lastconn;      // Last connection processed by net.input
   bool safe_shutdown;   // Determins how to shut down.
   bool strict_validation; // Verify bytecode at runtime before execution.
 } CONFIG_t;

--- a/src/libcall.c
+++ b/src/libcall.c
@@ -349,7 +349,7 @@ uint8_t *lc_net_input(uint8_t *nextop, ITEM_t *item) {
   // gets a turn.  Find the next activity.
   (void)item;
   config.lastconn++;
-  if (config.lastconn >= config.maxconns) {
+  if (config.maxconns == 0 || config.lastconn >= config.maxconns) {
     config.lastconn = 0;
   }
   while (config.lastconn < config.maxconns) {
@@ -359,7 +359,7 @@ uint8_t *lc_net_input(uint8_t *nextop, ITEM_t *item) {
       case LINE_connecting:
         line[config.lastconn].status = LINE_idle;
         // Set the input item to the current line
-        val.i = config.lastconn;
+        val.i = (long)config.lastconn;
         set_item(config.itemroot, config.inputline, val);
         // And return a value from this libcall to say what happened.
         val.i = 1;
@@ -369,14 +369,14 @@ uint8_t *lc_net_input(uint8_t *nextop, ITEM_t *item) {
         destroy_line(&line[config.lastconn]);
         line[config.lastconn].status = LINE_empty;
         // Set the input item to the current line
-        val.i = config.lastconn;
+        val.i = (long)config.lastconn;
         set_item(config.itemroot, config.inputline, val);
         val.i = 2;
         push_stack(VM->stack, val);
         return nextop;
       case LINE_data:
         // Set the input item to the current line
-        val.i = config.lastconn;
+        val.i = (long)config.lastconn;
         set_item(config.itemroot, config.inputline, val);
         // And grab some data.
         VALUE_t str = {VALUE_str, {0}};
@@ -400,58 +400,60 @@ uint8_t *lc_net_write(uint8_t *nextop, ITEM_t *item) {
   (void)item;
   VALUE_t out = pop_stack(VM->stack);
   VALUE_t linenum = pop_stack(VM->stack);
+  size_t line_index = 0;
 
-  if (!lc_value_is_type(linenum, VALUE_int) || linenum.i < 0 
-                                        || linenum.i >= config.maxconns) {
+  if (!lc_value_is_type(linenum, VALUE_int) || linenum.i < 0 ||
+      (size_t)linenum.i >= config.maxconns) {
     FREE_STR(out);
     FREE_STR(linenum);
     return lc_invalid_args_detail_return(nextop, VALUE_NIL,
         "net.write line must be an integer connection index; floats are invalid");
   } else {
-    if ((line[linenum.i].status != LINE_data
-        && line[linenum.i].status != LINE_idle)
-        || line[linenum.i].telnet == NULL) {
+    line_index = (size_t)linenum.i;
+    if ((line[line_index].status != LINE_data
+        && line[line_index].status != LINE_idle)
+        || line[line_index].telnet == NULL) {
       FREE_STR(out);
       push_stack(VM->stack, VALUE_NIL);
       return nextop;
     }
     switch(out.type) {
       case VALUE_str:
-        if (line[linenum.i].outbuf &&
-            !line_can_accept_output(&line[linenum.i], strlen(out.s))) {
-          logerr("net.write rejected for line %ld: output buffer limit or backpressure.\n",
-                 linenum.i);
+        if (line[line_index].outbuf &&
+            !line_can_accept_output(&line[line_index], strlen(out.s))) {
+          logerr("net.write rejected for line %zu: output buffer limit or backpressure.\n",
+                 line_index);
           FREE_STR(out);
           push_stack(VM->stack, VALUE_FALSE);
           return nextop;
         }
-        telnet_send_text(line[linenum.i].telnet, out.s, strlen(out.s));
+        telnet_send_text(line[line_index].telnet, out.s, strlen(out.s));
         FREE_STR(out);
         break;
       case VALUE_int: {
         char buffer[22];
         itoa(out.i, buffer, 10);
-        if (line[linenum.i].outbuf &&
-            !line_can_accept_output(&line[linenum.i], strlen(buffer))) {
-          logerr("net.write rejected for line %ld: output buffer limit or backpressure.\n",
-                 linenum.i);
+        if (line[line_index].outbuf &&
+            !line_can_accept_output(&line[line_index], strlen(buffer))) {
+          logerr("net.write rejected for line %zu: output buffer limit or backpressure.\n",
+                 line_index);
           push_stack(VM->stack, VALUE_FALSE);
           return nextop;
         }
-        telnet_send_text(line[linenum.i].telnet, buffer, strlen(buffer));
+        telnet_send_text(line[line_index].telnet, buffer, strlen(buffer));
         break;
       }
       case VALUE_float: {
         char fbuffer[64];
         if (sin_format_binary64_buf(out.f, fbuffer, sizeof(fbuffer))) {
-          if (line[linenum.i].outbuf &&
-              !line_can_accept_output(&line[linenum.i], strlen(fbuffer))) {
-            logerr("net.write rejected for line %ld: output buffer limit or backpressure.\n",
-                   linenum.i);
+          if (line[line_index].outbuf &&
+              !line_can_accept_output(&line[line_index], strlen(fbuffer))) {
+            logerr("net.write rejected for line %zu: output buffer limit or backpressure.\n",
+                   line_index);
             push_stack(VM->stack, VALUE_FALSE);
             return nextop;
           }
-          telnet_send_text(line[linenum.i].telnet, fbuffer, strlen(fbuffer));
+          telnet_send_text(line[line_index].telnet, fbuffer, strlen(fbuffer));
         }
         break;
       }
@@ -461,20 +463,20 @@ uint8_t *lc_net_write(uint8_t *nextop, ITEM_t *item) {
       case VALUE_bool: {
         char *t = "true";
         char *f = "false";
-        if (line[linenum.i].outbuf &&
-            !line_can_accept_output(&line[linenum.i], strlen(out.i?t:f))) {
-          logerr("net.write rejected for line %ld: output buffer limit or backpressure.\n",
-                 linenum.i);
+        if (line[line_index].outbuf &&
+            !line_can_accept_output(&line[line_index], strlen(out.i?t:f))) {
+          logerr("net.write rejected for line %zu: output buffer limit or backpressure.\n",
+                 line_index);
           push_stack(VM->stack, VALUE_FALSE);
           return nextop;
         }
-        telnet_send_text(line[linenum.i].telnet, out.i?t:f,
+        telnet_send_text(line[line_index].telnet, out.i?t:f,
                                                         strlen(out.i?t:f));
         break;
       }
     }
   }
-  if (line[linenum.i].status == LINE_disconnecting) {
+  if (line[line_index].status == LINE_disconnecting) {
     push_stack(VM->stack, VALUE_FALSE);
     return nextop;
   }

--- a/src/network.c
+++ b/src/network.c
@@ -4,7 +4,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <limits.h>
 #include <string.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "config.h"
@@ -38,11 +40,32 @@ LINE_t *line;
 
 void flush_output(LINE_t *linep);
 
+bool validate_network_config() {
+  if (config.maxconns == 0) {
+    logerr("Invalid maxconns: must be greater than zero.\n");
+    return false;
+  }
+  if (config.maxconns > (size_t)LONG_MAX) {
+    logerr("Invalid maxconns: %zu exceeds maximum line number %ld.\n",
+           config.maxconns, LONG_MAX);
+    return false;
+  }
+  if (config.maxconns > SIZE_MAX / sizeof(LINE_t)) {
+    logerr("Invalid maxconns: %zu is too large to allocate.\n",
+           config.maxconns);
+    return false;
+  }
+  return true;
+}
+
 void init_networking() {
   // Do that which needs to be done before starting the network interface
+  if (!validate_network_config()) {
+    exit(EXIT_FAILURE);
+  }
 
   line = GROW_ARRAY(LINE_t, line, 0, config.maxconns);
-  for (int l = 0; l < config.maxconns; l++) {
+  for (size_t l = 0; l < config.maxconns; l++) {
     line[l].status = LINE_empty;
     line[l].linenum = l;
     line[l].address[0] = '\0';
@@ -58,7 +81,7 @@ void init_networking() {
 }
 
 LINE_t *add_line(uv_tcp_t *line_handle) {
-  uint8_t l = 0;
+  size_t l = 0;
   while (line[l].status != LINE_empty) {
     l++;
     if (l >= config.maxconns) {
@@ -148,7 +171,7 @@ void destroy_line(LINE_t *linep) {
 LINE_t *find_line(uv_tcp_t *client) {
   // Given a TCP client connection, find its associated line.
   // Return the line, or NULL if not found.
-  uint8_t l = 0;
+  size_t l = 0;
   while (l < config.maxconns) {
     if (line[l].line_handle == client) {
       return &line[l];
@@ -165,12 +188,12 @@ void client_on_close(uv_handle_t *handle) {
     free(handle);
     return;
   }
-  logmsg("Line %d: %s disconnected.\n", linep->linenum, linep->address);
+  logmsg("Line %zu: %s disconnected.\n", linep->linenum, linep->address);
   linep->status = LINE_disconnecting;
 }
 
 static void disconnect_line_for_output_limit(LINE_t *linep, const char *reason) {
-  logerr("Line %d (%s) exceeded output limits: %s. Disconnecting.\n",
+  logerr("Line %zu (%s) exceeded output limits: %s. Disconnecting.\n",
          linep->linenum, linep->address[0] ? linep->address : "unknown", reason);
   if (linep->outbuf && linep->outbuf->buf.base) {
     linep->outbuf->buf.len = 0;
@@ -251,7 +274,7 @@ void append_output(LINE_t *linep, const char *msg, const ssize_t len) {
 }
 
 static void disconnect_line_for_input_limit(LINE_t *linep, const char *reason) {
-  logerr("Line %d (%s) exceeded input limits: %s. Disconnecting.\n",
+  logerr("Line %zu (%s) exceeded input limits: %s. Disconnecting.\n",
          linep->linenum, linep->address[0] ? linep->address : "unknown", reason);
   if (linep->inbuf && linep->inbuf->buf.base) {
     linep->inbuf->buf.len = 0;
@@ -354,7 +377,7 @@ char *get_input(LINE_t *linep) {
   // unchanged.  The buffer allocated by this function will need to be
   // freed by the calling function when it is no longer needed.
   if (!linep->inbuf || !linep->inbuf->buf.base) {
-    logerr("Line %d (%s) has no input buffer. Disconnecting.\n",
+    logerr("Line %zu (%s) has no input buffer. Disconnecting.\n",
            linep->linenum, linep->address[0] ? linep->address : "unknown");
     linep->status = LINE_disconnecting;
     if (linep->line_handle && !uv_is_closing((uv_handle_t *)linep->line_handle)) {
@@ -365,7 +388,7 @@ char *get_input(LINE_t *linep) {
 
   char *eol = memchr(linep->inbuf->buf.base, '\n', linep->inbuf->buf.len);
   if (!eol) {
-    logerr("Line %d (%s) marked as data without a newline. Returning to idle.\n",
+    logerr("Line %zu (%s) marked as data without a newline. Returning to idle.\n",
            linep->linenum, linep->address[0] ? linep->address : "unknown");
     linep->status = LINE_idle;
     linep->input_line_length = unterminated_input_line_length(
@@ -376,7 +399,7 @@ char *get_input(LINE_t *linep) {
   *eol = '\0';
   char *data = strdup(linep->inbuf->buf.base);
   if (!data) {
-    logerr("Failed to allocate input line for line %d.\n", linep->linenum);
+    logerr("Failed to allocate input line for line %zu.\n", linep->linenum);
     linep->status = LINE_disconnecting;
     if (linep->line_handle && !uv_is_closing((uv_handle_t *)linep->line_handle)) {
       uv_close((uv_handle_t *)linep->line_handle, client_on_close);
@@ -392,7 +415,7 @@ char *get_input(LINE_t *linep) {
   }
   char *newbuffer = malloc(new_capacity);
   if (!newbuffer) {
-    logerr("Failed to allocate replacement input buffer for line %d.\n",
+    logerr("Failed to allocate replacement input buffer for line %zu.\n",
            linep->linenum);
     free(data);
     linep->status = LINE_disconnecting;
@@ -446,7 +469,7 @@ static void output_write_cb(uv_write_t *req, int status) {
   LINE_t *linep = (LINE_t *)req->data;
 
   if (status < 0 && linep) {
-    logerr("Line %d (%s) write error: %s. Disconnecting.\n",
+    logerr("Line %zu (%s) write error: %s. Disconnecting.\n",
            linep->linenum, linep->address[0] ? linep->address : "unknown",
            uv_strerror(status));
   }
@@ -592,7 +615,7 @@ void on_new_connection(uv_stream_t *server, int status) {
   if (!newline) {
     uv_buf_t gamefull = {"Too many connections.\r\n", 23};
     uv_try_write((uv_stream_t *)client, &gamefull, 1);
-    logmsg("Rejected connection: maximum connections (%d) exceeded or allocation failed.\n",
+    logmsg("Rejected connection: maximum connections (%zu) exceeded or allocation failed.\n",
            config.maxconns);
     uv_close((uv_handle_t *)client, free_client_on_close);
     return;
@@ -601,7 +624,7 @@ void on_new_connection(uv_stream_t *server, int status) {
   newline->telnet = telnet_init(telopts, telnet_event_handler,
                                 TELNET_FLAG_NVT_EOL, newline);
   if (!newline->telnet) {
-    logerr("Rejected connection: telnet_init failed for line %d.\n",
+    logerr("Rejected connection: telnet_init failed for line %zu.\n",
            newline->linenum);
     newline->status = LINE_disconnecting;
     uv_close((uv_handle_t *)client, client_on_close);
@@ -637,7 +660,7 @@ void on_new_connection(uv_stream_t *server, int status) {
 
   telnet_printf(newline->telnet, "Connected.\n");
   flush_output(newline);
-  logmsg("Line %d: %s connected.\n", newline->linenum, newline->address);
+  logmsg("Line %zu: %s connected.\n", newline->linenum, newline->address);
 }
 
 void init_listener(uint32_t port) {
@@ -651,7 +674,7 @@ void init_listener(uint32_t port) {
   if (r) {
     logerr("Failed to start listening: %s\n", uv_strerror(r));
   } else {
-    logmsg("Listening on port %d.\n", port);
+    logmsg("Listening on port %u.\n", port);
   }
 }
 
@@ -667,7 +690,7 @@ void input_processor(uv_idle_t* handle) {
   interpret(input);
   reset_stack(VM->stack);
   // Flush the output of every connected line
-  for (int l = 0; l < config.maxconns; l++) {
+  for (size_t l = 0; l < config.maxconns; l++) {
     if (line[l].status != LINE_empty 
                                   && line[l].status != LINE_disconnecting) {
       flush_output(&line[l]);

--- a/src/network.h
+++ b/src/network.h
@@ -25,7 +25,7 @@ typedef struct {
   uv_tcp_t *line_handle;
   enum { LINE_empty, LINE_connecting,
          LINE_disconnecting, LINE_data, LINE_idle } status;
-  uint8_t linenum;
+  size_t linenum;
   char address[40];
   telnet_t *telnet;
   write_req_t *outbuf;
@@ -36,6 +36,7 @@ typedef struct {
   size_t input_line_length; // Bytes buffered since the last newline
 } LINE_t;
 
+bool validate_network_config();
 void init_networking();
 void init_listener(uint32_t port);
 void destroy_line(LINE_t *line);

--- a/src/sin.c
+++ b/src/sin.c
@@ -383,7 +383,10 @@ int main(int argc, char **argv) {
     // Here we go...
     logmsg("Running...\n");
     config.maxconns = MAXCONNS;
-    config.lastconn = 255;
+    config.lastconn = config.maxconns;
+    if (!validate_network_config()) {
+      exit(EXIT_FAILURE);
+    }
     init_networking();
     init_listener(listener_port);
     runloop_retval = uv_run(config.loop, UV_RUN_DEFAULT);

--- a/tests/core/test_libcall_registry.c
+++ b/tests/core/test_libcall_registry.c
@@ -36,7 +36,7 @@ static void setup_libcall_runtime(void) {
 
 static void teardown_libcall_runtime(void) {
   if (line) {
-    for (uint8_t i = 0; i < config.maxconns; i++) {
+    for (size_t i = 0; i < config.maxconns; i++) {
       if (line[i].telnet) {
         telnet_free(line[i].telnet);
         line[i].telnet = NULL;


### PR DESCRIPTION
### Motivation

- Prevent `maxconns` and line indices from being limited by 8-bit types so the server can support larger configured connection counts.  
- Ensure callers and libcalls that use a line index keep validity and do not overflow or truncate when `maxconns` is increased.  
- Make logging and formatting of line numbers correct for the wider index type and validate impossible `maxconns` values before network initialization.

### Description

- Changed `config.maxconns` and `config.lastconn` from `uint8_t` to `size_t` in `src/config.h`.  
- Changed `LINE_t.linenum` from `uint8_t` to `size_t` in `src/network.h`.  
- Converted loop and local index variables in `src/network.c` (`init_networking`, `add_line`, `find_line`, `input_processor`) from `int`/`uint8_t` to `size_t` to match `config.maxconns`.  
- Updated `lc_net_input()` and `lc_net_write()` in `src/libcall.c` to validate line arguments against `config.maxconns`, use a `size_t` `line_index` for indexing, and cast only after validation.  
- Replaced `printf`/`log*` format specifiers that printed line numbers from `%d`/`%ld` to the proper size-aware specifiers such as `%zu` (and updated port logging to use `%u` where appropriate).  
- Added `validate_network_config()` in `src/network.c` to reject `maxconns == 0`, unrepresentable values, or sizes too large to allocate, and wired it into startup (`init_networking()` and `sin` startup path) to fail fast.  
- Adjusted test and teardown loops in `tests/core/test_libcall_registry.c` to iterate with `size_t` to match the widened types.

### Testing

- Ran the full test harness with `make test`; all tests completed and passed (test harness summary: suites passed, `123/123` tests executed and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4558085a3c832e8f58ef5443f7f6cf)