### PR TITLE
Track parser diagnostic locations

### DIFF
--- a/src/compiler/compiler_pipeline.c
+++ b/src/compiler/compiler_pipeline.c
@@ -118,20 +118,56 @@ static char *first_source_line(const char *source, size_t len) {
   return line;
 }
 
-int8_t compile_source_to_bytecode_diag(const char *source, size_t len, OUTPUT_t **out, CompilerDiagnostic *out_diag){
- char *errdetail=NULL;
- int8_t rc = compile_source_to_bytecode(source,len,out,&errdetail);
- if(out_diag){
-  compiler_diag_reset(out_diag);
-  if(rc!=ERR_NOERROR){
-   compiler_diag_set(out_diag,rc,phase_from_detail(errdetail),errdetail?errdetail:"");
-   compiler_diag_set_source_name(out_diag,"<memory>");
-   compiler_diag_set_location(out_diag,1,1,1);
-   char *excerpt = first_source_line(source,len);
-   compiler_diag_set_excerpt(out_diag,excerpt?excerpt:"");
-   free(excerpt);
+int8_t compile_source_to_bytecode_diag(const char *source, size_t len, OUTPUT_t **out, CompilerDiagnostic *out_diag) {
+  char *errdetail = NULL;
+  CompilerContext ctx;
+  SCANNER_STATE_t parse_state = {0};
+  int8_t rc = ERR_NOERROR;
+
+  if (out) *out = NULL;
+  compiler_context_init(&ctx, source, len);
+
+  if (!source || !out) {
+    rc = ERR_COMP_SYNTAX;
+    errdetail = strdup("compile: invalid source or output");
+  } else if (compiler_context_prepare_bytecode_output(&ctx, 1024) != 0) {
+    rc = ERR_COMP_SYNTAX;
+    errdetail = strdup("compile: bytecode output allocation failed");
+  } else {
+    ctx.sem_ctx = sem_create_ctx();
+    ParseInput input = {ctx.source, ctx.source_len, "<memory>"};
+    rc = parse_source_diag(&input, &ctx.ast_root, &errdetail, &parse_state);
+    if (rc == ERR_NOERROR) rc = sem_check_locals(ctx.ast_root, &errdetail, ctx.sem_ctx);
+    if (rc == ERR_NOERROR) rc = lower_ast_to_ir(ctx.ast_root, ctx.sem_ctx, &ctx.ir_unit, &errdetail);
+    if (rc == ERR_NOERROR) rc = ir_validate(ctx.ir_unit, ctx.sem_ctx->count, &errdetail);
+    if (rc == ERR_NOERROR) {
+      rc = emit_bytecode(ctx.ir_unit, (uint8_t)ctx.sem_ctx->count, 0, ctx.bytecode_out, &errdetail);
+    }
+    if (rc == ERR_NOERROR) {
+      *out = ctx.bytecode_out;
+      ctx.bytecode_out = NULL;
+    }
   }
- }
- if(errdetail) free(errdetail);
- return rc;
+
+  if (out_diag) {
+    compiler_diag_reset(out_diag);
+    if (rc != ERR_NOERROR) {
+      DiagPhase phase = rc == ERR_COMP_SYNTAX || rc == ERR_COMP_UNKNOWNCHAR ? DIAG_PHASE_PARSE : phase_from_detail(errdetail);
+      compiler_diag_set(out_diag, rc, phase, errdetail ? errdetail : "");
+      compiler_diag_set_source_name(out_diag, "<memory>");
+      if (phase == DIAG_PHASE_PARSE && parse_state.line > 0) {
+        compiler_diag_set_location(out_diag, parse_state.line, parse_state.column, parse_state.span);
+      } else {
+        compiler_diag_set_location(out_diag, 1, 1, 1);
+      }
+      char *excerpt = first_source_line(source, len);
+      compiler_diag_set_excerpt(out_diag, excerpt ? excerpt : "");
+      free(excerpt);
+    }
+  }
+
+  free(errdetail);
+  free(parse_state.offending_token);
+  compiler_context_destroy(&ctx);
+  return rc;
 }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -5,6 +5,45 @@
   #include "log.h"
   #include "parser.h"
 
+  static int sin_utf8_columns(const char *text, int len) {
+    int cols = 0;
+    for (int i = 0; i < len; ++i) {
+      unsigned char c = (unsigned char)text[i];
+      if (c == '\n') continue;
+      if ((c & 0xC0) != 0x80) cols++;
+    }
+    return cols > 0 ? cols : 1;
+  }
+
+  static void sin_update_location(YYLTYPE *loc, SCANNER_STATE_t *state, const char *text, int len) {
+    if (!state || !loc) return;
+    loc->first_line = state->line;
+    loc->first_column = state->column;
+    int line = state->line;
+    int column = state->column;
+    int token_first_column = column;
+    int token_last_line = line;
+    int token_last_column = column;
+    for (int i = 0; i < len; ++i) {
+      unsigned char c = (unsigned char)text[i];
+      token_last_line = line;
+      token_last_column = column;
+      if (c == '\n') {
+        line++;
+        column = 1;
+      } else if ((c & 0xC0) != 0x80) {
+        column++;
+      }
+    }
+    loc->last_line = token_last_line;
+    loc->last_column = token_last_column;
+    state->line = line;
+    state->column = column;
+    state->span = token_last_line == loc->first_line ? token_last_column - token_first_column + 1 : sin_utf8_columns(text, len);
+  }
+
+  #define YY_USER_ACTION sin_update_location(yylloc, yyextra, yytext, yyleng);
+
   void str_append_str(char **buf, char **bufptr,
                       int *len, int *max, char *append) {
     // A helper function for string handling.
@@ -52,7 +91,7 @@
   }
 %}
 
-%option noinput nounput noyywrap reentrant bison-bridge case-insensitive
+%option noinput nounput noyywrap reentrant bison-bridge bison-locations case-insensitive extra-type="SCANNER_STATE_t *"
 %x STRINGLIT
 %x CODE
 %x CODEBODY

--- a/src/parser.y
+++ b/src/parser.y
@@ -6,6 +6,7 @@
 
 
 %define api.pure full
+%locations
 %lex-param {void *scanner}
 %parse-param {void *scanner}{SCANNER_STATE_t *state}
 
@@ -27,9 +28,14 @@
     char *errdetail;
     AS_NODE *absyn;
     const char *source_name;
+    int line;
+    int column;
+    int span;
+    char *offending_token;
   } SCANNER_STATE_t;
 
   int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail);
+  int8_t parse_source_diag(const ParseInput *input, AS_NODE **absyn, char **errdetail, SCANNER_STATE_t *out_state);
 }
 
 %{
@@ -45,9 +51,10 @@
 #include "libcall.h"
 
 typedef void *yyscan_t;
-int yylex (YYSTYPE *yylval_param, yyscan_t yyscanner);
+int yylex (YYSTYPE *yylval_param, YYLTYPE *yylloc_param, yyscan_t yyscanner);
 int yylex_init(yyscan_t* scanner);
 void yyset_in(FILE *_in_str, yyscan_t yyscanner);
+void yyset_extra(SCANNER_STATE_t *user_defined, yyscan_t yyscanner);
 int yylex_destroy(yyscan_t yyscanner);
 int yyparse();
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
@@ -73,10 +80,15 @@ static AS_NODE *as_new_unary_minus_node(AS_NODE *operand) {
   return as_new_node(N_SUB, as_new_intnode(0), operand);
 }
 
-void yyerror(yyscan_t locp, SCANNER_STATE_t *state, char const *s) {
+void yyerror(YYLTYPE *locp, yyscan_t scanner, SCANNER_STATE_t *state, char const *s) {
   // yyerror() is called whenever there is a syntax error, so we need to
   // set the error number in the state appropriately.
-  (void)locp;
+  (void)scanner;
+  if (locp && state->errnum == ERR_NOERROR) {
+    state->line = locp->first_line;
+    state->column = locp->first_column;
+    state->span = locp->last_column >= locp->first_column ? locp->last_column - locp->first_column + 1 : 1;
+  }
   if (state->errnum == ERR_NOERROR) {
     // This might have been set already so don't clobber it if it has
     state->errnum = ERR_COMP_SYNTAX;
@@ -94,7 +106,7 @@ void yyerror(yyscan_t locp, SCANNER_STATE_t *state, char const *s) {
   }
 }
 
-int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail) {
+int8_t parse_source_diag(const ParseInput *input, AS_NODE **absyn, char **errdetail, SCANNER_STATE_t *out_state) {
   // Compile the given string.
   // Returns 0 if successful or > 0 (error number) if not.
   // source holds the source input string
@@ -107,10 +119,15 @@ int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail) 
   scanner_state.errnum = ERR_NOERROR;
   scanner_state.errdetail = NULL;
   scanner_state.absyn = NULL;
+  scanner_state.line = 1;
+  scanner_state.column = 1;
+  scanner_state.span = 1;
+  scanner_state.offending_token = NULL;
   if (!input || !input->data || !absyn || !errdetail) {
     return ERR_COMP_SYNTAX;
   }
   scanner_state.source_name = input->source_name;
+  yyset_extra(&scanner_state, sc);
   YY_BUFFER_STATE in = yy_scan_bytes(input->data, (int)input->len, sc);
 
   bool failed = yyparse(sc, &scanner_state);
@@ -125,13 +142,25 @@ int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail) 
       scanner_state.absyn = NULL;
     }
     *errdetail = scanner_state.errdetail;
+    scanner_state.errdetail = NULL;
+    if (out_state) *out_state = scanner_state;
+    else free(scanner_state.offending_token);
     return scanner_state.errnum;
   } else {
     // scanner_state.absyn now points to the root of the abstract syntax tree
     *absyn = scanner_state.absyn;
     *errdetail = NULL;
+    if (out_state) *out_state = scanner_state;
+    else free(scanner_state.offending_token);
     return 0;
   }
+}
+
+int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail) {
+  SCANNER_STATE_t state;
+  int8_t rc = parse_source_diag(input, absyn, errdetail, &state);
+  free(state.offending_token);
+  return rc;
 }
 
 %}
@@ -233,6 +262,11 @@ expr:     TLOCAL { $$ = as_new_valnode(V_LOCAL, $1); }
         | TUNKNOWNCHAR { $$ = NULL;
                          state->errnum = ERR_COMP_UNKNOWNCHAR;
                          state->errdetail = $1;
+                         state->line = @1.first_line;
+                         state->column = @1.first_column;
+                         state->span = @1.last_column >= @1.first_column ? @1.last_column - @1.first_column + 1 : 1;
+                         free(state->offending_token);
+                         state->offending_token = strdup($1 ? $1 : "");
                          YYERROR;
                        }
         ;

--- a/tests/compiler/test_compiler_diag_pipeline.c
+++ b/tests/compiler/test_compiler_diag_pipeline.c
@@ -20,7 +20,8 @@ void test_compiler_diag_pipeline(void){
   ASSERT_NOT_NULL(d.excerpt); ASSERT_TRUE(strcmp("@x;", d.excerpt)==0);
 
   compiler_diag_reset(&d);
-  rc = compile_source_to_bytecode_diag("@x = 1;\n@yy = 2;\n@z = ;", 25, &out, &d);
+  const char *syntax_source = "@x = 1;\n@yy = 2;\n@z = ;";
+  rc = compile_source_to_bytecode_diag(syntax_source, strlen(syntax_source), &out, &d);
   ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
   ASSERT_EQ_INT(DIAG_PHASE_PARSE, d.phase);
   ASSERT_EQ_INT(3, d.line);
@@ -29,7 +30,8 @@ void test_compiler_diag_pipeline(void){
   ASSERT_TRUE(d.has_loc);
 
   compiler_diag_reset(&d);
-  rc = compile_source_to_bytecode_diag("@x = 1;\n@yy = 2;\n☃;", 22, &out, &d);
+  const char *unknown_source = "@x = 1;\n@yy = 2;\n☃;";
+  rc = compile_source_to_bytecode_diag(unknown_source, strlen(unknown_source), &out, &d);
   ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, rc);
   ASSERT_EQ_INT(DIAG_PHASE_PARSE, d.phase);
   ASSERT_EQ_INT(3, d.line);

--- a/tests/compiler/test_compiler_diag_pipeline.c
+++ b/tests/compiler/test_compiler_diag_pipeline.c
@@ -18,5 +18,23 @@ void test_compiler_diag_pipeline(void){
   ASSERT_NOT_NULL(d.source_name); ASSERT_TRUE(strcmp("<memory>", d.source_name)==0);
   ASSERT_EQ_INT(1, d.line); ASSERT_EQ_INT(1, d.column); ASSERT_TRUE(d.has_loc);
   ASSERT_NOT_NULL(d.excerpt); ASSERT_TRUE(strcmp("@x;", d.excerpt)==0);
+
+  compiler_diag_reset(&d);
+  rc = compile_source_to_bytecode_diag("@x = 1;\n@yy = 2;\n@z = ;", 25, &out, &d);
+  ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
+  ASSERT_EQ_INT(DIAG_PHASE_PARSE, d.phase);
+  ASSERT_EQ_INT(3, d.line);
+  ASSERT_EQ_INT(6, d.column);
+  ASSERT_EQ_INT(1, d.span);
+  ASSERT_TRUE(d.has_loc);
+
+  compiler_diag_reset(&d);
+  rc = compile_source_to_bytecode_diag("@x = 1;\n@yy = 2;\n☃;", 22, &out, &d);
+  ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, rc);
+  ASSERT_EQ_INT(DIAG_PHASE_PARSE, d.phase);
+  ASSERT_EQ_INT(3, d.line);
+  ASSERT_EQ_INT(1, d.column);
+  ASSERT_EQ_INT(1, d.span);
+  ASSERT_TRUE(d.has_loc);
   compiler_diag_reset(&d);
 }


### PR DESCRIPTION
### Motivation
- Provide precise parser diagnostic locations (line, column, span) for syntax and unknown-character errors, including multi-line sources and multibyte tokens.
- Thread scanner-owned location state through the lexer and parser so diagnostics contain structured location and offending token text instead of ad-hoc `errdetail` strings.

### Description
- Enable Bison location tracking with `%locations` and extend `SCANNER_STATE_t` with `line`, `column`, `span`, and `offending_token` fields and a new `parse_source_diag` API to return scanner state to callers.
- Change `yyerror` signature to accept `YYLTYPE *locp` and copy `locp` into the scanner state when an error occurs, and record offending token text for `TUNKNOWNCHAR` reductions.
- Integrate Flex location updates via `YY_USER_ACTION` using a new `sin_update_location` helper and `sin_utf8_columns` to compute columns correctly for UTF-8 multibyte tokens, and expose `yyset_extra` to attach `SCANNER_STATE_t` to the scanner.
- Thread parser locations through the compiler pipeline by calling `parse_source_diag` from `compile_source_to_bytecode_diag` and setting `CompilerDiagnostic` location/excerpt from the returned parse state.
- Add parser-negative tests in `tests/compiler/test_compiler_diag_pipeline.c` that assert exact line/column/span for malformed multi-line source and for a multi-byte unknown-character token.

### Testing
- Ran the full test suite with `make test` and all tests passed (`123/123`).
- The new negative parser tests (`tests/compiler/test_compiler_diag_pipeline.c`) executed and validated the reported parse locations. 
- Ran repository checks including `git diff --check` as part of validation and there were no whitespace/format errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47f8e5e638832ea69cec69eacc31b9)