### PR TITLE
Preserve structured sys.compile diagnostics

### DIFF
--- a/src/item.c
+++ b/src/item.c
@@ -1460,9 +1460,42 @@ bool is_valid_layer(const char *str) {
   return true;
 }
 
+static const char *safe_error_message(const int errnum) {
+  if (errnum >= 0 && errnum < MAXERRORS && errmsg[errnum]) {
+    return errmsg[errnum];
+  }
+  return "Unknown error";
+}
+
+static void set_string_error_field(const char *name, const char *value) {
+  VALUE_t v;
+  v.type = VALUE_str;
+  v.s = strdup(value ? value : "");
+  set_item(config.itemroot, name, v);
+}
+
+static void set_int_error_field(const char *name, int64_t value) {
+  VALUE_t v;
+  v.type = VALUE_int;
+  v.i = value;
+  set_item(config.itemroot, name, v);
+}
+
+void clear_error_item(void) {
+  set_item(config.itemroot, "error", VALUE_NIL);
+  set_item(config.itemroot, "error.msg", VALUE_NIL);
+  set_item(config.itemroot, "error.code", VALUE_NIL);
+  set_item(config.itemroot, "error.stage", VALUE_NIL);
+  set_item(config.itemroot, "error.file", VALUE_NIL);
+  set_item(config.itemroot, "error.line", VALUE_NIL);
+  set_item(config.itemroot, "error.column", VALUE_NIL);
+  set_item(config.itemroot, "error.excerpt", VALUE_NIL);
+}
+
 void set_error_item(const int errnum, const char *errdetail) {
   // Helper function to set the error item.
   VALUE_t e, emsg;
+  const char *base = safe_error_message(errnum);
   e.type = VALUE_int;
   e.i = errnum;
   set_item(config.itemroot, "error", e);
@@ -1471,11 +1504,62 @@ void set_error_item(const int errnum, const char *errdetail) {
     // It's possible that there is an extended error message.
     // Allocate enough space for the two error messages, plus
     // the extra characters "errmsg (errdetail)"
-    int elen = strlen(errmsg[errnum]) + strlen(errdetail) + 4;
+    int elen = strlen(base) + strlen(errdetail) + 4;
     emsg.s = GROW_ARRAY(char, NULL, 0, elen);
-    snprintf(emsg.s, elen, "%s (%s)", errmsg[errnum], errdetail);
+    snprintf(emsg.s, elen, "%s (%s)", base, errdetail);
   } else {
-    emsg.s = strdup(errmsg[errnum]);
+    emsg.s = strdup(base);
   }
   set_item(config.itemroot, "error.msg", emsg);
+  set_item(config.itemroot, "error.code", VALUE_NIL);
+  set_item(config.itemroot, "error.stage", VALUE_NIL);
+  set_item(config.itemroot, "error.file", VALUE_NIL);
+  set_item(config.itemroot, "error.line", VALUE_NIL);
+  set_item(config.itemroot, "error.column", VALUE_NIL);
+  set_item(config.itemroot, "error.excerpt", VALUE_NIL);
+}
+
+void set_compiler_error_item(const CompilerDiagnostic *diag) {
+  if (!diag) {
+    set_error_item(ERR_COMP_UNKNOWN, NULL);
+    return;
+  }
+
+  const char *stable_code = diag->stable_code
+      ? diag->stable_code
+      : compiler_diag_stable_code(diag->code, diag->phase);
+  const char *stage = compiler_diag_phase_name(diag->phase);
+  const char *file = diag->source_name ? diag->source_name : "";
+  const char *message = diag->message ? diag->message : "";
+  const char *excerpt = diag->excerpt ? diag->excerpt : "";
+  int line = diag->has_loc ? diag->line : 0;
+  int column = diag->has_loc ? diag->column : 0;
+
+  VALUE_t e;
+  e.type = VALUE_int;
+  e.i = diag->code;
+  set_item(config.itemroot, "error", e);
+
+  int needed = snprintf(NULL, 0,
+      "%s stage=%s file=%s line=%d column=%d message=%s excerpt=%s",
+      stable_code, stage, file, line, column, message, excerpt);
+  if (needed < 0) {
+    set_error_item(diag->code, message);
+    return;
+  }
+
+  VALUE_t emsg;
+  emsg.type = VALUE_str;
+  emsg.s = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+  snprintf(emsg.s, (size_t)needed + 1,
+      "%s stage=%s file=%s line=%d column=%d message=%s excerpt=%s",
+      stable_code, stage, file, line, column, message, excerpt);
+  set_item(config.itemroot, "error.msg", emsg);
+
+  set_string_error_field("error.code", stable_code);
+  set_string_error_field("error.stage", stage);
+  set_string_error_field("error.file", file);
+  set_int_error_field("error.line", line);
+  set_int_error_field("error.column", column);
+  set_string_error_field("error.excerpt", excerpt);
 }

--- a/src/item.h
+++ b/src/item.h
@@ -14,6 +14,7 @@
 #include <stdbool.h>
 
 #include "value.h"
+#include "compiler/compdiag.h"
 
 // Items are up to 8 layers deep, and each layer name is a maximum of
 // 32 characters.  There is a dot separating each layer name (7 in total)
@@ -115,3 +116,5 @@ uint64_t get_itemstore_generation(void);
 // Other item-related API functions
 bool is_valid_layer(const char *str);
 void set_error_item(const int errnum, const char *errdetail);
+void set_compiler_error_item(const CompilerDiagnostic *diag);
+void clear_error_item(void);

--- a/src/libcall.c
+++ b/src/libcall.c
@@ -157,18 +157,26 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
   }
 
   int8_t result = 0;
-  char *errdetail = NULL;
+  CompilerDiagnostic diag;
+  compiler_diag_init(&diag);
   OUTPUT_t *out = NULL;
   char tmpname[MAX_ITEM_NAME];
   static uint64_t tmpname_counter = 0;
 
   // Compile source -> bytecode
-  result = compile_source_to_bytecode(val.s, strlen(val.s), &out, &errdetail);
+  result = compile_source_to_bytecode_diag(val.s, strlen(val.s), &out, &diag);
 
   if (result != 0 || !out || !out->bytecode) {
-    // Compile failed; release owned errdetail/out/val.s exactly once.
-    set_error_item(result != 0 ? result : ERR_COMP_UNKNOWN, errdetail);
-    lc_cleanup_cstr(errdetail);
+    // Compile failed; preserve structured compiler diagnostics.
+    if (result == 0) {
+      compiler_diag_reset(&diag);
+      compiler_diag_set(&diag, ERR_COMP_UNKNOWN, DIAG_PHASE_COMPILE,
+          "compile: missing bytecode output");
+      compiler_diag_set_source_name(&diag, "<memory>");
+      compiler_diag_set_location(&diag, 1, 1, 1);
+      compiler_diag_set_excerpt(&diag, val.s ? val.s : "");
+    }
+    set_compiler_error_item(&diag);
     if (out) {
       if (out->bytecode) {
         FREE_ARRAY(unsigned char, out->bytecode, out->maxsize);
@@ -176,6 +184,7 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
       FREE_ARRAY(OUTPUT_t, out, 1);
     }
     lc_cleanup_cstr(val.s);
+    compiler_diag_reset(&diag);
     push_stack(VM->stack, VALUE_FALSE);
     return nextop;
   }
@@ -188,6 +197,7 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
     FREE_ARRAY(unsigned char, out->bytecode, out->maxsize);
     FREE_ARRAY(OUTPUT_t, out, 1);
     lc_cleanup_cstr(val.s);
+    compiler_diag_reset(&diag);
     push_stack(VM->stack, VALUE_FALSE);
     return nextop;
   }
@@ -207,6 +217,7 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
     FREE_ARRAY(unsigned char, out->bytecode, out->maxsize);
     FREE_ARRAY(OUTPUT_t, out, 1);
     lc_cleanup_cstr(val.s);
+    compiler_diag_reset(&diag);
     push_stack(VM->stack, VALUE_FALSE);
     return nextop;
   }
@@ -222,11 +233,11 @@ uint8_t *lc_sys_compile(uint8_t *nextop, ITEM_t *item) {
   delete_item(config.itemroot, tmpname);
 
   // clear compiler/runtime error indicators on success
-  set_item(config.itemroot, "error", VALUE_NIL);
-  set_item(config.itemroot, "error.msg", VALUE_NIL);
+  clear_error_item();
 
   FREE_ARRAY(OUTPUT_t, out, 1); // bytecode ownership moved into inserted item
   lc_cleanup_cstr(val.s);
+  compiler_diag_reset(&diag);
 
   push_stack(VM->stack, VALUE_TRUE);
   return nextop;

--- a/tests/compiler/test_sys_compile_libcall.c
+++ b/tests/compiler/test_sys_compile_libcall.c
@@ -37,6 +37,25 @@ static void assert_bool(VALUE_t v, int expected) {
   ASSERT_EQ_INT(expected, v.i);
 }
 
+static ITEM_t *assert_string_item(const char *name, const char *contains) {
+  ITEM_t *item = find_item(config.itemroot, name);
+  ASSERT_NOT_NULL(item);
+  ASSERT_EQ_INT(VALUE_str, item->value.type);
+  ASSERT_NOT_NULL(item->value.s);
+  if (contains) {
+    ASSERT_TRUE(strstr(item->value.s, contains) != NULL);
+  }
+  return item;
+}
+
+static ITEM_t *assert_int_item(const char *name, int64_t expected) {
+  ITEM_t *item = find_item(config.itemroot, name);
+  ASSERT_NOT_NULL(item);
+  ASSERT_EQ_INT(VALUE_int, item->value.type);
+  ASSERT_EQ_INT(expected, item->value.i);
+  return item;
+}
+
 static void assert_compile_success_bool(const char *source) {
   push_stack(config.vm->stack, vstr(source));
   (void)lc_sys_compile(NULL, config.itemroot);
@@ -65,6 +84,19 @@ void test_sys_compile_libcall_runtime(void) {
   ASSERT_TRUE(err_item->value.i != ERR_NOERROR);
   ASSERT_EQ_INT(VALUE_str, msg_item->value.type);
   ASSERT_TRUE(msg_item->value.s != NULL && strlen(msg_item->value.s) > 0);
+  ASSERT_TRUE(strstr(msg_item->value.s, "SIN-PARSE-") != NULL);
+  ASSERT_TRUE(strstr(msg_item->value.s, "stage=PARSE") != NULL);
+  ASSERT_TRUE(strstr(msg_item->value.s, "file=<memory>") != NULL);
+  ASSERT_TRUE(strstr(msg_item->value.s, "line=") != NULL);
+  ASSERT_TRUE(strstr(msg_item->value.s, "column=") != NULL);
+  ASSERT_TRUE(strstr(msg_item->value.s, "message=") != NULL);
+  ASSERT_TRUE(strstr(msg_item->value.s, "excerpt=sys.log{;") != NULL);
+  assert_string_item("error.code", "SIN-PARSE-");
+  assert_string_item("error.stage", "PARSE");
+  assert_string_item("error.file", "<memory>");
+  assert_int_item("error.line", 1);
+  assert_int_item("error.column", 9);
+  assert_string_item("error.excerpt", "sys.log{;");
 
   VALUE_t intarg = {VALUE_int, {.i = 42}};
   push_stack(config.vm->stack, intarg);

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -8,6 +8,7 @@
 #include "error.h"
 #include "interpret.h"
 #include "item.h"
+#include "compiler/compdiag.h"
 #include "test_assert.h"
 #include "value.h"
 #include "vm.h"
@@ -96,6 +97,70 @@ static VALUE_t run_float_binary(uint64_t lhs, uint64_t rhs, uint8_t op, const ch
   return run_code(name, code, pos);
 }
 
+
+
+void test_error_item_preserves_compiler_diagnostic_fields(void) {
+  setup_runtime();
+
+  CompilerDiagnostic diag;
+  compiler_diag_init(&diag);
+  compiler_diag_set(&diag, ERR_COMP_UNKNOWNCHAR, DIAG_PHASE_PARSE,
+                    "parse: unexpected character");
+  compiler_diag_set_source_name(&diag, "example.sin");
+  compiler_diag_set_location(&diag, 7, 3, 1);
+  compiler_diag_set_excerpt(&diag, "bad ^ token");
+
+  set_compiler_error_item(&diag);
+
+  ITEM_t *err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(VALUE_int, err->value.type);
+  ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, err->value.i);
+
+  ITEM_t *msg = find_item(config.itemroot, "error.msg");
+  ASSERT_NOT_NULL(msg);
+  ASSERT_EQ_INT(VALUE_str, msg->value.type);
+  ASSERT_TRUE(strstr(msg->value.s, "SIN-PARSE-0005") != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "stage=PARSE") != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "file=example.sin") != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "line=7") != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "column=3") != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "message=parse: unexpected character") != NULL);
+  ASSERT_TRUE(strstr(msg->value.s, "excerpt=bad ^ token") != NULL);
+
+  ITEM_t *code = find_item(config.itemroot, "error.code");
+  ASSERT_NOT_NULL(code);
+  ASSERT_EQ_INT(VALUE_str, code->value.type);
+  ASSERT_TRUE(strcmp(code->value.s, "SIN-PARSE-0005") == 0);
+
+  ITEM_t *stage = find_item(config.itemroot, "error.stage");
+  ASSERT_NOT_NULL(stage);
+  ASSERT_EQ_INT(VALUE_str, stage->value.type);
+  ASSERT_TRUE(strcmp(stage->value.s, "PARSE") == 0);
+
+  ITEM_t *file = find_item(config.itemroot, "error.file");
+  ASSERT_NOT_NULL(file);
+  ASSERT_EQ_INT(VALUE_str, file->value.type);
+  ASSERT_TRUE(strcmp(file->value.s, "example.sin") == 0);
+
+  ITEM_t *line = find_item(config.itemroot, "error.line");
+  ASSERT_NOT_NULL(line);
+  ASSERT_EQ_INT(VALUE_int, line->value.type);
+  ASSERT_EQ_INT(7, line->value.i);
+
+  ITEM_t *column = find_item(config.itemroot, "error.column");
+  ASSERT_NOT_NULL(column);
+  ASSERT_EQ_INT(VALUE_int, column->value.type);
+  ASSERT_EQ_INT(3, column->value.i);
+
+  ITEM_t *excerpt = find_item(config.itemroot, "error.excerpt");
+  ASSERT_NOT_NULL(excerpt);
+  ASSERT_EQ_INT(VALUE_str, excerpt->value.type);
+  ASSERT_TRUE(strcmp(excerpt->value.s, "bad ^ token") == 0);
+
+  compiler_diag_reset(&diag);
+  teardown_runtime();
+}
 
 void test_value_ieee754_environment_contract(void) {
   volatile double one = 1.0;

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -134,6 +134,7 @@ void test_relative_item_leading_dot_boundary_max_name_after_prefix_expansion_com
 void test_relative_item_leading_dot_existing_absolute_item_unchanged(void);
 void test_float_item_literal_layer_rejected_at_compile_time(void);
 void test_float_local_deref_layer_returns_nil_and_does_not_save_item(void);
+void test_error_item_preserves_compiler_diagnostic_fields(void);
 void test_value_ieee754_environment_contract(void);
 void test_value_integer_arithmetic_helpers(void);
 void test_value_arithmetic_invalid_and_nil_operands(void);
@@ -252,6 +253,7 @@ static const test_case_t core_tests[] = {
     {"test_relative_item_leading_dot_existing_absolute_item_unchanged", test_relative_item_leading_dot_existing_absolute_item_unchanged},
     {"test_float_item_literal_layer_rejected_at_compile_time", test_float_item_literal_layer_rejected_at_compile_time},
     {"test_float_local_deref_layer_returns_nil_and_does_not_save_item", test_float_local_deref_layer_returns_nil_and_does_not_save_item},
+    {"test_error_item_preserves_compiler_diagnostic_fields", test_error_item_preserves_compiler_diagnostic_fields},
     {"test_value_ieee754_environment_contract", test_value_ieee754_environment_contract},
     {"test_value_integer_arithmetic_helpers", test_value_integer_arithmetic_helpers},
     {"test_value_arithmetic_invalid_and_nil_operands", test_value_arithmetic_invalid_and_nil_operands},


### PR DESCRIPTION
### Motivation

- Switch `lc_sys_compile` to the structured diagnostic compiler API so compiler diagnostics are preserved in a stable, machine-parseable form. 
- Surface structured diagnostic fields in the itemstore (`error.code`, `error.stage`, `error.file`, `error.line`, `error.column`, `error.excerpt`) while keeping the legacy numeric `error` item for compatibility. 
- Provide a stable, formatted `error.msg` that includes stable diagnostic code, stage, source, location, message and excerpt for human-facing output.

### Description

- Updated `lc_sys_compile` in `src/libcall.c` to call `compile_source_to_bytecode_diag`, manage a `CompilerDiagnostic` instance, and call `set_compiler_error_item` on failure while resetting/clearing the diagnostic on success or cleanup. 
- Added `set_compiler_error_item`, `clear_error_item`, and small helpers (`set_string_error_field`, `set_int_error_field`, `safe_error_message`) to `src/item.c` and declared them in `src/item.h` so structured fields are set under `config.itemroot` without breaking numeric `error` behavior. 
- Kept `set_error_item(const int, const char *)` behavior intact (numeric `error` remains compatible) but made it safer for unknown codes and ensured it clears structured fields when used for non-compiler errors. 
- Formatted `error.msg` from structured diagnostics to include stable code, stage name, source name, line, column, message and excerpt; updated call sites to clear structured diagnostics on success.

### Testing

- Ran the full automated test suite with `make test -j2`, which completed successfully (all tests passed). 
- Updated/added unit tests: `tests/compiler/test_sys_compile_libcall.c` now asserts structured diagnostic content appears in `error.msg` and verifies `error.code`, `error.stage`, `error.file`, `error.line`, `error.column`, and `error.excerpt`; `tests/core/test_value_behavior.c` adds `test_error_item_preserves_compiler_diagnostic_fields` to verify `set_compiler_error_item` behavior. 
- The test harness reported a passing run for the compiled test binary (`tests/test-compiler`) with the modified tests included.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4813e0fd40832ea094d28341d6678f)