### PR TITLE
Add structured compiler diagnostics by stage

### DIFF
--- a/src/compiler/compdiag.c
+++ b/src/compiler/compdiag.c
@@ -39,6 +39,28 @@ bool compdiag_set_once(int8_t *current_errnum, char **errdetail,
   return true;
 }
 
+
+bool compdiag_set_once_diag(int8_t *current_errnum, char **errdetail,
+                            CompilerDiagnostic *diag, int8_t new_errnum,
+                            DiagPhase diag_phase, const char *phase,
+                            const char *detail) {
+  if (!current_errnum || *current_errnum != ERR_NOERROR) return false;
+
+  *current_errnum = new_errnum;
+  char *formatted = compdiag_alloc_detail(phase, detail);
+  if (errdetail) {
+    compdiag_reset_detail(errdetail);
+    *errdetail = formatted;
+  }
+  if (diag) {
+    compiler_diag_set(diag, new_errnum, diag_phase, formatted ? formatted : detail);
+  }
+  if (!errdetail && formatted) {
+    size_t len = strlen(formatted);
+    FREE_ARRAY(char, formatted, len + 1);
+  }
+  return true;
+}
 bool compdiag_setf_once(int8_t *current_errnum, char **errdetail,
                         int8_t new_errnum, const char *phase,
                         const char *fmt, ...) {
@@ -68,6 +90,37 @@ bool compdiag_setf_once(int8_t *current_errnum, char **errdetail,
   return recorded;
 }
 
+
+bool compdiag_setf_once_diag(int8_t *current_errnum, char **errdetail,
+                             CompilerDiagnostic *diag, int8_t new_errnum,
+                             DiagPhase diag_phase, const char *phase,
+                             const char *fmt, ...) {
+  if (!current_errnum || *current_errnum != ERR_NOERROR) return false;
+
+  va_list args;
+  va_start(args, fmt);
+  int needed = vsnprintf(NULL, 0, fmt, args);
+  va_end(args);
+  if (needed < 0) {
+    return compdiag_set_once_diag(current_errnum, errdetail, diag, new_errnum,
+                                  diag_phase, phase, "formatting error");
+  }
+
+  char *msg = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+  if (!msg) {
+    return compdiag_set_once_diag(current_errnum, errdetail, diag, new_errnum,
+                                  diag_phase, phase, "out of memory");
+  }
+
+  va_start(args, fmt);
+  vsnprintf(msg, (size_t)needed + 1, fmt, args);
+  va_end(args);
+
+  bool recorded = compdiag_set_once_diag(current_errnum, errdetail, diag,
+                                         new_errnum, diag_phase, phase, msg);
+  FREE_ARRAY(char, msg, (size_t)needed + 1);
+  return recorded;
+}
 void compdiag_reset_detail(char **errdetail) {
   if (!errdetail || !*errdetail) return;
 
@@ -154,6 +207,8 @@ const char *compiler_diag_phase_name(DiagPhase p) {
       return "IR_VALIDATE";
     case DIAG_PHASE_EMITBC:
       return "EMITBC";
+    case DIAG_PHASE_COMPILE:
+      return "COMPILE";
     case DIAG_PHASE_IO:
       return "IO";
     default:

--- a/src/compiler/compdiag.h
+++ b/src/compiler/compdiag.h
@@ -7,14 +7,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-bool compdiag_set_once(int8_t *current_errnum, char **errdetail,
-                       int8_t new_errnum, const char *phase,
-                       const char *detail);
-bool compdiag_setf_once(int8_t *current_errnum, char **errdetail,
-                        int8_t new_errnum, const char *phase,
-                        const char *fmt, ...);
-void compdiag_reset_detail(char **errdetail);
-
 typedef enum {
   DIAG_PHASE_NONE = 0,
   DIAG_PHASE_PARSE,
@@ -22,6 +14,7 @@ typedef enum {
   DIAG_PHASE_LOWER,
   DIAG_PHASE_IR_VALIDATE,
   DIAG_PHASE_EMITBC,
+  DIAG_PHASE_COMPILE,
   DIAG_PHASE_IO
 } DiagPhase;
 
@@ -35,6 +28,22 @@ typedef struct {
   int line, column, span;
   bool has_loc;
 } CompilerDiagnostic;
+
+bool compdiag_set_once(int8_t *current_errnum, char **errdetail,
+                       int8_t new_errnum, const char *phase,
+                       const char *detail);
+bool compdiag_set_once_diag(int8_t *current_errnum, char **errdetail,
+                            CompilerDiagnostic *diag, int8_t new_errnum,
+                            DiagPhase diag_phase, const char *phase,
+                            const char *detail);
+bool compdiag_setf_once(int8_t *current_errnum, char **errdetail,
+                        int8_t new_errnum, const char *phase,
+                        const char *fmt, ...);
+bool compdiag_setf_once_diag(int8_t *current_errnum, char **errdetail,
+                             CompilerDiagnostic *diag, int8_t new_errnum,
+                             DiagPhase diag_phase, const char *phase,
+                             const char *fmt, ...);
+void compdiag_reset_detail(char **errdetail);
 
 void compiler_diag_init(CompilerDiagnostic *d);
 void compiler_diag_reset(CompilerDiagnostic *d);

--- a/src/compiler/compiler_pipeline.c
+++ b/src/compiler/compiler_pipeline.c
@@ -110,16 +110,6 @@ int8_t compile_parse_input_to_bytecode(const ParseInput *input, OUTPUT_t **out, 
 
 #include <string.h>
 
-static DiagPhase phase_from_detail(const char *d){
-  if(!d) return DIAG_PHASE_NONE;
-  if(strncmp(d,"semant:",7)==0) return DIAG_PHASE_SEMANT;
-  if(strncmp(d,"lower:",6)==0) return DIAG_PHASE_LOWER;
-  if(strncmp(d,"ir:",3)==0) return DIAG_PHASE_IR_VALIDATE;
-  if(strncmp(d,"emitbc:",7)==0) return DIAG_PHASE_EMITBC;
-  if(strstr(d,"syntax error")||strcmp(d,"^")==0) return DIAG_PHASE_PARSE;
-  return DIAG_PHASE_NONE;
-}
-
 static char *first_source_line(const char *source, size_t len) {
   if (!source) return NULL;
   size_t line_len = 0;
@@ -140,24 +130,28 @@ int8_t compile_parse_input_to_bytecode_diag(const ParseInput *input, OUTPUT_t **
   int8_t rc = ERR_NOERROR;
   const char *source_name = default_source_name(input);
 
+  if (out_diag) compiler_diag_reset(out_diag);
   if (out) *out = NULL;
   compiler_context_init(&ctx, input ? input->data : NULL, input ? input->len : 0);
 
   if (!input || !input->data || !out) {
     rc = ERR_COMP_SYNTAX;
-    errdetail = strdup("compile: invalid source or output");
+    if (out_diag) compiler_diag_set(out_diag, rc, DIAG_PHASE_COMPILE, "compile: invalid source or output");
   } else if (compiler_context_prepare_bytecode_output(&ctx, 1024) != 0) {
     rc = ERR_COMP_SYNTAX;
-    errdetail = strdup("compile: bytecode output allocation failed");
+    if (out_diag) compiler_diag_set(out_diag, rc, DIAG_PHASE_COMPILE, "compile: bytecode output allocation failed");
   } else {
     ctx.sem_ctx = sem_create_ctx();
     ParseInput parse_input = {ctx.source, ctx.source_len, source_name};
     rc = parse_source_diag(&parse_input, &ctx.ast_root, &errdetail, &parse_state);
-    if (rc == ERR_NOERROR) rc = sem_check_locals(ctx.ast_root, &errdetail, ctx.sem_ctx);
-    if (rc == ERR_NOERROR) rc = lower_ast_to_ir(ctx.ast_root, ctx.sem_ctx, &ctx.ir_unit, &errdetail);
-    if (rc == ERR_NOERROR) rc = ir_validate(ctx.ir_unit, ctx.sem_ctx->count, &errdetail);
+    if (rc != ERR_NOERROR) {
+      if (out_diag) compiler_diag_set(out_diag, rc, DIAG_PHASE_PARSE, errdetail ? errdetail : "");
+    }
+    if (rc == ERR_NOERROR) rc = sem_check_locals_diag(ctx.ast_root, &errdetail, out_diag, ctx.sem_ctx);
+    if (rc == ERR_NOERROR) rc = lower_ast_to_ir_diag(ctx.ast_root, ctx.sem_ctx, &ctx.ir_unit, &errdetail, out_diag);
+    if (rc == ERR_NOERROR) rc = ir_validate_diag(ctx.ir_unit, ctx.sem_ctx->count, &errdetail, out_diag);
     if (rc == ERR_NOERROR) {
-      rc = emit_bytecode(ctx.ir_unit, (uint8_t)ctx.sem_ctx->count, 0, ctx.bytecode_out, &errdetail);
+      rc = emit_bytecode_diag(ctx.ir_unit, (uint8_t)ctx.sem_ctx->count, 0, ctx.bytecode_out, &errdetail, out_diag);
     }
     if (rc == ERR_NOERROR) {
       *out = ctx.bytecode_out;
@@ -165,21 +159,16 @@ int8_t compile_parse_input_to_bytecode_diag(const ParseInput *input, OUTPUT_t **
     }
   }
 
-  if (out_diag) {
-    compiler_diag_reset(out_diag);
-    if (rc != ERR_NOERROR) {
-      DiagPhase phase = rc == ERR_COMP_SYNTAX || rc == ERR_COMP_UNKNOWNCHAR ? DIAG_PHASE_PARSE : phase_from_detail(errdetail);
-      compiler_diag_set(out_diag, rc, phase, errdetail ? errdetail : "");
-      compiler_diag_set_source_name(out_diag, source_name);
-      if (phase == DIAG_PHASE_PARSE && parse_state.line > 0) {
-        compiler_diag_set_location(out_diag, parse_state.line, parse_state.column, parse_state.span);
-      } else {
-        compiler_diag_set_location(out_diag, 1, 1, 1);
-      }
-      char *excerpt = first_source_line(input ? input->data : NULL, input ? input->len : 0);
-      compiler_diag_set_excerpt(out_diag, excerpt ? excerpt : "");
-      free(excerpt);
+  if (out_diag && rc != ERR_NOERROR) {
+    compiler_diag_set_source_name(out_diag, source_name);
+    if (out_diag->phase == DIAG_PHASE_PARSE && parse_state.line > 0) {
+      compiler_diag_set_location(out_diag, parse_state.line, parse_state.column, parse_state.span);
+    } else {
+      compiler_diag_set_location(out_diag, 1, 1, 1);
     }
+    char *excerpt = first_source_line(input ? input->data : NULL, input ? input->len : 0);
+    compiler_diag_set_excerpt(out_diag, excerpt ? excerpt : "");
+    free(excerpt);
   }
 
   free(errdetail);

--- a/src/compiler/emitbc.c
+++ b/src/compiler/emitbc.c
@@ -83,12 +83,13 @@ static int bw_write_bytes(BC_Writer *w, const void *src, size_t n) {
   return 1;
 }
 
-int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
-                     OUTPUT_t *out, char **errdetail) {
+int8_t emit_bytecode_diag(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
+                          OUTPUT_t *out, char **errdetail, CompilerDiagnostic *diag) {
+  if (diag) compiler_diag_reset(diag);
   if (errdetail) compdiag_reset_detail(errdetail);
   if (!ir || !out) {
     int8_t errnum = ERR_NOERROR;
-    compdiag_set_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "null input");
+    compdiag_set_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "null input");
     return errnum;
   }
 
@@ -96,7 +97,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
   size_t *pos = NULL;
   if (!alloc_grow_array((void **)&pos, 0, pos_count, sizeof(size_t))) {
     int8_t errnum = ERR_NOERROR;
-    compdiag_set_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "out of memory allocating position map");
+    compdiag_set_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "out of memory allocating position map");
     return errnum;
   }
   size_t pc = 2;
@@ -146,7 +147,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
       FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
       {
         int8_t errnum = ERR_NOERROR;
-        compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "unsupported IR op %d", in->op);
+        compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "unsupported IR op %d", in->op);
         return errnum;
       }
     }
@@ -157,7 +158,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         if (in->a < 0 || in->a > UINT8_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "%s operand a out of range for u8: %d", meta->name, in->a);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "%s operand a out of range for u8: %d", meta->name, in->a);
           return errnum;
         }
         break;
@@ -165,7 +166,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         if (in->a < 0 || in->a > UINT16_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "%s operand a out of range for u16: %d", meta->name, in->a);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "%s operand a out of range for u16: %d", meta->name, in->a);
           return errnum;
         }
         break;
@@ -173,7 +174,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         if (in->a < 0 || in->a > UINT8_MAX || in->b < 0 || in->b > UINT8_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "%s operands out of range for u8: a=%d b=%d", meta->name, in->a, in->b);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "%s operands out of range for u8: a=%d b=%d", meta->name, in->a, in->b);
           return errnum;
         }
         break;
@@ -194,7 +195,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         if (len > UINT16_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "string literal too long: %zu", len);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "string literal too long: %zu", len);
           return errnum;
         }
         if (!bw_write_u16(&w, (uint16_t)len) || !bw_write_bytes(&w, s, len)) goto oom;
@@ -221,14 +222,14 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         if (in->a < 0 || (size_t)in->a >= ir->labels.count) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "jump invalid label id %d", in->a);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "jump invalid label id %d", in->a);
           return errnum;
         }
         IR_Label *label = &ir->labels.entries[in->a];
         if (!label->bound) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "jump unbound label %d", in->a);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "jump unbound label %d", in->a);
           return errnum;
         }
         size_t from = pos[i] + 1;
@@ -237,7 +238,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         if (diff < INT16_MIN || diff > INT16_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "jump offset out of range: %ld", diff);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "jump offset out of range: %ld", diff);
           return errnum;
         }
         if (!bw_write_i16(&w, (int16_t)diff)) goto oom;
@@ -248,14 +249,14 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         if (!s) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_set_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "null layer name");
+          compdiag_set_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "null layer name");
           return errnum;
         }
         size_t len = strlen(s);
         if (len > UINT8_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "layer name too long: %zu", len);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "layer name too long: %zu", len);
           return errnum;
         }
         if (!bw_write_u8(&w, (uint8_t)len) || !bw_write_bytes(&w, s, len)) goto oom;
@@ -265,7 +266,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         if (in->a < 0 || (size_t)in->a >= ir->embedded_code.count) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "invalid embedded code payload index %d", in->a);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "invalid embedded code payload index %d", in->a);
           return errnum;
         }
         const IR_EmbeddedCodePayload *payload = &ir->embedded_code.entries[in->a];
@@ -277,7 +278,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
             if (nlen > UINT16_MAX) {
               FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
               int8_t errnum = ERR_NOERROR;
-              compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "embedded param too long: %zu", nlen);
+              compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "embedded param too long: %zu", nlen);
               return errnum;
             }
             if (!bw_write_u16(&w, (uint16_t)nlen) || !bw_write_bytes(&w, name, nlen)) goto oom;
@@ -287,14 +288,14 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
         if (!payload->source) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "embedded code payload %d has null source", in->a);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "embedded code payload %d has null source", in->a);
           return errnum;
         }
         size_t len = strlen(payload->source);
         if (len > UINT16_MAX) {
           FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
           int8_t errnum = ERR_NOERROR;
-          compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "embedded code too long: %zu", len);
+          compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "embedded code too long: %zu", len);
           return errnum;
         }
         if (!bw_write_u16(&w, (uint16_t)len) || !bw_write_bytes(&w, payload->source, len)) goto oom;
@@ -309,7 +310,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
   size_t bytecode_len = (size_t)(out->nextbyte - out->bytecode);
   if (bytecode_len > UINT32_MAX) {
     int8_t errnum = ERR_NOERROR;
-    compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc",
+    compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc",
                        "emitted bytecode length %zu exceeds verifier limit",
                        bytecode_len);
     return errnum;
@@ -321,7 +322,7 @@ int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
       &verify_options);
   if (verify.status != BC_VERIFY_OK) {
     int8_t errnum = ERR_NOERROR;
-    compdiag_setf_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc",
+    compdiag_setf_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc",
                        "bytecode verification failed: %s",
                        verify.diagnostic.message);
     return errnum;
@@ -331,7 +332,12 @@ oom:
   FREE_ARRAY(size_t, pos, ir->function.count > 0 ? ir->function.count : 1);
   {
     int8_t errnum = ERR_NOERROR;
-    compdiag_set_once(&errnum, errdetail, ERR_COMP_SYNTAX, "emitbc", "bytecode writer out of memory");
+    compdiag_set_once_diag(&errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_EMITBC, "emitbc", "bytecode writer out of memory");
     return errnum;
   }
+}
+
+int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
+                     OUTPUT_t *out, char **errdetail) {
+  return emit_bytecode_diag(ir, local_count, param_count, out, errdetail, NULL);
 }

--- a/src/compiler/emitbc.h
+++ b/src/compiler/emitbc.h
@@ -7,7 +7,10 @@
 #include <stdint.h>
 
 #include "ir.h"
+#include "compdiag.h"
 #include "parser.h"
 
+int8_t emit_bytecode_diag(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
+                          OUTPUT_t *out, char **errdetail, CompilerDiagnostic *diag);
 int8_t emit_bytecode(IR_Unit *ir, uint8_t local_count, uint8_t param_count,
                      OUTPUT_t *out, char **errdetail);

--- a/src/compiler/ir.c
+++ b/src/compiler/ir.c
@@ -170,26 +170,26 @@ void ir_dump(FILE* out, IR_Unit* unit) {
   }
 }
 
-static int8_t ir_validate_error(char **errdetail, int8_t errnum, const char *fmt, ...) {
+static int8_t ir_validate_error(char **errdetail, CompilerDiagnostic *diag, int8_t errnum, const char *fmt, ...) {
   va_list args;
   int needed;
   char *msg;
 
-  if (errdetail == NULL) return errnum;
+  if (errdetail == NULL && diag == NULL) return errnum;
 
   va_start(args, fmt);
   needed = vsnprintf(NULL, 0, fmt, args);
   va_end(args);
   if (needed < 0) {
     int8_t current = ERR_NOERROR;
-    compdiag_set_once(&current, errdetail, errnum, "ir", "formatting error");
+    compdiag_set_once_diag(&current, errdetail, diag, errnum, DIAG_PHASE_IR_VALIDATE, "ir", "formatting error");
     return errnum;
   }
 
   msg = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
   if (!msg) {
     int8_t current = ERR_NOERROR;
-    compdiag_set_once(&current, errdetail, errnum, "ir", "out of memory");
+    compdiag_set_once_diag(&current, errdetail, diag, errnum, DIAG_PHASE_IR_VALIDATE, "ir", "out of memory");
     return errnum;
   }
 
@@ -199,25 +199,26 @@ static int8_t ir_validate_error(char **errdetail, int8_t errnum, const char *fmt
 
   {
     int8_t current = ERR_NOERROR;
-    compdiag_set_once(&current, errdetail, errnum, "ir", msg);
+    compdiag_set_once_diag(&current, errdetail, diag, errnum, DIAG_PHASE_IR_VALIDATE, "ir", msg);
   }
   FREE_ARRAY(char, msg, (size_t)needed + 1);
   return errnum;
 }
 
-int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail) {
+int8_t ir_validate_diag(IR_Unit* unit, uint32_t local_count, char **errdetail, CompilerDiagnostic *diag) {
+  if (diag) compiler_diag_reset(diag);
   if (errdetail != NULL) {
     compdiag_reset_detail(errdetail);
   }
 
   if (unit == NULL) {
-    return ir_validate_error(errdetail, ERR_COMP_SYNTAX, "IR unit is null.");
+    return ir_validate_error(errdetail, diag, ERR_COMP_SYNTAX, "IR unit is null.");
   }
 
   for (size_t i = 0; i < unit->labels.count; i++) {
     IR_Label* label = &unit->labels.entries[i];
     if (!label->bound) {
-      return ir_validate_error(errdetail, ERR_COMP_SYNTAX,
+      return ir_validate_error(errdetail, diag, ERR_COMP_SYNTAX,
                                "Unbound label .L%d.", label->id);
     }
   }
@@ -229,12 +230,12 @@ int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail) {
       case IR_OP_JUMP_IF_FALSE:
       case IR_OP_LABEL: {
         if (inst->a < 0 || (size_t)inst->a >= unit->labels.count) {
-          return ir_validate_error(errdetail, ERR_COMP_SYNTAX,
+          return ir_validate_error(errdetail, diag, ERR_COMP_SYNTAX,
                                    "Instruction %zu (%s) references invalid label id %d.",
                                    i, ir_op_name(inst->op), inst->a);
         }
         if (!unit->labels.entries[inst->a].bound) {
-          return ir_validate_error(errdetail, ERR_COMP_SYNTAX,
+          return ir_validate_error(errdetail, diag, ERR_COMP_SYNTAX,
                                    "Instruction %zu (%s) references unbound label .L%d.",
                                    i, ir_op_name(inst->op), inst->a);
         }
@@ -246,7 +247,7 @@ int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail) {
       case IR_OP_DEC_LOCAL:
       case IR_OP_ITEM_PUSH_DEREF_LOCAL: {
         if (inst->a < 0 || (uint32_t)inst->a >= local_count) {
-          return ir_validate_error(errdetail, ERR_COMP_LOCALBEFOREDEF,
+          return ir_validate_error(errdetail, diag, ERR_COMP_LOCALBEFOREDEF,
                                    "Instruction %zu (%s) has out-of-range local index %d (locals=%u).",
                                    i, ir_op_name(inst->op), inst->a, local_count);
         }
@@ -254,7 +255,7 @@ int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail) {
       }
       case IR_OP_CALL: {
         if (inst->a < 0) {
-          return ir_validate_error(errdetail, ERR_COMP_TOOMANYARGS,
+          return ir_validate_error(errdetail, diag, ERR_COMP_TOOMANYARGS,
                                    "Instruction %zu (CALL) has negative arity %d.",
                                    i, ir_op_name(inst->op), inst->a);
         }
@@ -262,7 +263,7 @@ int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail) {
       }
       case IR_OP_LIBCALL_TOKEN:
         if (inst->a < 0) {
-          return ir_validate_error(errdetail, ERR_COMP_SYNTAX,
+          return ir_validate_error(errdetail, diag, ERR_COMP_SYNTAX,
                                    "Instruction %zu (LIBCALL_TOKEN) has negative token %d.",
                                    i, inst->a);
         }
@@ -314,4 +315,8 @@ int8_t ir_opcode_schema_validate_unique(char **errdetail) {
     seen_by[meta->encoded_symbol] = meta->op;
   }
   return ERR_NOERROR;
+}
+
+int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail) {
+  return ir_validate_diag(unit, local_count, errdetail, NULL);
 }

--- a/src/compiler/ir.h
+++ b/src/compiler/ir.h
@@ -11,6 +11,7 @@
 #include <stdio.h>
 
 #include "absyn.h"
+#include "compdiag.h"
 
 typedef enum {
   IR_OP_HALT = 0,
@@ -129,4 +130,5 @@ bool ir_embedded_locals_from_params(AS_NODE* params, IR_EmbeddedCodePayload* pay
 void ir_dump(FILE* out, IR_Unit* unit);
 
 const char* ir_op_name(IR_Op op);
+int8_t ir_validate_diag(IR_Unit* unit, uint32_t local_count, char **errdetail, CompilerDiagnostic *diag);
 int8_t ir_validate(IR_Unit* unit, uint32_t local_count, char **errdetail);

--- a/src/compiler/lower.c
+++ b/src/compiler/lower.c
@@ -568,12 +568,13 @@ static void lower_node(LOWER_CTX *ctx, AS_NODE *node) {
   lower_stmt(ctx, node);
 }
 
-int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **errdetail) {
+int8_t lower_ast_to_ir_diag(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **errdetail, CompilerDiagnostic *diag) {
+  if (diag) compiler_diag_reset(diag);
   LOWER_CTX ctx;
   int8_t startup_errnum = ERR_NOERROR;
 
   if (!out_ir) {
-    compdiag_set_once(&startup_errnum, errdetail, ERR_COMP_SYNTAX, "lower", "out_ir is NULL");
+    compdiag_set_once_diag(&startup_errnum, errdetail, diag, ERR_COMP_SYNTAX, DIAG_PHASE_LOWER, "lower", "out_ir is NULL");
     return startup_errnum;
   }
 
@@ -585,13 +586,13 @@ int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **err
   ctx.errnum = ERR_NOERROR;
 
   if (!libcall_init_registry()) {
-    compdiag_set_once(&startup_errnum, errdetail, ERR_COMP_INUSE, "lower",
-                      "failed to initialize libcall registry");
+    compdiag_set_once_diag(&startup_errnum, errdetail, diag, ERR_COMP_INUSE, DIAG_PHASE_LOWER, "lower",
+                          "failed to initialize libcall registry");
     return startup_errnum;
   }
 
   if (!ctx.ir) {
-    compdiag_set_once(&startup_errnum, errdetail, ERR_COMP_INUSE, "lower", "failed to allocate IR unit");
+    compdiag_set_once_diag(&startup_errnum, errdetail, diag, ERR_COMP_INUSE, DIAG_PHASE_LOWER, "lower", "failed to allocate IR unit");
     return startup_errnum;
   }
 
@@ -603,10 +604,17 @@ int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **err
   }
 
   ir_destroy_unit(ctx.ir);
+  if (diag && ctx.errnum != ERR_NOERROR) {
+    compiler_diag_set(diag, ctx.errnum, DIAG_PHASE_LOWER, ctx.errdetail ? ctx.errdetail : "");
+  }
   if (errdetail) {
     *errdetail = ctx.errdetail;
   } else if (ctx.errdetail) {
     free(ctx.errdetail);
   }
   return ctx.errnum;
+}
+
+int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **errdetail) {
+  return lower_ast_to_ir_diag(root, sem, out_ir, errdetail, NULL);
 }

--- a/src/compiler/lower.h
+++ b/src/compiler/lower.h
@@ -9,6 +9,7 @@
 #include "absyn.h"
 #include "ir.h"
 #include "semant.h"
+#include "compdiag.h"
 
 typedef struct {
   SEM_CTX *sem;
@@ -17,5 +18,6 @@ typedef struct {
   char *errdetail;
 } LOWER_CTX;
 
+int8_t lower_ast_to_ir_diag(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **errdetail, CompilerDiagnostic *diag);
 int8_t lower_ast_to_ir(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char **errdetail);
 

--- a/src/compiler/semant.c
+++ b/src/compiler/semant.c
@@ -256,7 +256,7 @@ static void sem_walk(SEM_CTX *ctx, AS_NODE *node) {
   }
 }
 
-int8_t sem_check_locals(AS_NODE *root, char **errdetail, SEM_CTX *ctx) {
+int8_t sem_check_locals_diag(AS_NODE *root, char **errdetail, CompilerDiagnostic *diag, SEM_CTX *ctx) {
   // sem_check_locals is reusable per SEM_CTX. It preserves discovered locals
   // across calls, but resets and re-computes per-call error state.
   //
@@ -276,7 +276,15 @@ int8_t sem_check_locals(AS_NODE *root, char **errdetail, SEM_CTX *ctx) {
     *errdetail = ctx->errdetail ? strdup(ctx->errdetail) : NULL;
   }
 
+  if (diag && ctx->errnum != ERR_NOERROR) {
+    compiler_diag_set(diag, ctx->errnum, DIAG_PHASE_SEMANT, ctx->errdetail ? ctx->errdetail : "");
+  }
+
   return ctx->errnum;
+}
+
+int8_t sem_check_locals(AS_NODE *root, char **errdetail, SEM_CTX *ctx) {
+  return sem_check_locals_diag(root, errdetail, NULL, ctx);
 }
 
 bool sem_get_local_index(SEM_CTX *ctx, const char *name, uint8_t *index_out) {

--- a/src/compiler/semant.h
+++ b/src/compiler/semant.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "absyn.h"
+#include "compdiag.h"
 
 typedef struct {
   char *name;
@@ -43,6 +44,7 @@ void sem_delete_ctx(SEM_CTX *ctx);
 // - preserves discovered locals in ctx
 // - resets ctx error state on each call
 // - if errdetail is non-NULL, returns an owned heap copy (caller frees)
+int8_t sem_check_locals_diag(AS_NODE *root, char **errdetail, CompilerDiagnostic *diag, SEM_CTX *ctx);
 int8_t sem_check_locals(AS_NODE *root, char **errdetail, SEM_CTX *ctx);
 bool sem_get_local_index(SEM_CTX *ctx, const char *name, uint8_t *index_out);
 void sem_seed_params(SEM_CTX *ctx, const char **params, size_t count);

--- a/src/parser.y
+++ b/src/parser.y
@@ -16,6 +16,7 @@
 
   #include "absyn.h"
   #include "parse_input.h"
+  #include "compdiag.h"
 
   typedef struct {
     unsigned char *bytecode;
@@ -36,6 +37,7 @@
 
   int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail);
   int8_t parse_source_diag(const ParseInput *input, AS_NODE **absyn, char **errdetail, SCANNER_STATE_t *out_state);
+  int8_t parse_source_compiler_diag(const ParseInput *input, AS_NODE **absyn, char **errdetail, CompilerDiagnostic *diag, SCANNER_STATE_t *out_state);
 }
 
 %{
@@ -154,6 +156,20 @@ int8_t parse_source_diag(const ParseInput *input, AS_NODE **absyn, char **errdet
     else free(scanner_state.offending_token);
     return 0;
   }
+}
+
+int8_t parse_source_compiler_diag(const ParseInput *input, AS_NODE **absyn, char **errdetail, CompilerDiagnostic *diag, SCANNER_STATE_t *out_state) {
+  SCANNER_STATE_t state;
+  if (diag) compiler_diag_reset(diag);
+  int8_t rc = parse_source_diag(input, absyn, errdetail, &state);
+  if (rc != ERR_NOERROR && diag) {
+    compiler_diag_set(diag, rc, DIAG_PHASE_PARSE, errdetail && *errdetail ? *errdetail : "");
+    compiler_diag_set_source_name(diag, input && input->source_name ? input->source_name : "<memory>");
+    compiler_diag_set_location(diag, state.line, state.column, state.span);
+  }
+  if (out_state) *out_state = state;
+  else free(state.offending_token);
+  return rc;
 }
 
 int8_t parse_source(const ParseInput *input, AS_NODE **absyn, char **errdetail) {

--- a/tests/compiler/test_compiler_diag_pipeline.c
+++ b/tests/compiler/test_compiler_diag_pipeline.c
@@ -1,6 +1,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include "compiler_pipeline.h"
+#include "semant.h"
+#include "lower.h"
+#include "ir.h"
 #include "error.h"
 #include "test_assert.h"
 
@@ -57,5 +60,60 @@ void test_compiler_diag_pipeline(void){
   ASSERT_TRUE(strcmp("custom_source.sin", d.source_name)==0);
   ASSERT_NOT_NULL(d.message);
   ASSERT_TRUE(strstr(d.message, "custom_source.sin") != NULL);
+
+
+  compiler_diag_reset(&d);
+  AS_NODE *ast = NULL;
+  SCANNER_STATE_t parse_state = {0};
+  ParseInput parse_input = {"^;", 2, "parse_stage.sin"};
+  errdetail = NULL;
+  rc = parse_source_compiler_diag(&parse_input, &ast, &errdetail, &d, &parse_state);
+  ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, rc);
+  ASSERT_EQ_INT(DIAG_PHASE_PARSE, d.phase);
+  ASSERT_NOT_NULL(errdetail);
+  free(errdetail);
+  free(parse_state.offending_token);
+
+  compiler_diag_reset(&d);
+  SEM_CTX *sem = sem_create_ctx();
+  ParseInput sem_input = {"@x;", 3, "semant_stage.sin"};
+  errdetail = NULL;
+  rc = parse_source(&sem_input, &ast, &errdetail);
+  ASSERT_EQ_INT(ERR_NOERROR, rc);
+  rc = sem_check_locals_diag(ast, &errdetail, &d, sem);
+  ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
+  ASSERT_EQ_INT(DIAG_PHASE_SEMANT, d.phase);
+  free(errdetail);
+  as_delete(ast);
+  sem_delete_ctx(sem);
+
+  compiler_diag_reset(&d);
+  IR_Unit *ir = NULL;
+  errdetail = NULL;
+  rc = lower_ast_to_ir_diag(NULL, NULL, NULL, &errdetail, &d);
+  ASSERT_TRUE(rc != ERR_NOERROR);
+  (void)ir;
+  ASSERT_EQ_INT(DIAG_PHASE_LOWER, d.phase);
+  free(errdetail);
+
+  compiler_diag_reset(&d);
+  errdetail = NULL;
+  rc = ir_validate_diag(NULL, 0, &errdetail, &d);
+  ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
+  ASSERT_EQ_INT(DIAG_PHASE_IR_VALIDATE, d.phase);
+  free(errdetail);
+
+  compiler_diag_reset(&d);
+  errdetail = NULL;
+  rc = emit_bytecode_diag(NULL, 0, 0, NULL, &errdetail, &d);
+  ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
+  ASSERT_EQ_INT(DIAG_PHASE_EMITBC, d.phase);
+  free(errdetail);
+
+  compiler_diag_reset(&d);
+  rc = compile_source_to_bytecode_diag(NULL, 0, &out, &d);
+  ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
+  ASSERT_EQ_INT(DIAG_PHASE_COMPILE, d.phase);
+
   compiler_diag_reset(&d);
 }


### PR DESCRIPTION
### Motivation
- Provide a structured diagnostic path (`CompilerDiagnostic`) alongside the legacy `char **errdetail` to allow callers to inspect diagnostics by explicit compilation phase. 
- Ensure each compiler stage (parse, semant, lower, IR validate, emitbc, compile) sets a discrete `DiagPhase` so phase inference from formatted strings is no longer required.
- Preserve existing `char **errdetail` behavior as a compatibility formatting layer derived from the structured diagnostic information.

### Description
- Added `CompilerDiagnostic` phase constants (including `DIAG_PHASE_COMPILE`) and the `compdiag_set_once_diag` / `compdiag_setf_once_diag` helpers that populate both `char **errdetail` and a `CompilerDiagnostic` instance. 
- Introduced stage-specific diagnostic APIs and wrappers: `parse_source_compiler_diag`, `sem_check_locals_diag`, `lower_ast_to_ir_diag`, `ir_validate_diag`, and `emit_bytecode_diag`, with the original `*()` variants retained as simple `..._diag(..., NULL)` wrappers. 
- Updated the compiler pipeline to propagate explicit `DiagPhase` values to `CompilerDiagnostic` (and stop relying on `phase_from_detail`), and to set compile-level diagnostics for allocation/argument validation errors. 
- Added tests in `tests/compiler/test_compiler_diag_pipeline.c` that exercise parse, semantic, lower, IR validate, emitbc, and compile-level failures and assert the expected `DiagPhase` and structured diagnostic fields.

### Testing
- Ran the full test suite with `make test`, which executed all tests and completed with status PASS (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47fec5ca98832e8a0f5879c925b7c3)