### PR TITLE
Extend compiler diagnostic metadata

### DIFF
--- a/src/compiler/compdiag.c
+++ b/src/compiler/compdiag.c
@@ -76,11 +76,23 @@ void compdiag_reset_detail(char **errdetail) {
   *errdetail = NULL;
 }
 
+static char *compiler_diag_strdup(const char *s) {
+  const char *safe = s ? s : "";
+  size_t len = strlen(safe);
+  char *copy = malloc(len + 1);
+  if (!copy) return NULL;
+  memcpy(copy, safe, len + 1);
+  return copy;
+}
+
 void compiler_diag_init(CompilerDiagnostic *d) {
   if (!d) return;
   d->code = 0;
   d->phase = DIAG_PHASE_NONE;
   d->message = NULL;
+  d->stable_code = NULL;
+  d->source_name = NULL;
+  d->excerpt = NULL;
   d->line = d->column = d->span = -1;
   d->has_loc = false;
 }
@@ -88,6 +100,9 @@ void compiler_diag_init(CompilerDiagnostic *d) {
 void compiler_diag_reset(CompilerDiagnostic *d) {
   if (!d) return;
   free(d->message);
+  free(d->stable_code);
+  free(d->source_name);
+  free(d->excerpt);
   compiler_diag_init(d);
 }
 
@@ -97,7 +112,34 @@ void compiler_diag_set(CompilerDiagnostic *d, int8_t code, DiagPhase phase,
   compiler_diag_reset(d);
   d->code = code;
   d->phase = phase;
-  d->message = strdup(message ? message : "");
+  d->message = compiler_diag_strdup(message ? message : "");
+  d->stable_code = compiler_diag_strdup(compiler_diag_stable_code(code, phase));
+}
+
+void compiler_diag_set_location(CompilerDiagnostic *d, int line, int column, int span) {
+  if (!d) return;
+  d->line = line;
+  d->column = column;
+  d->span = span;
+  d->has_loc = line > 0 && column > 0;
+}
+
+void compiler_diag_set_source_name(CompilerDiagnostic *d, const char *source_name) {
+  if (!d) return;
+  free(d->source_name);
+  d->source_name = compiler_diag_strdup(source_name ? source_name : "");
+}
+
+void compiler_diag_set_excerpt(CompilerDiagnostic *d, const char *excerpt) {
+  if (!d) return;
+  free(d->excerpt);
+  d->excerpt = compiler_diag_strdup(excerpt ? excerpt : "");
+}
+
+const char *compiler_diag_stable_code(int8_t errnum, DiagPhase phase) {
+  static char buf[32];
+  snprintf(buf, sizeof(buf), "SIN-%s-%04d", compiler_diag_phase_name(phase), errnum);
+  return buf;
 }
 
 const char *compiler_diag_phase_name(DiagPhase p) {

--- a/src/compiler/compdiag.h
+++ b/src/compiler/compdiag.h
@@ -29,6 +29,9 @@ typedef struct {
   int8_t code;
   DiagPhase phase;
   char *message;
+  char *stable_code;
+  char *source_name;
+  char *excerpt;
   int line, column, span;
   bool has_loc;
 } CompilerDiagnostic;
@@ -36,4 +39,8 @@ typedef struct {
 void compiler_diag_init(CompilerDiagnostic *d);
 void compiler_diag_reset(CompilerDiagnostic *d);
 void compiler_diag_set(CompilerDiagnostic *d, int8_t code, DiagPhase phase, const char *message);
+void compiler_diag_set_location(CompilerDiagnostic *d, int line, int column, int span);
+void compiler_diag_set_source_name(CompilerDiagnostic *d, const char *source_name);
+void compiler_diag_set_excerpt(CompilerDiagnostic *d, const char *excerpt);
+const char *compiler_diag_stable_code(int8_t errnum, DiagPhase phase);
 const char *compiler_diag_phase_name(DiagPhase p);

--- a/src/compiler/compiler_pipeline.c
+++ b/src/compiler/compiler_pipeline.c
@@ -105,10 +105,33 @@ static DiagPhase phase_from_detail(const char *d){
   return DIAG_PHASE_NONE;
 }
 
+static char *first_source_line(const char *source, size_t len) {
+  if (!source) return NULL;
+  size_t line_len = 0;
+  while (line_len < len && source[line_len] != '\n' && source[line_len] != '\r') {
+    line_len++;
+  }
+  char *line = malloc(line_len + 1);
+  if (!line) return NULL;
+  memcpy(line, source, line_len);
+  line[line_len] = '\0';
+  return line;
+}
+
 int8_t compile_source_to_bytecode_diag(const char *source, size_t len, OUTPUT_t **out, CompilerDiagnostic *out_diag){
  char *errdetail=NULL;
  int8_t rc = compile_source_to_bytecode(source,len,out,&errdetail);
- if(out_diag){ compiler_diag_reset(out_diag); if(rc!=ERR_NOERROR){ compiler_diag_set(out_diag,rc,phase_from_detail(errdetail),errdetail?errdetail:""); }}
+ if(out_diag){
+  compiler_diag_reset(out_diag);
+  if(rc!=ERR_NOERROR){
+   compiler_diag_set(out_diag,rc,phase_from_detail(errdetail),errdetail?errdetail:"");
+   compiler_diag_set_source_name(out_diag,"<memory>");
+   compiler_diag_set_location(out_diag,1,1,1);
+   char *excerpt = first_source_line(source,len);
+   compiler_diag_set_excerpt(out_diag,excerpt?excerpt:"");
+   free(excerpt);
+  }
+ }
  if(errdetail) free(errdetail);
  return rc;
 }

--- a/tests/compiler/test_compiler_diag_pipeline.c
+++ b/tests/compiler/test_compiler_diag_pipeline.c
@@ -6,9 +6,17 @@
 void test_compiler_diag_pipeline(void){
   OUTPUT_t *out=NULL; CompilerDiagnostic d; compiler_diag_init(&d);
   int8_t rc = compile_source_to_bytecode_diag("^;",2,&out,&d);
-  ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, rc); ASSERT_EQ_INT(DIAG_PHASE_PARSE, d.phase); ASSERT_NOT_NULL(d.message);
+  ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, rc); ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, d.code); ASSERT_EQ_INT(DIAG_PHASE_PARSE, d.phase); ASSERT_NOT_NULL(d.message);
+  ASSERT_NOT_NULL(d.stable_code); ASSERT_TRUE(strcmp("SIN-PARSE-0005", d.stable_code)==0);
+  ASSERT_NOT_NULL(d.source_name); ASSERT_TRUE(strcmp("<memory>", d.source_name)==0);
+  ASSERT_EQ_INT(1, d.line); ASSERT_EQ_INT(1, d.column); ASSERT_TRUE(d.has_loc);
+  ASSERT_NOT_NULL(d.excerpt); ASSERT_TRUE(strcmp("^;", d.excerpt)==0);
   compiler_diag_reset(&d);
   rc = compile_source_to_bytecode_diag("@x;",3,&out,&d);
-  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc); ASSERT_EQ_INT(DIAG_PHASE_SEMANT, d.phase); ASSERT_NOT_NULL(d.message);
+  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc); ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, d.code); ASSERT_EQ_INT(DIAG_PHASE_SEMANT, d.phase); ASSERT_NOT_NULL(d.message);
+  ASSERT_NOT_NULL(d.stable_code); ASSERT_TRUE(strcmp("SIN-SEMANT-0004", d.stable_code)==0);
+  ASSERT_NOT_NULL(d.source_name); ASSERT_TRUE(strcmp("<memory>", d.source_name)==0);
+  ASSERT_EQ_INT(1, d.line); ASSERT_EQ_INT(1, d.column); ASSERT_TRUE(d.has_loc);
+  ASSERT_NOT_NULL(d.excerpt); ASSERT_TRUE(strcmp("@x;", d.excerpt)==0);
   compiler_diag_reset(&d);
 }


### PR DESCRIPTION
### Motivation
- Provide deterministic, machine-friendly diagnostic identifiers and richer provenance for compiler diagnostics by adding owned metadata to the diagnostic object.
- Keep the existing numeric `code` so existing `ERR_*` consumers remain compatible while introducing stable identifiers independent of localized text.
- Give callers APIs to populate location, source name, and source excerpts so pipelines can return richer, structured diagnostic payloads.

### Description
- Extended `CompilerDiagnostic` with owned `char *` fields: `stable_code`, `source_name`, and `excerpt`, and kept the numeric `code` and `phase` fields (`compdiag.h`).
- Added helper APIs: `compiler_diag_set_location`, `compiler_diag_set_source_name`, `compiler_diag_set_excerpt`, and `compiler_diag_stable_code` and declared them in the header (`compdiag.h`).
- Implemented allocation/freeing helpers and updated `compiler_diag_init`, `compiler_diag_reset`, and `compiler_diag_set` to initialize, free, and populate the owned fields safely (`compdiag.c`), and produce a deterministic stable code string of the form `SIN-<PHASE>-<zero-padded-code>`.
- Populated diagnostic provenance in the compiler pipeline by filling `source_name` (`"<memory>"`), a default location, and capturing the first source line as `excerpt` in `compile_source_to_bytecode_diag` (`compiler_pipeline.c`).
- Updated tests (`tests/compiler/test_compiler_diag_pipeline.c`) to assert `stable_code`, `source_name`, `line`, `column`, `excerpt`, `phase`, and the retained numeric `code`.

### Testing
- Ran the full test suite with `make test`, and the test harness completed with all tests passing (`tests=123/123`, summary `PASS`).
- The updated `tests/compiler/test_compiler_diag_pipeline.c` executed as part of the suite and passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474ec00770832e95de7acd1e2c9d7e)