### PR TITLE
Improve scomp diagnostics

### DIFF
--- a/src/scomp.c
+++ b/src/scomp.c
@@ -17,6 +17,73 @@
 // Things which need to be known
 CONFIG_t config;
 
+static const char *diag_message(const CompilerDiagnostic *diag) {
+  return diag && diag->message ? diag->message : "";
+}
+
+static void print_source_line(FILE *stream, const char *source, size_t source_len,
+                              int line) {
+  const char *line_start = source;
+  const char *line_end = source;
+  int current_line = 1;
+
+  if (!stream || !source || source_len == 0 || line < 1) {
+    fprintf(stream, "\n");
+    return;
+  }
+
+  while (line_start < source + source_len && current_line < line) {
+    if (*line_start == '\n') current_line++;
+    line_start++;
+  }
+
+  line_end = line_start;
+  while (line_end < source + source_len && *line_end != '\n' &&
+         *line_end != '\r') {
+    line_end++;
+  }
+
+  fprintf(stream, "%.*s\n", (int)(line_end - line_start), line_start);
+}
+
+static void print_caret_marker(FILE *stream, int column, int span) {
+  int caret_column = column > 0 ? column : 1;
+  int caret_span = span > 0 ? span : 1;
+
+  if (!stream) return;
+  for (int i = 1; i < caret_column; i++) fputc(' ', stream);
+  fputc('^', stream);
+  for (int i = 1; i < caret_span; i++) fputc('~', stream);
+  fputc('\n', stream);
+}
+
+static void print_compiler_diagnostic(const CompilerDiagnostic *diag,
+                                      const char *source, size_t source_len) {
+  const char *stable_code = diag && diag->stable_code
+                                ? diag->stable_code
+                                : compiler_diag_stable_code(diag ? diag->code : 0,
+                                                            diag ? diag->phase : DIAG_PHASE_NONE);
+  const char *stage = diag ? compiler_diag_phase_name(diag->phase)
+                           : compiler_diag_phase_name(DIAG_PHASE_NONE);
+  const char *file = diag && diag->source_name ? diag->source_name : "<unknown>";
+  int line = diag && diag->has_loc ? diag->line : 1;
+  int column = diag && diag->has_loc ? diag->column : 1;
+  int span = diag && diag->span > 0 ? diag->span : 1;
+
+  logerr("Diagnostic %s\n", stable_code);
+  logerr("  stage: %s\n", stage);
+  logerr("  file: %s\n", file);
+  logerr("  line: %d\n", line);
+  logerr("  column: %d\n", column);
+  logerr("  message: %s\n", diag_message(diag));
+  logerr("  legacy: ERR_%d\n", diag ? diag->code : 0);
+  logerr("  source:\n");
+  logerr("    ");
+  print_source_line(stderr, source, source_len, line);
+  logerr("    ");
+  print_caret_marker(stderr, column, span);
+}
+
 int load_file_buffer(const char *path, char **out_data, size_t *out_len) {
   FILE *in = NULL;
   long file_len = 0;
@@ -66,14 +133,18 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  if (load_file_buffer(argv[1], &source, &source_len) != 0) {    result = ERR_COMP_SYNTAX;
+  if (load_file_buffer(argv[1], &source, &source_len) != 0) {
+    result = ERR_COMP_SYNTAX;
     compiler_diag_set(&diag, result, DIAG_PHASE_IO, "input file IO failure");
+    compiler_diag_set_source_name(&diag, argv[1]);
+    compiler_diag_set_location(&diag, 1, 1, 1);
     goto compile_error;
   }
   logmsg("Source loaded: %zu bytes.\n", source_len);
 
   logmsg("Compiling...\n");
-  result = compile_source_to_bytecode_diag(source, source_len, &out, &diag);
+  ParseInput input = {source, source_len, argv[1]};
+  result = compile_parse_input_to_bytecode_diag(&input, &out, &diag);
   if (result != ERR_NOERROR) {
     goto compile_error;
   }
@@ -90,7 +161,7 @@ int main(int argc, char **argv) {
 
 compile_error:
   logerr("Error: (#%d) %s\n", result, errmsg[result]);
-  logerr("Diag: code=%d phase=%s message=%s\n", diag.code, compiler_diag_phase_name(diag.phase), diag.message ? diag.message : "");
+  print_compiler_diagnostic(&diag, source, source_len);
   logerr("Compilation failed.\n");
 
 cleanup:

--- a/tests/compiler/test_compiler_diag_pipeline.c
+++ b/tests/compiler/test_compiler_diag_pipeline.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include "compiler_pipeline.h"
 #include "semant.h"
 #include "lower.h"
@@ -7,7 +8,57 @@
 #include "error.h"
 #include "test_assert.h"
 
+static char *read_text_file_for_diag_test(const char *path) {
+  FILE *f = fopen(path, "rb");
+  ASSERT_NOT_NULL(f);
+  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_END));
+  long n = ftell(f);
+  ASSERT_TRUE(n >= 0);
+  ASSERT_EQ_INT(0, fseek(f, 0, SEEK_SET));
+  char *buf = malloc((size_t)n + 1);
+  ASSERT_NOT_NULL(buf);
+  ASSERT_EQ_INT((int)n, (int)fread(buf, 1, (size_t)n, f));
+  buf[n] = '\0';
+  ASSERT_EQ_INT(0, fclose(f));
+  return buf;
+}
+
+static void test_scomp_cli_malformed_diagnostic_shape(void) {
+  const char *src_path = "tests/fixtures/scomp-cli-malformed.tmp.src";
+  const char *obj_path = "tests/fixtures/scomp-cli-malformed.tmp.obj";
+  const char *err_path = "tests/fixtures/scomp-cli-malformed.tmp.err";
+  FILE *src = fopen(src_path, "wb");
+  ASSERT_NOT_NULL(src);
+  const char *malformed = "@x = 1;\n@yy = 2;\n^;";
+  ASSERT_EQ_INT((int)strlen(malformed), (int)fwrite(malformed, 1, strlen(malformed), src));
+  ASSERT_EQ_INT(0, fclose(src));
+
+  char cmd[512];
+  int cmd_len = snprintf(cmd, sizeof(cmd), "./scomp %s %s > /dev/null 2> %s", src_path, obj_path, err_path);
+  ASSERT_TRUE(cmd_len > 0 && (size_t)cmd_len < sizeof(cmd));
+  ASSERT_TRUE(system(cmd) != 0);
+
+  char *err = read_text_file_for_diag_test(err_path);
+  ASSERT_TRUE(strstr(err, "Diagnostic SIN-PARSE-") != NULL);
+  ASSERT_TRUE(strstr(err, "stage: PARSE") != NULL);
+  ASSERT_TRUE(strstr(err, "file: tests/fixtures/scomp-cli-malformed.tmp.src") != NULL);
+  ASSERT_TRUE(strstr(err, "line: 3") != NULL);
+  ASSERT_TRUE(strstr(err, "column: 1") != NULL);
+  ASSERT_TRUE(strstr(err, "message:") != NULL);
+  ASSERT_TRUE(strstr(err, "legacy: ERR_") != NULL);
+  ASSERT_TRUE(strstr(err, "source:") != NULL);
+  ASSERT_TRUE(strstr(err, "    ^;") != NULL);
+  ASSERT_TRUE(strstr(err, "    ^") != NULL);
+  ASSERT_TRUE(strstr(err, "Diag: code=") == NULL);
+
+  free(err);
+  remove(src_path);
+  remove(obj_path);
+  remove(err_path);
+}
+
 void test_compiler_diag_pipeline(void){
+  test_scomp_cli_malformed_diagnostic_shape();
   OUTPUT_t *out=NULL; CompilerDiagnostic d; compiler_diag_init(&d);
   int8_t rc = compile_source_to_bytecode_diag("^;",2,&out,&d);
   ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, rc); ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, d.code); ASSERT_EQ_INT(DIAG_PHASE_PARSE, d.phase); ASSERT_NOT_NULL(d.message);


### PR DESCRIPTION
### Motivation
- Make CLI diagnostics more actionable by using the actual input file path as the diagnostic source name instead of the in-memory default.
- Replace the terse numeric `Diag: code=...` line with a stable, human-readable diagnostic shape that includes stage, location, and a source excerpt so users can quickly find and understand errors.
- Preserve backward compatibility by retaining the original numeric `ERR_*` value in the output for tools that rely on it.

### Description
- `src/scomp.c`: pass the CLI input path into the compilation pipeline by creating a `ParseInput` with `argv[1]` and calling `compile_parse_input_to_bytecode_diag`, and set source name/location for IO failures. Also replace the old `Diag: code=...` logging with `print_compiler_diagnostic`, which emits a structured human-readable diagnostic containing stable diagnostic code, stage, file, line, column, message, a `legacy: ERR_<n>` numeric field, the source excerpt, and a caret/span marker. (New helper functions: `diag_message`, `print_source_line`, `print_caret_marker`, `print_compiler_diagnostic`.)
- `tests/compiler/test_compiler_diag_pipeline.c`: add a CLI-level golden/fuzz-shape test `test_scomp_cli_malformed_diagnostic_shape` which invokes `./scomp` on a malformed source file, captures stderr, and asserts the new diagnostic shape (stable code prefix, stage, file path, line/column, `message:` label, `legacy: ERR_`, source excerpt and caret) while intentionally avoiding overfitting exact parser wording.

### Testing
- Ran the full test suite via `make test`, which completed successfully and reported all tests passing. 
- The new CLI diagnostic shape test is included in `tests/compiler/test_compiler_diag_pipeline.c` and executed as part of the test run (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a480b6453ac832eaa022d221adadc5b)