### PR TITLE
Unify compiler diagnostic string ownership

### DIFF
--- a/src/compiler/compdiag.c
+++ b/src/compiler/compdiag.c
@@ -10,7 +10,22 @@
 #include <string.h>
 
 #include "error.h"
-#include "memory.h"
+static char *compiler_diag_strdup(const char *s) {
+  const char *safe = s ? s : "";
+  size_t len = strlen(safe);
+  char *copy = malloc(len + 1);
+  if (!copy) return NULL;
+  memcpy(copy, safe, len + 1);
+  return copy;
+}
+
+static void compiler_diag_free(char *s) {
+  free(s);
+}
+
+char *compdiag_copy_detail(const char *errdetail) {
+  return errdetail ? compiler_diag_strdup(errdetail) : NULL;
+}
 
 static char *compdiag_alloc_detail(const char *phase, const char *msg) {
   const char *safe_phase = phase ? phase : "comp";
@@ -19,7 +34,7 @@ static char *compdiag_alloc_detail(const char *phase, const char *msg) {
   int needed = snprintf(NULL, 0, "%s: %s", safe_phase, safe_msg);
   if (needed < 0) return NULL;
 
-  char *buf = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+  char *buf = malloc((size_t)needed + 1);
   if (!buf) return NULL;
 
   snprintf(buf, (size_t)needed + 1, "%s: %s", safe_phase, safe_msg);
@@ -56,8 +71,7 @@ bool compdiag_set_once_diag(int8_t *current_errnum, char **errdetail,
     compiler_diag_set(diag, new_errnum, diag_phase, formatted ? formatted : detail);
   }
   if (!errdetail && formatted) {
-    size_t len = strlen(formatted);
-    FREE_ARRAY(char, formatted, len + 1);
+    compiler_diag_free(formatted);
   }
   return true;
 }
@@ -75,7 +89,7 @@ bool compdiag_setf_once(int8_t *current_errnum, char **errdetail,
                              "formatting error");
   }
 
-  char *msg = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+  char *msg = malloc((size_t)needed + 1);
   if (!msg) {
     return compdiag_set_once(current_errnum, errdetail, new_errnum, phase,
                              "out of memory");
@@ -86,7 +100,7 @@ bool compdiag_setf_once(int8_t *current_errnum, char **errdetail,
   va_end(args);
 
   bool recorded = compdiag_set_once(current_errnum, errdetail, new_errnum, phase, msg);
-  FREE_ARRAY(char, msg, (size_t)needed + 1);
+  compiler_diag_free(msg);
   return recorded;
 }
 
@@ -106,7 +120,7 @@ bool compdiag_setf_once_diag(int8_t *current_errnum, char **errdetail,
                                   diag_phase, phase, "formatting error");
   }
 
-  char *msg = GROW_ARRAY(char, NULL, 0, (size_t)needed + 1);
+  char *msg = malloc((size_t)needed + 1);
   if (!msg) {
     return compdiag_set_once_diag(current_errnum, errdetail, diag, new_errnum,
                                   diag_phase, phase, "out of memory");
@@ -118,25 +132,16 @@ bool compdiag_setf_once_diag(int8_t *current_errnum, char **errdetail,
 
   bool recorded = compdiag_set_once_diag(current_errnum, errdetail, diag,
                                          new_errnum, diag_phase, phase, msg);
-  FREE_ARRAY(char, msg, (size_t)needed + 1);
+  compiler_diag_free(msg);
   return recorded;
 }
 void compdiag_reset_detail(char **errdetail) {
   if (!errdetail || !*errdetail) return;
 
-  size_t len = strlen(*errdetail);
-  FREE_ARRAY(char, *errdetail, len + 1);
+  compiler_diag_free(*errdetail);
   *errdetail = NULL;
 }
 
-static char *compiler_diag_strdup(const char *s) {
-  const char *safe = s ? s : "";
-  size_t len = strlen(safe);
-  char *copy = malloc(len + 1);
-  if (!copy) return NULL;
-  memcpy(copy, safe, len + 1);
-  return copy;
-}
 
 void compiler_diag_init(CompilerDiagnostic *d) {
   if (!d) return;
@@ -152,10 +157,10 @@ void compiler_diag_init(CompilerDiagnostic *d) {
 
 void compiler_diag_reset(CompilerDiagnostic *d) {
   if (!d) return;
-  free(d->message);
-  free(d->stable_code);
-  free(d->source_name);
-  free(d->excerpt);
+  compiler_diag_free(d->message);
+  compiler_diag_free(d->stable_code);
+  compiler_diag_free(d->source_name);
+  compiler_diag_free(d->excerpt);
   compiler_diag_init(d);
 }
 
@@ -179,13 +184,13 @@ void compiler_diag_set_location(CompilerDiagnostic *d, int line, int column, int
 
 void compiler_diag_set_source_name(CompilerDiagnostic *d, const char *source_name) {
   if (!d) return;
-  free(d->source_name);
+  compiler_diag_free(d->source_name);
   d->source_name = compiler_diag_strdup(source_name ? source_name : "");
 }
 
 void compiler_diag_set_excerpt(CompilerDiagnostic *d, const char *excerpt) {
   if (!d) return;
-  free(d->excerpt);
+  compiler_diag_free(d->excerpt);
   d->excerpt = compiler_diag_strdup(excerpt ? excerpt : "");
 }
 

--- a/src/compiler/compdiag.h
+++ b/src/compiler/compdiag.h
@@ -43,6 +43,7 @@ bool compdiag_setf_once_diag(int8_t *current_errnum, char **errdetail,
                              CompilerDiagnostic *diag, int8_t new_errnum,
                              DiagPhase diag_phase, const char *phase,
                              const char *fmt, ...);
+char *compdiag_copy_detail(const char *errdetail);
 void compdiag_reset_detail(char **errdetail);
 
 void compiler_diag_init(CompilerDiagnostic *d);

--- a/src/compiler/compiler_pipeline.c
+++ b/src/compiler/compiler_pipeline.c
@@ -171,7 +171,7 @@ int8_t compile_parse_input_to_bytecode_diag(const ParseInput *input, OUTPUT_t **
     free(excerpt);
   }
 
-  free(errdetail);
+  compdiag_reset_detail(&errdetail);
   free(parse_state.offending_token);
   compiler_context_destroy(&ctx);
   return rc;

--- a/src/compiler/lower.c
+++ b/src/compiler/lower.c
@@ -610,7 +610,7 @@ int8_t lower_ast_to_ir_diag(AS_NODE *root, SEM_CTX *sem, IR_Unit **out_ir, char 
   if (errdetail) {
     *errdetail = ctx.errdetail;
   } else if (ctx.errdetail) {
-    free(ctx.errdetail);
+    compdiag_reset_detail(&ctx.errdetail);
   }
   return ctx.errnum;
 }

--- a/src/compiler/semant.c
+++ b/src/compiler/semant.c
@@ -273,7 +273,7 @@ int8_t sem_check_locals_diag(AS_NODE *root, char **errdetail, CompilerDiagnostic
   sem_walk(ctx, root);
 
   if (errdetail) {
-    *errdetail = ctx->errdetail ? strdup(ctx->errdetail) : NULL;
+    *errdetail = compdiag_copy_detail(ctx->errdetail);
   }
 
   if (diag && ctx->errnum != ERR_NOERROR) {

--- a/tests/compiler/test_compiler_diag_pipeline.c
+++ b/tests/compiler/test_compiler_diag_pipeline.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "compiler_pipeline.h"
+#include "compdiag.h"
 #include "semant.h"
 #include "lower.h"
 #include "ir.h"
@@ -57,7 +58,40 @@ static void test_scomp_cli_malformed_diagnostic_shape(void) {
   remove(err_path);
 }
 
+static void test_compiler_diag_repeated_set_reset_cycles(void) {
+  CompilerDiagnostic d;
+  compiler_diag_init(&d);
+
+  for (int i = 0; i < 256; i++) {
+    compiler_diag_set(&d, ERR_COMP_SYNTAX, DIAG_PHASE_PARSE, "parse: repeated diagnostic");
+    compiler_diag_set_source_name(&d, "repeat.sin");
+    compiler_diag_set_excerpt(&d, "^;");
+    ASSERT_NOT_NULL(d.message);
+    ASSERT_NOT_NULL(d.stable_code);
+    ASSERT_NOT_NULL(d.source_name);
+    ASSERT_NOT_NULL(d.excerpt);
+    compiler_diag_reset(&d);
+    ASSERT_TRUE(d.message == NULL);
+    ASSERT_TRUE(d.stable_code == NULL);
+    ASSERT_TRUE(d.source_name == NULL);
+    ASSERT_TRUE(d.excerpt == NULL);
+    ASSERT_TRUE(!d.has_loc);
+  }
+
+  char *errdetail = NULL;
+  for (int i = 0; i < 256; i++) {
+    int8_t errnum = ERR_NOERROR;
+    ASSERT_TRUE(compdiag_setf_once(&errnum, &errdetail, ERR_COMP_SYNTAX, "diag",
+                                   "repeated detail %d", i));
+    ASSERT_EQ_INT(ERR_COMP_SYNTAX, errnum);
+    ASSERT_NOT_NULL(errdetail);
+    compdiag_reset_detail(&errdetail);
+    ASSERT_TRUE(errdetail == NULL);
+  }
+}
+
 void test_compiler_diag_pipeline(void){
+  test_compiler_diag_repeated_set_reset_cycles();
   test_scomp_cli_malformed_diagnostic_shape();
   OUTPUT_t *out=NULL; CompilerDiagnostic d; compiler_diag_init(&d);
   int8_t rc = compile_source_to_bytecode_diag("^;",2,&out,&d);
@@ -102,7 +136,7 @@ void test_compiler_diag_pipeline(void){
   ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
   ASSERT_NOT_NULL(errdetail);
   ASSERT_TRUE(strstr(errdetail, "custom_source.sin") != NULL);
-  free(errdetail);
+  compdiag_reset_detail(&errdetail);
 
   compiler_diag_reset(&d);
   rc = compile_parse_input_to_bytecode_diag(&named_input, &out, &d);
@@ -122,7 +156,7 @@ void test_compiler_diag_pipeline(void){
   ASSERT_EQ_INT(ERR_COMP_UNKNOWNCHAR, rc);
   ASSERT_EQ_INT(DIAG_PHASE_PARSE, d.phase);
   ASSERT_NOT_NULL(errdetail);
-  free(errdetail);
+  compdiag_reset_detail(&errdetail);
   free(parse_state.offending_token);
 
   compiler_diag_reset(&d);
@@ -134,7 +168,7 @@ void test_compiler_diag_pipeline(void){
   rc = sem_check_locals_diag(ast, &errdetail, &d, sem);
   ASSERT_EQ_INT(ERR_COMP_LOCALBEFOREDEF, rc);
   ASSERT_EQ_INT(DIAG_PHASE_SEMANT, d.phase);
-  free(errdetail);
+  compdiag_reset_detail(&errdetail);
   as_delete(ast);
   sem_delete_ctx(sem);
 
@@ -145,21 +179,21 @@ void test_compiler_diag_pipeline(void){
   ASSERT_TRUE(rc != ERR_NOERROR);
   (void)ir;
   ASSERT_EQ_INT(DIAG_PHASE_LOWER, d.phase);
-  free(errdetail);
+  compdiag_reset_detail(&errdetail);
 
   compiler_diag_reset(&d);
   errdetail = NULL;
   rc = ir_validate_diag(NULL, 0, &errdetail, &d);
   ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
   ASSERT_EQ_INT(DIAG_PHASE_IR_VALIDATE, d.phase);
-  free(errdetail);
+  compdiag_reset_detail(&errdetail);
 
   compiler_diag_reset(&d);
   errdetail = NULL;
   rc = emit_bytecode_diag(NULL, 0, 0, NULL, &errdetail, &d);
   ASSERT_EQ_INT(ERR_COMP_SYNTAX, rc);
   ASSERT_EQ_INT(DIAG_PHASE_EMITBC, d.phase);
-  free(errdetail);
+  compdiag_reset_detail(&errdetail);
 
   compiler_diag_reset(&d);
   rc = compile_source_to_bytecode_diag(NULL, 0, &out, &d);


### PR DESCRIPTION
### Motivation
- Eliminate inconsistent allocation/free conventions for diagnostic-owned strings and ensure callers and the diagnostic module use a single convention to avoid double-free/UB with sanitizers.
- Provide helper APIs within the diagnostics module to centralize allocation and freeing semantics for messages and `errdetail` copies.
- Add sanitizer-friendly test coverage around repeated allocate/reset cycles to catch lifetime regressions early.

### Description
- Introduced internal allocation helpers `compiler_diag_strdup` and `compiler_diag_free` and a public `compdiag_copy_detail` in `src/compiler/compdiag.c/.h` and made all diagnostic-owned strings use these helpers instead of a mix of `malloc`/`GROW_ARRAY`/`FREE_ARRAY`/`free`.
- Changed `compdiag_reset_detail` and `compiler_diag_reset` to release owned strings with the new `compiler_diag_free` helper so frees match the allocator.
- Updated call sites to use the new helpers and consistent ownership: `src/compiler/semant.c` now uses `compdiag_copy_detail` when returning `errdetail`, `src/compiler/lower.c` and `src/compiler/compiler_pipeline.c` use `compdiag_reset_detail` instead of calling `free` directly.
- Reworked `tests/compiler/test_compiler_diag_pipeline.c` to clean up `errdetail` via `compdiag_reset_detail` and added `test_compiler_diag_repeated_set_reset_cycles` which repeatedly sets and resets diagnostics and `errdetail` to exercise allocator/free behavior under heavy reuse.

### Testing
- Ran the full test suite with `make test` and observed all tests pass (124/124).
- Ran sanitizer-enabled tests with `make test-asan` and observed the test suite passes under ASan/UBSan (124/124), covering repeated allocate/reset cycles added in the new test.
- Integrated compile/test cycles during development to validate no sanitizer failures and to confirm the modified call sites handle ownership consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4815cb7c64832e87802bbc27c482fe)