### PR TITLE
Preserve ParseInput source names in compiler pipeline

### DIFF
--- a/src/compiler/compiler_pipeline.c
+++ b/src/compiler/compiler_pipeline.c
@@ -10,18 +10,27 @@
 #include "parser.h"
 #include <stdlib.h>
 
-int8_t compile_source_to_bytecode_with_params(const char *source, size_t len,
-                                              const char **params, size_t param_count,
-                                              OUTPUT_t **out, char **errdetail) {
+static const char *default_source_name(const ParseInput *input) {
+  return input && input->source_name ? input->source_name : "<memory>";
+}
+
+static ParseInput make_default_parse_input(const char *source, size_t len) {
+  ParseInput input = {source, len, "<memory>"};
+  return input;
+}
+
+static int8_t compile_parse_input_to_bytecode_with_params(const ParseInput *input,
+                                                          const char **params, size_t param_count,
+                                                          OUTPUT_t **out, char **errdetail) {
   CompilerContext ctx;
   int8_t rc = ERR_NOERROR;
 
-  if (!source || !out) {
+  if (!input || !input->data || !out) {
     return ERR_COMP_SYNTAX;
   }
 
   *out = NULL;
-  compiler_context_init(&ctx, source, len);
+  compiler_context_init(&ctx, input->data, input->len);
 
   if (compiler_context_prepare_bytecode_output(&ctx, 1024) != 0) {
     rc = ERR_COMP_SYNTAX;
@@ -29,8 +38,8 @@ int8_t compile_source_to_bytecode_with_params(const char *source, size_t len,
   }
 
   ctx.sem_ctx = sem_create_ctx();
-  ParseInput input = {ctx.source, ctx.source_len, "<memory>"};
-  rc = parse_source(&input, &ctx.ast_root, errdetail);
+  ParseInput parse_input = {ctx.source, ctx.source_len, default_source_name(input)};
+  rc = parse_source(&parse_input, &ctx.ast_root, errdetail);
   if (rc != ERR_NOERROR) {
     goto done;
   }
@@ -84,13 +93,19 @@ done:
   return rc;
 }
 
+int8_t compile_source_to_bytecode_with_params(const char *source, size_t len,
+                                              const char **params, size_t param_count,
+                                              OUTPUT_t **out, char **errdetail) {
+  ParseInput input = make_default_parse_input(source, len);
+  return compile_parse_input_to_bytecode_with_params(&input, params, param_count, out, errdetail);
+}
+
 int8_t compile_source_to_bytecode(const char *source, size_t len, OUTPUT_t **out, char **errdetail) {
   return compile_source_to_bytecode_with_params(source, len, NULL, 0, out, errdetail);
 }
 
 int8_t compile_parse_input_to_bytecode(const ParseInput *input, OUTPUT_t **out, char **errdetail) {
-  if (!input) return ERR_COMP_SYNTAX;
-  return compile_source_to_bytecode(input->data, input->len, out, errdetail);
+  return compile_parse_input_to_bytecode_with_params(input, NULL, 0, out, errdetail);
 }
 
 #include <string.h>
@@ -118,16 +133,17 @@ static char *first_source_line(const char *source, size_t len) {
   return line;
 }
 
-int8_t compile_source_to_bytecode_diag(const char *source, size_t len, OUTPUT_t **out, CompilerDiagnostic *out_diag) {
+int8_t compile_parse_input_to_bytecode_diag(const ParseInput *input, OUTPUT_t **out, CompilerDiagnostic *out_diag) {
   char *errdetail = NULL;
   CompilerContext ctx;
   SCANNER_STATE_t parse_state = {0};
   int8_t rc = ERR_NOERROR;
+  const char *source_name = default_source_name(input);
 
   if (out) *out = NULL;
-  compiler_context_init(&ctx, source, len);
+  compiler_context_init(&ctx, input ? input->data : NULL, input ? input->len : 0);
 
-  if (!source || !out) {
+  if (!input || !input->data || !out) {
     rc = ERR_COMP_SYNTAX;
     errdetail = strdup("compile: invalid source or output");
   } else if (compiler_context_prepare_bytecode_output(&ctx, 1024) != 0) {
@@ -135,8 +151,8 @@ int8_t compile_source_to_bytecode_diag(const char *source, size_t len, OUTPUT_t 
     errdetail = strdup("compile: bytecode output allocation failed");
   } else {
     ctx.sem_ctx = sem_create_ctx();
-    ParseInput input = {ctx.source, ctx.source_len, "<memory>"};
-    rc = parse_source_diag(&input, &ctx.ast_root, &errdetail, &parse_state);
+    ParseInput parse_input = {ctx.source, ctx.source_len, source_name};
+    rc = parse_source_diag(&parse_input, &ctx.ast_root, &errdetail, &parse_state);
     if (rc == ERR_NOERROR) rc = sem_check_locals(ctx.ast_root, &errdetail, ctx.sem_ctx);
     if (rc == ERR_NOERROR) rc = lower_ast_to_ir(ctx.ast_root, ctx.sem_ctx, &ctx.ir_unit, &errdetail);
     if (rc == ERR_NOERROR) rc = ir_validate(ctx.ir_unit, ctx.sem_ctx->count, &errdetail);
@@ -154,13 +170,13 @@ int8_t compile_source_to_bytecode_diag(const char *source, size_t len, OUTPUT_t 
     if (rc != ERR_NOERROR) {
       DiagPhase phase = rc == ERR_COMP_SYNTAX || rc == ERR_COMP_UNKNOWNCHAR ? DIAG_PHASE_PARSE : phase_from_detail(errdetail);
       compiler_diag_set(out_diag, rc, phase, errdetail ? errdetail : "");
-      compiler_diag_set_source_name(out_diag, "<memory>");
+      compiler_diag_set_source_name(out_diag, source_name);
       if (phase == DIAG_PHASE_PARSE && parse_state.line > 0) {
         compiler_diag_set_location(out_diag, parse_state.line, parse_state.column, parse_state.span);
       } else {
         compiler_diag_set_location(out_diag, 1, 1, 1);
       }
-      char *excerpt = first_source_line(source, len);
+      char *excerpt = first_source_line(input ? input->data : NULL, input ? input->len : 0);
       compiler_diag_set_excerpt(out_diag, excerpt ? excerpt : "");
       free(excerpt);
     }
@@ -170,4 +186,9 @@ int8_t compile_source_to_bytecode_diag(const char *source, size_t len, OUTPUT_t 
   free(parse_state.offending_token);
   compiler_context_destroy(&ctx);
   return rc;
+}
+
+int8_t compile_source_to_bytecode_diag(const char *source, size_t len, OUTPUT_t **out, CompilerDiagnostic *out_diag) {
+  ParseInput input = make_default_parse_input(source, len);
+  return compile_parse_input_to_bytecode_diag(&input, out, out_diag);
 }

--- a/src/compiler/compiler_pipeline.h
+++ b/src/compiler/compiler_pipeline.h
@@ -15,4 +15,5 @@ int8_t compile_source_to_bytecode(const char *source, size_t len, OUTPUT_t **out
 int8_t compile_parse_input_to_bytecode(const ParseInput *input, OUTPUT_t **out, char **errdetail);
 int8_t compile_source_to_bytecode_with_params(const char *source, size_t len, const char **params, size_t param_count, OUTPUT_t **out, char **errdetail);
 int8_t compile_source_to_bytecode_diag(const char *source, size_t len, OUTPUT_t **out, CompilerDiagnostic *out_diag);
+int8_t compile_parse_input_to_bytecode_diag(const ParseInput *input, OUTPUT_t **out, CompilerDiagnostic *out_diag);
 

--- a/tests/compiler/test_compiler_diag_pipeline.c
+++ b/tests/compiler/test_compiler_diag_pipeline.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdlib.h>
 #include "compiler_pipeline.h"
 #include "error.h"
 #include "test_assert.h"
@@ -38,5 +39,23 @@ void test_compiler_diag_pipeline(void){
   ASSERT_EQ_INT(1, d.column);
   ASSERT_EQ_INT(1, d.span);
   ASSERT_TRUE(d.has_loc);
+
+  compiler_diag_reset(&d);
+  const char *named_source = "@x = ;";
+  ParseInput named_input = {named_source, strlen(named_source), "custom_source.sin"};
+  char *errdetail = NULL;
+  rc = compile_parse_input_to_bytecode(&named_input, &out, &errdetail);
+  ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
+  ASSERT_NOT_NULL(errdetail);
+  ASSERT_TRUE(strstr(errdetail, "custom_source.sin") != NULL);
+  free(errdetail);
+
+  compiler_diag_reset(&d);
+  rc = compile_parse_input_to_bytecode_diag(&named_input, &out, &d);
+  ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
+  ASSERT_NOT_NULL(d.source_name);
+  ASSERT_TRUE(strcmp("custom_source.sin", d.source_name)==0);
+  ASSERT_NOT_NULL(d.message);
+  ASSERT_TRUE(strstr(d.message, "custom_source.sin") != NULL);
   compiler_diag_reset(&d);
 }


### PR DESCRIPTION
### Motivation
- Ensure the compiler pipeline can accept a full `ParseInput` so callers can supply a custom `source_name` that is preserved through parsing and diagnostics.

### Description
- Refactored the core pipeline to a `ParseInput`-based implementation by adding `compile_parse_input_to_bytecode_with_params` and helper functions `default_source_name` and `make_default_parse_input` so string-based APIs can still wrap inputs with `"<memory>"`.
- Made `compile_source_to_bytecode_with_params` and `compile_source_to_bytecode_diag` wrap the original `source`/`len` into a `ParseInput` using `"<memory>"` and delegate to the new ParseInput-based functions.
- Implemented `compile_parse_input_to_bytecode_diag` to pass `input->source_name` through to `parse_source_diag` and to set `CompilerDiagnostic.source_name` and message excerpts based on the provided `ParseInput`.
- Updated the public header `src/compiler/compiler_pipeline.h` and added tests in `tests/compiler/test_compiler_diag_pipeline.c` that call `compile_parse_input_to_bytecode` and `compile_parse_input_to_bytecode_diag` with a custom source name and assert diagnostics preserve it.

### Testing
- Ran the full test suite with `make test`, which completed successfully and reported all tests passing including the updated `tests/compiler/test_compiler_diag_pipeline.c`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47fd607e9c832e9097496f0f39e957)