### PR TITLE
Refactor runtime bytecode decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ LIB_OBJECTS := $(OBJ_DIR)/log.o $(OBJ_DIR)/memory.o $(OBJ_DIR)/bytecode_verify.o
                $(OBJ_DIR)/compiler/ir.o $(OBJ_DIR)/compiler/lower.o $(OBJ_DIR)/compiler/compiler_context.o $(OBJ_DIR)/compiler/compiler_pipeline.o $(OBJ_DIR)/compiler/emitbc.o \
                $(OBJ_DIR)/compiler/compdiag.o $(OBJ_DIR)/error.o $(OBJ_DIR)/util.o $(OBJ_DIR)/libcall.o \
                $(OBJ_DIR)/stack.o $(OBJ_DIR)/value.o $(OBJ_DIR)/item.o \
-               $(OBJ_DIR)/vm.o $(OBJ_DIR)/task.o $(OBJ_DIR)/interpret.o \
+               $(OBJ_DIR)/vm.o $(OBJ_DIR)/task.o $(OBJ_DIR)/runtime_decode.o $(OBJ_DIR)/interpret.o \
                $(OBJ_DIR)/network.o $(OBJ_DIR)/libtelnet.o
 
 # Parser files for library

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -22,6 +22,7 @@
 #include "value.h"
 #include "stack.h"
 #include "item.h"
+#include "runtime_decode.h"
 
 // The configuration object, defined in sin.c
 extern CONFIG_t config;
@@ -72,52 +73,21 @@ static bool verify_runtime_bytecode(RuntimeContext *ctx, ITEM_t *item) {
   return false;
 }
 
-static inline bool require_bytes(RuntimeContext *ctx, uint8_t *nextop, size_t bytes, const char *opname) {
-  if (!ctx->current_frame_start || !ctx->current_frame_end) return true;
-  if (nextop > ctx->current_frame_end || (size_t)(ctx->current_frame_end - nextop) < bytes) {
-    char detail[128];
-    snprintf(detail, sizeof(detail), "%s truncated bytecode read (%zu bytes)", opname, bytes);
-    logerr("%s.\n", detail);
-    set_error_item(ERR_RUNTIME_TRUNCATED, detail);
-    return false;
+static bool report_decode_status(RuntimeDecodeStatus status) {
+  if (runtime_decode_status_ok(status)) return true;
+  if (status.code == RUNTIME_DECODE_TRUNCATED) {
+    logerr("%s.\n", status.detail);
+    set_error_item(ERR_RUNTIME_TRUNCATED, status.detail);
   }
-  return true;
+  return false;
+}
+
+static uint8_t *decode_next(RuntimeDecodeStatus status) {
+  return report_decode_status(status) ? status.next : NULL;
 }
 
 #define REQUIRE_BYTES(nextop, n, opname) \
-  do { if (!require_bytes(ctx, (nextop), (n), (opname))) return NULL; } while (0)
-
-static uint8_t *bc_read_u8(RuntimeContext *ctx, uint8_t *nextop, uint8_t *out, const char *opname) {
-  REQUIRE_BYTES(nextop, sizeof(*out), opname);
-  memcpy(out, nextop, sizeof(*out));
-  return nextop + sizeof(*out);
-}
-
-static uint8_t *bc_read_u16(RuntimeContext *ctx, uint8_t *nextop, uint16_t *out, const char *opname) {
-  REQUIRE_BYTES(nextop, sizeof(*out), opname);
-  memcpy(out, nextop, sizeof(*out));
-  return nextop + sizeof(*out);
-}
-
-static uint8_t *bc_read_i16(RuntimeContext *ctx, uint8_t *nextop, int16_t *out, const char *opname) {
-  REQUIRE_BYTES(nextop, sizeof(*out), opname);
-  memcpy(out, nextop, sizeof(*out));
-  return nextop + sizeof(*out);
-}
-
-static uint8_t *bc_read_u64_payload(RuntimeContext *ctx, uint8_t *nextop, uint64_t *out, const char *opname) {
-  REQUIRE_BYTES(nextop, sizeof(*out), opname);
-  memcpy(out, nextop, sizeof(*out));
-  return nextop + sizeof(*out);
-}
-
-static uint8_t *bc_read_i64(RuntimeContext *ctx, uint8_t *nextop, int64_t *out, const char *opname) {
-  uint64_t payload;
-  uint8_t *after = bc_read_u64_payload(ctx, nextop, &payload, opname);
-  if (!after) return NULL;
-  memcpy(out, &payload, sizeof(*out));
-  return after;
-}
+  do { if (!report_decode_status(require_bytes(&ctx->decoder, (nextop), (n), (opname)))) return NULL; } while (0)
 
 uint8_t *op_undefined(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item);
 typedef struct {
@@ -344,7 +314,7 @@ uint8_t *op_pushint(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   (void)item;
   VALUE_t v;
   v.type = VALUE_int;
-  nextop = bc_read_i64(ctx, nextop, &v.i, "OP_PUSHINT");
+  nextop = decode_next(bc_read_i64(&ctx->decoder, nextop, &v.i, "OP_PUSHINT"));
   if (!nextop) return NULL;
   push_stack(VM->stack, v);
   DISASS_LOG("OP_PUSHINT: %ld\n", v.i);
@@ -356,7 +326,7 @@ uint8_t *op_pushfloat(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   VALUE_t v;
   v.type = VALUE_float;
   uint64_t bits;
-  nextop = bc_read_u64_payload(ctx, nextop, &bits, "OP_PUSHFLOAT");
+  nextop = decode_next(bc_read_u64_payload(&ctx->decoder, nextop, &bits, "OP_PUSHFLOAT"));
   if (!nextop) return NULL;
   v.f = value_float_from_bits(bits);
   push_stack(VM->stack, v);
@@ -367,7 +337,7 @@ uint8_t *op_pushfloat(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
 uint8_t *op_pushbool(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   (void)item;
   uint8_t raw;
-  nextop = bc_read_u8(ctx, nextop, &raw, "OP_PUSHBOOL");
+  nextop = decode_next(bc_read_u8(&ctx->decoder, nextop, &raw, "OP_PUSHBOOL"));
   if (!nextop) return NULL;
   VALUE_t v;
   v.type = VALUE_bool;
@@ -382,7 +352,7 @@ uint8_t *op_inclocal(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   // If that local is an int, increment it.  Otherwise complain.
   (void)item;
   uint8_t raw_index;
-  nextop = bc_read_u8(ctx, nextop, &raw_index, "OP_INCLOCAL");
+  nextop = decode_next(bc_read_u8(&ctx->decoder, nextop, &raw_index, "OP_INCLOCAL"));
   if (!nextop) return NULL;
   uint8_t index = raw_index + VM->stack->base;
   if (VM->stack->stack[index].type == VALUE_int) {
@@ -399,7 +369,7 @@ uint8_t *op_declocal(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   // If that local is an int, decrement it.  Otherwise complain.
   (void)item;
   uint8_t raw_index;
-  nextop = bc_read_u8(ctx, nextop, &raw_index, "OP_DECLOCAL");
+  nextop = decode_next(bc_read_u8(&ctx->decoder, nextop, &raw_index, "OP_DECLOCAL"));
   if (!nextop) return NULL;
   uint8_t index = raw_index + VM->stack->base;
   if (VM->stack->stack[index].type == VALUE_int) {
@@ -416,7 +386,7 @@ uint8_t *op_jump(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   // SIGNED int, and then modify the bytecode pointer by that amount.
   (void)item;
   int16_t offset;
-  nextop = bc_read_i16(ctx, nextop, &offset, "OP_JUMP");
+  nextop = decode_next(bc_read_i16(&ctx->decoder, nextop, &offset, "OP_JUMP"));
   if (!nextop) return NULL;
   DISASS_LOG("OP_JUMP: offset is  %d.\n", offset);
   return nextop - sizeof(offset) + offset;
@@ -431,7 +401,7 @@ uint8_t *op_jumpfalse(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   (void)item;
   int16_t offset;
   uint8_t *offset_start = nextop;
-  nextop = bc_read_i16(ctx, nextop, &offset, "OP_JUMPFALSE");
+  nextop = decode_next(bc_read_i16(&ctx->decoder, nextop, &offset, "OP_JUMPFALSE"));
   if (!nextop) return NULL;
   VALUE_t v1;
   v1 = pop_stack(VM->stack);
@@ -454,7 +424,7 @@ uint8_t *op_savelocal(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   // Interpret the next byte as an index into the stack.
   (void)item;
   uint8_t raw_index;
-  nextop = bc_read_u8(ctx, nextop, &raw_index, "OP_SAVELOCAL");
+  nextop = decode_next(bc_read_u8(&ctx->decoder, nextop, &raw_index, "OP_SAVELOCAL"));
   if (!nextop) return NULL;
   uint8_t index = raw_index + VM->stack->base;
   // First check if the current value is a string.  If so, free it.
@@ -469,7 +439,7 @@ uint8_t *op_getlocal(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   // Interpret the next byte as an index into the stack.
   (void)item;
   uint8_t raw_index;
-  nextop = bc_read_u8(ctx, nextop, &raw_index, "OP_GETLOCAL");
+  nextop = decode_next(bc_read_u8(&ctx->decoder, nextop, &raw_index, "OP_GETLOCAL"));
   if (!nextop) return NULL;
   uint8_t index = raw_index + VM->stack->base;
 
@@ -498,7 +468,7 @@ uint8_t *op_pushstr(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   v.type = VALUE_str;
   uint16_t len;
   // Get the length
-  nextop = bc_read_u16(ctx, nextop, &len, "OP_PUSHSTR length");
+  nextop = decode_next(bc_read_u16(&ctx->decoder, nextop, &len, "OP_PUSHSTR length"));
   if (!nextop) return NULL;
   REQUIRE_BYTES(nextop, len, "OP_PUSHSTR payload");
   v.s = malloc((size_t)len + 1);
@@ -690,7 +660,7 @@ uint8_t *op_logicalor(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
 
 uint8_t *op_libcall_token(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   uint8_t token;
-  nextop = bc_read_u8(ctx, nextop, &token, "OP_LIBCALL");
+  nextop = decode_next(bc_read_u8(&ctx->decoder, nextop, &token, "OP_LIBCALL"));
   if (!nextop) return NULL;
   DISASS_LOG("Calling libcall token %d.\n", token);
   OP_t libcall = libcall_func_token(token);
@@ -978,7 +948,7 @@ uint8_t *op_fetchitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
 
   // First, let's get the number of arguments passed to this item
   uint16_t arg_count;
-  nextop = bc_read_u16(ctx, nextop, &arg_count, "OP_FETCHITEM arg-count");
+  nextop = decode_next(bc_read_u16(&ctx->decoder, nextop, &arg_count, "OP_FETCHITEM arg-count"));
   if (!nextop) return NULL;
 
   // Now the item name.
@@ -1028,7 +998,7 @@ uint8_t *op_fetchitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
         // correctly adjusted to account for them at the top of the
         // current stack (they will be at the bottom of the frame for
         // the new item).
-        push_callstack(VM, item, nextop, i->bytecode[1], ctx->current_frame_start, ctx->current_frame_end);
+        push_callstack(VM, item, nextop, i->bytecode[1], (uint8_t *)ctx->decoder.frame_start, (uint8_t *)ctx->decoder.frame_end);
         // Invariant at call-entry:
         // - caller VM stack/base/locals/params are captured in callstack.
         // - caller continuation (item + nextop + bytecode bounds) is captured.
@@ -1453,8 +1423,7 @@ VALUE_t interpret(RuntimeContext *ctx, ITEM_t *item) {
 
   if (!verify_runtime_bytecode(ctx, ctx->current_item)) {
     ctx->current_item = NULL;
-    ctx->current_frame_start = NULL;
-    ctx->current_frame_end = NULL;
+    runtime_decoder_init(&ctx->decoder, NULL, NULL);
     return VALUE_NIL;
   }
 
@@ -1464,8 +1433,7 @@ VALUE_t interpret(RuntimeContext *ctx, ITEM_t *item) {
   VM->stack->locals = ctx->current_item->bytecode[0];
   VM->stack->params = ctx->current_item->bytecode[1];
   uint8_t *op = ctx->current_item->bytecode + 2;
-  ctx->current_frame_start = op;
-  ctx->current_frame_end = ctx->current_item->bytecode + ctx->current_item->bytecode_len;
+  runtime_decoder_init(&ctx->decoder, op, ctx->current_item->bytecode + ctx->current_item->bytecode_len);
 
   while (true) {
     if (*op == 'h') {
@@ -1473,8 +1441,7 @@ VALUE_t interpret(RuntimeContext *ctx, ITEM_t *item) {
       ctx->current_item->inuse = false;
 
       if (size_callstack(VM->callstack) == 0) {
-        ctx->current_frame_start = NULL;
-        ctx->current_frame_end = NULL;
+        runtime_decoder_init(&ctx->decoder, NULL, NULL);
         ctx->current_item = NULL;
         return return_value;
       }
@@ -1486,8 +1453,7 @@ VALUE_t interpret(RuntimeContext *ctx, ITEM_t *item) {
       ctx->current_item = prev_frame->item;
       ctx->current_item->inuse = true;
       op = prev_frame->nextop;
-      ctx->current_frame_start = prev_frame->bytecode_start;
-      ctx->current_frame_end = prev_frame->bytecode_end;
+      runtime_decoder_init(&ctx->decoder, prev_frame->bytecode_start, prev_frame->bytecode_end);
       push_stack(VM->stack, return_value);
       continue;
     }
@@ -1503,13 +1469,11 @@ VALUE_t interpret(RuntimeContext *ctx, ITEM_t *item) {
         VM->stack->locals = ctx->current_item->bytecode[0];
         VM->stack->params = ctx->current_item->bytecode[1];
         op = ctx->current_item->bytecode + 2;
-        ctx->current_frame_start = op;
-        ctx->current_frame_end = ctx->current_item->bytecode + ctx->current_item->bytecode_len;
+        runtime_decoder_init(&ctx->decoder, op, ctx->current_item->bytecode + ctx->current_item->bytecode_len);
         continue;
       }
       ctx->current_item->inuse = false;
-      ctx->current_frame_start = NULL;
-      ctx->current_frame_end = NULL;
+      runtime_decoder_init(&ctx->decoder, NULL, NULL);
       ctx->current_item = NULL;
       return VALUE_NIL;
     }

--- a/src/runtime_context.h
+++ b/src/runtime_context.h
@@ -9,6 +9,7 @@
 
 #include "item.h"
 #include "vm.h"
+#include "runtime_decode.h"
 
 typedef struct RuntimeContext RuntimeContext;
 
@@ -18,8 +19,7 @@ typedef uint8_t *(*OP_t)(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item);
 
 struct RuntimeContext {
   VM_t *vm;
-  uint8_t *current_frame_start;
-  uint8_t *current_frame_end;
+  RuntimeDecoder decoder;
   ITEM_t *current_item;
   ITEM_t *pending_call_item;
   OP_t opcode[256];

--- a/src/runtime_decode.c
+++ b/src/runtime_decode.c
@@ -1,0 +1,78 @@
+// Runtime bytecode decoder helpers
+
+// Licensed under the MIT License - see LICENSE file for details.
+
+#include "runtime_decode.h"
+
+#include <stdio.h>
+#include <string.h>
+
+void runtime_decoder_init(RuntimeDecoder *decoder, const uint8_t *frame_start, const uint8_t *frame_end) {
+  if (!decoder) return;
+  decoder->frame_start = frame_start;
+  decoder->frame_end = frame_end;
+}
+
+bool runtime_decode_status_ok(RuntimeDecodeStatus status) {
+  return status.code == RUNTIME_DECODE_OK;
+}
+
+static RuntimeDecodeStatus runtime_decode_ok(uint8_t *next) {
+  RuntimeDecodeStatus status;
+  status.code = RUNTIME_DECODE_OK;
+  status.next = next;
+  status.detail[0] = '\0';
+  return status;
+}
+
+static RuntimeDecodeStatus runtime_decode_truncated(size_t bytes, const char *opname) {
+  RuntimeDecodeStatus status;
+  status.code = RUNTIME_DECODE_TRUNCATED;
+  status.next = NULL;
+  snprintf(status.detail, sizeof(status.detail), "%s truncated bytecode read (%zu bytes)", opname, bytes);
+  return status;
+}
+
+RuntimeDecodeStatus require_bytes(const RuntimeDecoder *decoder, uint8_t *nextop, size_t bytes, const char *opname) {
+  if (!decoder || !decoder->frame_start || !decoder->frame_end) return runtime_decode_ok(nextop);
+  if ((const uint8_t *)nextop > decoder->frame_end || (size_t)(decoder->frame_end - (const uint8_t *)nextop) < bytes) {
+    return runtime_decode_truncated(bytes, opname);
+  }
+  return runtime_decode_ok(nextop);
+}
+
+RuntimeDecodeStatus bc_read_u8(const RuntimeDecoder *decoder, uint8_t *nextop, uint8_t *out, const char *opname) {
+  RuntimeDecodeStatus status = require_bytes(decoder, nextop, sizeof(*out), opname);
+  if (!runtime_decode_status_ok(status)) return status;
+  memcpy(out, nextop, sizeof(*out));
+  return runtime_decode_ok(nextop + sizeof(*out));
+}
+
+RuntimeDecodeStatus bc_read_u16(const RuntimeDecoder *decoder, uint8_t *nextop, uint16_t *out, const char *opname) {
+  RuntimeDecodeStatus status = require_bytes(decoder, nextop, sizeof(*out), opname);
+  if (!runtime_decode_status_ok(status)) return status;
+  memcpy(out, nextop, sizeof(*out));
+  return runtime_decode_ok(nextop + sizeof(*out));
+}
+
+RuntimeDecodeStatus bc_read_i16(const RuntimeDecoder *decoder, uint8_t *nextop, int16_t *out, const char *opname) {
+  RuntimeDecodeStatus status = require_bytes(decoder, nextop, sizeof(*out), opname);
+  if (!runtime_decode_status_ok(status)) return status;
+  memcpy(out, nextop, sizeof(*out));
+  return runtime_decode_ok(nextop + sizeof(*out));
+}
+
+RuntimeDecodeStatus bc_read_u64_payload(const RuntimeDecoder *decoder, uint8_t *nextop, uint64_t *out, const char *opname) {
+  RuntimeDecodeStatus status = require_bytes(decoder, nextop, sizeof(*out), opname);
+  if (!runtime_decode_status_ok(status)) return status;
+  memcpy(out, nextop, sizeof(*out));
+  return runtime_decode_ok(nextop + sizeof(*out));
+}
+
+RuntimeDecodeStatus bc_read_i64(const RuntimeDecoder *decoder, uint8_t *nextop, int64_t *out, const char *opname) {
+  uint64_t payload;
+  RuntimeDecodeStatus status = bc_read_u64_payload(decoder, nextop, &payload, opname);
+  if (!runtime_decode_status_ok(status)) return status;
+  memcpy(out, &payload, sizeof(*out));
+  return status;
+}

--- a/src/runtime_decode.h
+++ b/src/runtime_decode.h
@@ -1,0 +1,55 @@
+// Runtime bytecode decoder helpers
+
+// Licensed under the MIT License - see LICENSE file for details.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum RuntimeDecodeCode {
+  RUNTIME_DECODE_OK = 0,
+  RUNTIME_DECODE_TRUNCATED
+} RuntimeDecodeCode;
+
+typedef struct RuntimeDecoder {
+  const uint8_t *frame_start;
+  const uint8_t *frame_end;
+} RuntimeDecoder;
+
+typedef struct RuntimeDecodeStatus {
+  RuntimeDecodeCode code;
+  uint8_t *next;
+  char detail[128];
+} RuntimeDecodeStatus;
+
+/*
+ * Initialize a non-owning decoder view over the active bytecode frame.
+ * The decoder does not allocate, copy, or free bytecode; callers retain
+ * ownership of the memory referenced by frame_start and frame_end.
+ */
+void runtime_decoder_init(RuntimeDecoder *decoder, const uint8_t *frame_start, const uint8_t *frame_end);
+
+/*
+ * Ensure that bytes are available at nextop without advancing nextop.
+ * Returns RUNTIME_DECODE_TRUNCATED with a stable detail string when the
+ * requested range is outside the decoder frame. A decoder with a NULL start
+ * or end is treated as unbounded for compatibility with legacy callers.
+ */
+RuntimeDecodeStatus require_bytes(const RuntimeDecoder *decoder, uint8_t *nextop, size_t bytes, const char *opname);
+
+/*
+ * Read helpers copy the requested payload from nextop into out and return the
+ * first unread byte in status.next. On success, nextop advances exactly by the
+ * size of the decoded type. On failure, out is left untouched and status.next
+ * is NULL; callers should stop interpreting the current frame and surface the
+ * returned structured status as an interpreter/runtime error.
+ */
+RuntimeDecodeStatus bc_read_u8(const RuntimeDecoder *decoder, uint8_t *nextop, uint8_t *out, const char *opname);
+RuntimeDecodeStatus bc_read_u16(const RuntimeDecoder *decoder, uint8_t *nextop, uint16_t *out, const char *opname);
+RuntimeDecodeStatus bc_read_i16(const RuntimeDecoder *decoder, uint8_t *nextop, int16_t *out, const char *opname);
+RuntimeDecodeStatus bc_read_u64_payload(const RuntimeDecoder *decoder, uint8_t *nextop, uint64_t *out, const char *opname);
+RuntimeDecodeStatus bc_read_i64(const RuntimeDecoder *decoder, uint8_t *nextop, int64_t *out, const char *opname);
+
+bool runtime_decode_status_ok(RuntimeDecodeStatus status);


### PR DESCRIPTION
### Motivation
- Remove ad-hoc bytecode-read helpers and implicit dependencies on frame globals to centralize decoding logic and make reads explicit and testable.
- Provide a non-owning decoder view and structured decode statuses so opcode handlers can translate failures into runtime errors consistently.

### Description
- Add a new decoder module with `src/runtime_decode.h` and `src/runtime_decode.c` introducing `RuntimeDecoder`, `RuntimeDecodeStatus`, and read helpers `bc_read_u8`, `bc_read_u16`, `bc_read_i16`, `bc_read_u64_payload`, and `bc_read_i64` that return structured `RuntimeDecodeStatus` values and include ownership/pointer-advance documentation in the header.
- Replace `current_frame_start`/`current_frame_end` in `RuntimeContext` with a `RuntimeDecoder` field and initialize/clear it via `runtime_decoder_init` at frame entry/return/call sites in `src/interpret.c`.
- Move bytecode-bound checks into `require_bytes` in the decoder and convert interpreter checks to use `report_decode_status`/`decode_next` so opcode handlers call `bc_read_*(&ctx->decoder, ...)` and receive NULL on error while `ERR_RUNTIME_TRUNCATED` is still set with the same detail text.
- Update `push_callstack` calls to pass the decoder bounds via `(uint8_t *)ctx->decoder.frame_start` and `(uint8_t *)ctx->decoder.frame_end` and add `runtime_decode.o` to the shared library build in the `Makefile`.

### Testing
- Built and ran the full test suite with `make test`, which completed and reported all tests passing (124/124).
- Rebuilt and ran with stricter warnings via `make test-warnings`, which also completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bda9e9a78832eb0fac26df36ef0e7)