### PR TITLE
Thread runtime dependencies through RuntimeContext

### DIFF
--- a/src/interpret.c
+++ b/src/interpret.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#include "config.h"
 #include "error.h"
 #include "util.h"
 #include "interpret.h"
@@ -24,9 +23,6 @@
 #include "runtime_item_ops.h"
 #include "runtime_opcode.h"
 #include "runtime_value.h"
-
-// The configuration object, defined in sin.c
-extern CONFIG_t config;
 
 #define VM ctx->vm
 
@@ -47,7 +43,7 @@ static const char *runtime_item_label(ITEM_t *item, char *buffer, size_t size) {
 }
 
 static bool verify_runtime_bytecode(RuntimeContext *ctx, ITEM_t *item) {
-  if (!config.strict_validation || !item || item->type != ITEM_code) return true;
+  if (!ctx->strict_validation || !item || item->type != ITEM_code) return true;
 
   char item_name[MAX_ITEM_NAME] = {0};
   const char *label = runtime_item_label(item, item_name, sizeof(item_name));
@@ -607,11 +603,11 @@ uint8_t *op_assigncodeitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
     itemname.s = strdup(fullname);
   }
 
-  result = compile_and_insert_codeitem(config.itemroot, &itemname, &in, &errdetail);
+  result = compile_and_insert_codeitem(ctx->itemroot, &itemname, &in, &errdetail);
   if (result == 0) {
-    persist_codeitem_source(config.itemroot, &itemname, &in);
-    set_item(config.itemroot, "error", VALUE_NIL);
-    set_item(config.itemroot, "error.msg", VALUE_NIL);
+    persist_codeitem_source(ctx->itemroot, &itemname, &in);
+    set_item(ctx->itemroot, "error", VALUE_NIL);
+    set_item(ctx->itemroot, "error.msg", VALUE_NIL);
   } else {
     logerr("Compilation failed.\n");
     set_error_item(result, errdetail);
@@ -644,7 +640,7 @@ uint8_t *op_assignitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
       logerr("Unable to create item '%s': failed to resolve canonical name.\n", itemname.s);
     }
   }
-  assignitem(config.itemroot, &itemname, val);
+  assignitem(ctx->itemroot, &itemname, val);
   return nextop;
 }
 
@@ -677,7 +673,7 @@ uint8_t *op_fetchitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
       FREE_STR(itemname);
       return nextop;
     }
-    ITEM_t *i = find_item_cached(config.itemroot, fullname, NULL);
+    ITEM_t *i = find_item_cached(ctx->itemroot, fullname, NULL);
     if (i) {
       ITEMDEBUG_LOG("Fetched item %s (called with %d arguments).\n", fullname, arg_count);
       // Just push the item value onto the stack.
@@ -855,7 +851,7 @@ uint8_t *assembleitem_helper(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item,
             VALUE_t layername = pop_stack(VM->stack);
             if (layername.type == VALUE_str) {
               //  This is basically the same as op_fetchitem
-              ITEM_t *i = find_item(config.itemroot, layername.s);
+              ITEM_t *i = find_item(ctx->itemroot, layername.s);
               if (i) {
                 // We have an item.  Only two value types are allowed.
                 switch (i->value.type) {
@@ -1004,7 +1000,7 @@ uint8_t *op_delete(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   if (val.type == VALUE_str) {
     char fullname[MAX_ITEM_NAME];
     if (canonicalize_itemname(val.s, item, fullname)) {
-      delete_item(config.itemroot, fullname);
+      delete_item(ctx->itemroot, fullname);
     } else {
       logerr("OP_DELETE failed to resolve canonical name for '%s'.\n", val.s);
     }
@@ -1033,7 +1029,7 @@ uint8_t *op_exists(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
     push_stack(VM->stack, VALUE_FALSE);
     return nextop;
   }
-  ITEM_t *i = find_item(config.itemroot, fullname);
+  ITEM_t *i = find_item(ctx->itemroot, fullname);
   FREE_STR(val);
   push_stack(VM->stack, i ? VALUE_TRUE : VALUE_FALSE);
   DISASS_LOG("OP_EXISTS\n");
@@ -1050,7 +1046,7 @@ uint8_t *op_nthname(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   VALUE_t itemname = pop_stack(VM->stack);
   bool found = false;
   if (index.type == VALUE_int && index.i >= 0 && itemname.type == VALUE_str) {
-    ITEM_t *i = find_item(config.itemroot, itemname.s);
+    ITEM_t *i = find_item(ctx->itemroot, itemname.s);
     if (i) {
       ITEM_t *child = find_item_by_index(i, index.i);
       if (child) {
@@ -1076,7 +1072,7 @@ uint8_t *op_rootname(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   VALUE_t index = pop_stack(VM->stack);
   bool found = false;
   if (index.type == VALUE_int && index.i >= 0) {
-    ITEM_t *child = find_item_by_index(config.itemroot, index.i);
+    ITEM_t *child = find_item_by_index(ctx->itemroot, index.i);
     if (child) {
       found = true;
       VALUE_t result = {VALUE_str, {0}};
@@ -1105,8 +1101,8 @@ VALUE_t interpret(RuntimeContext *ctx, ITEM_t *item) {
     init_interpreter(ctx);
     ctx->interpreter_initialized = true;
   }
-  set_item(config.itemroot, "error", VALUE_NIL);
-  set_item(config.itemroot, "error.msg", VALUE_NIL);
+  set_item(ctx->itemroot, "error", VALUE_NIL);
+  set_item(ctx->itemroot, "error.msg", VALUE_NIL);
   // Given some bytecode, interpret it until the HALT instruction is seen
   // NB: The HALT opcode (currently represented by the character 'h') does
   // not have an associated function.

--- a/src/libcall.c
+++ b/src/libcall.c
@@ -10,7 +10,6 @@
 #include "util.h"
 #include "error.h"
 #include "memory.h"
-#include "config.h"
 #include "network.h"
 #include "task.h"
 #include "libcall.h"
@@ -20,9 +19,6 @@
 #include "compiler_pipeline.h"
 #include "interpret.h"
 #include "floatconv.h"
-
-// Configuration object.  Defined in sin.c
-extern CONFIG_t config;
 
 // Connected lines.  Defined in network.c
 extern LINE_t *line;
@@ -69,10 +65,10 @@ uint8_t *lc_sys_backup(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   time_t now = time(NULL);
   struct tm *tm_now = localtime(&now);
   strftime(timestamp, sizeof(timestamp), "%Y%m%d-%H%M%S", tm_now);
-  char backupfile[strlen(config.itemstore)+strlen(timestamp)+2];
-  snprintf(backupfile, sizeof(backupfile), "%s_%s", config.itemstore,
+  char backupfile[strlen(ctx->itemstore_filename)+strlen(timestamp)+2];
+  snprintf(backupfile, sizeof(backupfile), "%s_%s", ctx->itemstore_filename,
                                                                 timestamp);
-  if (!save_itemstore(backupfile, config.itemroot)) {
+  if (!save_itemstore(backupfile, ctx->itemroot)) {
     logerr("sys.backup failed to persist itemstore backup '%s'.\n",
            backupfile);
   }
@@ -123,8 +119,8 @@ uint8_t *lc_sys_shutdown(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   // This call takes no parameters.
   (void)item;
   logmsg("Sys.shutdown called.  Shutting down.\n");
-  config.safe_shutdown = true;
-  uv_stop(config.loop);
+  (*ctx->safe_shutdown) = true;
+  uv_stop(ctx->loop);
   // libcalls always return a value.
   push_stack(VM->stack, VALUE_NIL);
   return nextop;
@@ -136,8 +132,8 @@ uint8_t *lc_sys_abort(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   // This call takes no parameters.
   (void)item;
   logmsg("Sys.abort called.  Immediate (and messy) shutdown.\n");
-  config.safe_shutdown = false;
-  uv_stop(config.loop);
+  (*ctx->safe_shutdown) = false;
+  uv_stop(ctx->loop);
   // libcalls always return a value.
   push_stack(VM->stack, VALUE_NIL);
   return nextop;
@@ -208,7 +204,7 @@ uint8_t *lc_sys_compile(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   // nested interpret() run. This keeps Sys.compile safe when invoked from
   // within an already-active interpreter frame.
   uint32_t len = out->nextbyte - out->bytecode;
-  ITEM_t *tmpitem = insert_code_item(config.itemroot, tmpname, len, out->bytecode);
+  ITEM_t *tmpitem = insert_code_item(ctx->itemroot, tmpname, len, out->bytecode);
 
   if (!tmpitem) {
     // Could not create temp item (likely in-use/name conflict).
@@ -230,7 +226,7 @@ uint8_t *lc_sys_compile(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   }
 
   // Best-effort cleanup of temp item
-  delete_item(config.itemroot, tmpname);
+  delete_item(ctx->itemroot, tmpname);
 
   // clear compiler/runtime error indicators on success
   clear_error_item();
@@ -249,12 +245,11 @@ void execute_task_cb(uv_timer_t *req) {
   DEBUG_LOG("Executing task %s (id: %d)\n", task->itemname, task->id);
   // Each task runs in its own VM (which may not be necessary, but
   // we will keep it up for now).
-  config.vm = task->vm;
-  ITEM_t *item = find_item(config.itemroot, task->itemname);
+  RuntimeContext *task_ctx = &task->runtime_context;
+  task_ctx->vm = task->vm;
+  ITEM_t *item = find_item(task_ctx->itemroot, task->itemname);
   if (item && item->type == ITEM_code) {
-    RuntimeContext task_ctx;
-    runtime_context_init(&task_ctx, task->vm);
-    VALUE_t ret = interpret(&task_ctx, item);
+    VALUE_t ret = interpret(task_ctx, item);
     reset_stack(task->vm->stack);
     if (ret.type == VALUE_int) {
       logmsg("Bytecode interpreter returned: %ld\n", ret.i);
@@ -302,7 +297,7 @@ uint8_t *lc_task_newgametask(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item)
     return lc_invalid_args_detail_return(ctx, nextop, VALUE_NIL,
         "task.newgametask expects string item name and integer start/repeat intervals; floats are invalid for intervals");
   }
-  ITEM_t *taskitem = find_item(config.itemroot, itemname.s);
+  ITEM_t *taskitem = find_item(ctx->itemroot, itemname.s);
   if (!taskitem) {
     // If the task item doesn't exist, it can't be run.
     // Ownership: free itemname once on this error path before returning.
@@ -316,10 +311,12 @@ uint8_t *lc_task_newgametask(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item)
   repeatin.i *= 100;
   startin.i *= 100;
   TASK_t *newtask = make_task(itemname.s, repeatin.i);
+  newtask->runtime_context = *ctx;
+  newtask->runtime_context.vm = newtask->vm;
   // Success path: this is the only free on this path (the !taskitem branch returns).
   FREE_STR(itemname);
   // Now add the task to the game loop starting at the correct interval
-  uv_timer_init(config.loop, newtask->timer);
+  uv_timer_init(ctx->loop, newtask->timer);
   // The handle needs to be able to access its task
   newtask->timer->data = newtask;
   // Off we go!
@@ -361,45 +358,45 @@ uint8_t *lc_net_input(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   // We operate a fair queuing process here.  Everyone
   // gets a turn.  Find the next activity.
   (void)item;
-  config.lastconn++;
-  if (config.maxconns == 0 || config.lastconn >= config.maxconns) {
-    config.lastconn = 0;
+  (*ctx->lastconn)++;
+  if ((*ctx->maxconns) == 0 || (*ctx->lastconn) >= (*ctx->maxconns)) {
+    (*ctx->lastconn) = 0;
   }
-  while (config.lastconn < config.maxconns) {
+  while ((*ctx->lastconn) < (*ctx->maxconns)) {
     VALUE_t val = {VALUE_int, {0}};
     // Find some activity.
-    switch (line[config.lastconn].status) {
+    switch (line[(*ctx->lastconn)].status) {
       case LINE_connecting:
-        line[config.lastconn].status = LINE_idle;
+        line[(*ctx->lastconn)].status = LINE_idle;
         // Set the input item to the current line
-        val.i = (long)config.lastconn;
-        set_item(config.itemroot, config.inputline, val);
+        val.i = (long)(*ctx->lastconn);
+        set_item(ctx->itemroot, ctx->inputline_name, val);
         // And return a value from this libcall to say what happened.
         val.i = 1;
         push_stack(VM->stack, val);
         return nextop;
       case LINE_disconnecting:
-        destroy_line(&line[config.lastconn]);
-        line[config.lastconn].status = LINE_empty;
+        destroy_line(&line[(*ctx->lastconn)]);
+        line[(*ctx->lastconn)].status = LINE_empty;
         // Set the input item to the current line
-        val.i = (long)config.lastconn;
-        set_item(config.itemroot, config.inputline, val);
+        val.i = (long)(*ctx->lastconn);
+        set_item(ctx->itemroot, ctx->inputline_name, val);
         val.i = 2;
         push_stack(VM->stack, val);
         return nextop;
       case LINE_data:
         // Set the input item to the current line
-        val.i = (long)config.lastconn;
-        set_item(config.itemroot, config.inputline, val);
+        val.i = (long)(*ctx->lastconn);
+        set_item(ctx->itemroot, ctx->inputline_name, val);
         // And grab some data.
         VALUE_t str = {VALUE_str, {0}};
-        str.s = get_input(&line[config.lastconn]);
-        set_item(config.itemroot, config.inputtext, str);
+        str.s = get_input(&line[(*ctx->lastconn)]);
+        set_item(ctx->itemroot, ctx->inputtext_name, str);
         val.i = 3;
         push_stack(VM->stack, val);
         return nextop;
       default:
-        config.lastconn++;
+        (*ctx->lastconn)++;
     }
   }
   // No activity found.
@@ -416,7 +413,7 @@ uint8_t *lc_net_write(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
   size_t line_index = 0;
 
   if (!lc_value_is_type(linenum, VALUE_int) || linenum.i < 0 ||
-      (size_t)linenum.i >= config.maxconns) {
+      (size_t)linenum.i >= (*ctx->maxconns)) {
     FREE_STR(out);
     FREE_STR(linenum);
     return lc_invalid_args_detail_return(ctx, nextop, VALUE_NIL,

--- a/src/network.c
+++ b/src/network.c
@@ -670,17 +670,18 @@ void init_listener(uint32_t port) {
 
 void input_processor(uv_idle_t* handle) {
   // Called once per iteration of the game loop
-  (void)handle;
-  config.vm = config.input_vm;
-  ITEM_t *input = find_item(config.itemroot, config.input);
+  RuntimeContext *input_ctx = handle ? (RuntimeContext *)handle->data : NULL;
+  if (!input_ctx) {
+    logerr("Input runtime context is missing! Cannot continue.\n");
+    exit(EXIT_FAILURE);
+  }
+  ITEM_t *input = find_item(input_ctx->itemroot, input_ctx->input_name);
   if (!input) {
     logerr("Input item does not exist!  Cannot continue.\n");
     exit(EXIT_FAILURE);
   }
-  RuntimeContext input_ctx;
-  runtime_context_init(&input_ctx, config.input_vm);
-  interpret(&input_ctx, input);
-  reset_stack(VM->stack);
+  interpret(input_ctx, input);
+  reset_stack(input_ctx->vm->stack);
   // Flush the output of every connected line
   for (size_t l = 0; l < config.maxconns; l++) {
     if (line[l].status != LINE_empty 

--- a/src/runtime_context.h
+++ b/src/runtime_context.h
@@ -6,6 +6,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
+#include <uv.h>
 
 #include "item.h"
 #include "vm.h"
@@ -18,7 +20,27 @@ typedef struct RuntimeContext RuntimeContext;
 typedef uint8_t *(*OP_t)(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item);
 
 struct RuntimeContext {
+  // Borrowed runtime dependencies supplied by process startup. Runtime
+  // execution mutates the VM stack/callstack, the item tree contents, the
+  // event loop handles, *maxconns, *lastconn, and *safe_shutdown, but does not
+  // own or free these pointers or strings.
   VM_t *vm;
+  ITEM_t *itemroot;
+  uv_loop_t *loop;
+  const char *itemstore_filename;
+  ITEMSTORE_DURABILITY_e itemstore_durability;
+  const char *srcroot;
+  const char *input_name;
+  const char *inputline_name;
+  const char *inputtext_name;
+  size_t *maxconns;
+  size_t *lastconn;
+  bool *safe_shutdown;
+  bool strict_validation;
+
+  // Owned by this RuntimeContext invocation and freely mutated while the
+  // interpreter runs. The bytecode and ITEM_t objects referenced by these
+  // fields remain borrowed from the itemstore or caller.
   RuntimeDecoder decoder;
   ITEM_t *current_item;
   ITEM_t *pending_call_item;

--- a/src/sin.c
+++ b/src/sin.c
@@ -33,6 +33,22 @@ jmp_buf recovery;
 // The configuration object - for passing interesting data around globally.
 CONFIG_t config;
 
+static void runtime_context_from_config(RuntimeContext *ctx, VM_t *vm) {
+  runtime_context_init(ctx, vm);
+  ctx->itemroot = config.itemroot;
+  ctx->loop = config.loop;
+  ctx->itemstore_filename = config.itemstore;
+  ctx->itemstore_durability = config.itemstore_durability;
+  ctx->srcroot = config.srcroot;
+  ctx->input_name = config.input;
+  ctx->inputline_name = config.inputline;
+  ctx->inputtext_name = config.inputtext;
+  ctx->maxconns = &config.maxconns;
+  ctx->lastconn = &config.lastconn;
+  ctx->safe_shutdown = &config.safe_shutdown;
+  ctx->strict_validation = config.strict_validation;
+}
+
 void close_all_tasks(uv_handle_t* handle, void* arg) {
   (void)arg;
   if (!uv_is_closing(handle)) { //FALSE, handle is closing
@@ -319,9 +335,6 @@ int main(int argc, char **argv) {
   DISASS_LOG("DISASS IS DEFINED\n");
   config.vm = make_vm();
   RuntimeContext boot_ctx;
-  runtime_context_init(&boot_ctx, config.vm);
-  init_interpreter(&boot_ctx);
-  boot_ctx.interpreter_initialized = true;
   // If the itemstore hasn't been loaded, do so now.
   if (!config.itemroot) {
     config.itemstore = strdup("items.dat");
@@ -338,6 +351,9 @@ int main(int argc, char **argv) {
   // so the loop needs to be read for 'em.
   config.loop = malloc(sizeof *config.loop);
   uv_loop_init(config.loop);
+  runtime_context_from_config(&boot_ctx, config.vm);
+  init_interpreter(&boot_ctx);
+  boot_ctx.interpreter_initialized = true;
 
   // This is a relatively safe restart point if things turn ugly.
   // This will need to be revisited once the eventloop is running.
@@ -348,7 +364,7 @@ int main(int argc, char **argv) {
     logerr("Destroying and recreating all stacks.\n");
     destroy_vm(config.vm);
     config.vm = make_vm();
-    runtime_context_init(&boot_ctx, config.vm);
+    runtime_context_from_config(&boot_ctx, config.vm);
   }
   // Execute the boot item.  This should set up all the tasks for
   // the main game.  It must not be an infinite loop!
@@ -382,12 +398,15 @@ int main(int argc, char **argv) {
     // Set up the item which handles input.
     logmsg("Using `%s` as the input item.\n", config.input);
     config.input_vm = make_vm();
+    config.maxconns = MAXCONNS;
+    config.lastconn = config.maxconns;
+    RuntimeContext input_ctx;
+    runtime_context_from_config(&input_ctx, config.input_vm);
     uv_idle_init(config.loop, &input_task);
+    input_task.data = &input_ctx;
     uv_idle_start(&input_task, input_processor);
     // Here we go...
     logmsg("Running...\n");
-    config.maxconns = MAXCONNS;
-    config.lastconn = config.maxconns;
     if (!validate_network_config()) {
       exit(EXIT_FAILURE);
     }

--- a/src/task.c
+++ b/src/task.c
@@ -71,6 +71,8 @@ TASK_t *make_task(char *itemname, uint64_t interval) {
   TASK_t *task = malloc(sizeof *task);
   strcpy(task->itemname, itemname);
   task->vm = make_vm();
+  memset(&task->runtime_context, 0, sizeof(task->runtime_context));
+  task->runtime_context.vm = task->vm;
   task->id = new_task_id();
   task->interval = interval;
   task->timer = malloc(sizeof *task->timer);

--- a/src/task.h
+++ b/src/task.h
@@ -9,12 +9,14 @@
 
 #include "vm.h"
 #include "item.h"
+#include "runtime_context.h"
 
 typedef struct {
   uint64_t id;
   uint64_t interval; // centiseconds
   uv_timer_t *timer;
   VM_t *vm;
+  RuntimeContext runtime_context;
   char itemname[MAX_ITEM_NAME];
 } TASK_t;
 
@@ -24,4 +26,3 @@ TASK_t *make_task(char *name, uint64_t interval);
 void destroy_task(TASK_t *task);
 void destroy_task_by_id(uint64_t id);
 TASK_t *find_task_by_id(uint64_t id);
-

--- a/tests/compiler/test_sys_compile_libcall.c
+++ b/tests/compiler/test_sys_compile_libcall.c
@@ -14,6 +14,8 @@ CONFIG_t config;
 static RuntimeContext test_runtime_ctx;
 static RuntimeContext *test_ctx(void) {
   runtime_context_init(&test_runtime_ctx, config.vm);
+  test_runtime_ctx.itemroot = config.itemroot;
+  test_runtime_ctx.strict_validation = config.strict_validation;
   return &test_runtime_ctx;
 }
 uint8_t *lc_sys_compile(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item);

--- a/tests/core/test_libcall_registry.c
+++ b/tests/core/test_libcall_registry.c
@@ -28,6 +28,14 @@ extern CONFIG_t config;
 static RuntimeContext test_runtime_ctx;
 static RuntimeContext *test_ctx(void) {
   runtime_context_init(&test_runtime_ctx, config.vm);
+  test_runtime_ctx.itemroot = config.itemroot;
+  test_runtime_ctx.strict_validation = config.strict_validation;
+  test_runtime_ctx.maxconns = &config.maxconns;
+  test_runtime_ctx.lastconn = &config.lastconn;
+  test_runtime_ctx.inputline_name = config.inputline;
+  test_runtime_ctx.inputtext_name = config.inputtext;
+  test_runtime_ctx.loop = config.loop;
+  test_runtime_ctx.safe_shutdown = &config.safe_shutdown;
   return &test_runtime_ctx;
 }
 

--- a/tests/core/test_relative_item_leading_dot.c
+++ b/tests/core/test_relative_item_leading_dot.c
@@ -56,6 +56,8 @@ static VALUE_t compile_and_run(const char *name, const char *source) {
   ASSERT_NOT_NULL(code);
   RuntimeContext ctx;
   runtime_context_init(&ctx, config.vm);
+  ctx.itemroot = config.itemroot;
+  ctx.strict_validation = config.strict_validation;
   VALUE_t result = interpret(&ctx, code);
 
   free(out->bytecode);

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -51,6 +51,8 @@ static void emit_str(uint8_t *code, size_t *pos, const char *value) {
 static VALUE_t run_interpret(ITEM_t *item) {
   RuntimeContext ctx;
   runtime_context_init(&ctx, config.vm);
+  ctx.itemroot = config.itemroot;
+  ctx.strict_validation = config.strict_validation;
   return interpret(&ctx, item);
 }
 

--- a/tests/interpreter/test_interpret_semantics_golden.c
+++ b/tests/interpreter/test_interpret_semantics_golden.c
@@ -233,6 +233,8 @@ void test_interpret_rejects_malformed_bytecode_before_execution(void) {
 
   RuntimeContext ctx;
   runtime_context_init(&ctx, config.vm);
+  ctx.itemroot = config.itemroot;
+  ctx.strict_validation = config.strict_validation;
   VALUE_t result = interpret(&ctx, code);
   ASSERT_EQ_INT(VALUE_nil, result.type);
   ITEM_t *err = find_item(config.itemroot, "error");


### PR DESCRIPTION
### Motivation

- Reduce global `CONFIG_t` reliance by making interpreter and libcalls read runtime dependencies from an explicit `RuntimeContext` so execution contexts are self-contained and easier to reason about.  
- Expose the common runtime inputs (VM, itemstore, loop, input names, validation flags, connection/shutdown state) so libcalls and interpreter validation can operate against the correct per-invocation environment.  
- Document ownership/aliasing so callers and runtime code know which fields are borrowed vs owned and which may be mutated during execution.

### Description

- Extended `RuntimeContext` with explicit borrowed runtime dependency fields: `vm`, `itemroot`, `loop`, `itemstore_filename`, `itemstore_durability`, `srcroot`, `input_name`, `inputline_name`, `inputtext_name`, pointer-to-`maxconns`, pointer-to-`lastconn`, pointer-to-`safe_shutdown`, and `strict_validation`, and added comments clarifying borrowed vs owned/mutable fields (`src/runtime_context.h`).
- Refactored interpreter code to read runtime configuration from the `RuntimeContext` (e.g. `ctx->strict_validation`, `ctx->itemroot`) instead of `extern CONFIG_t config` and updated interpreter initialization routines to use the context (`src/interpret.c`).
- Updated libcalls and related handlers to accept and use `RuntimeContext` fields (e.g. itemstore backup, `sys.shutdown`/`sys.abort`, `sys.compile`, task creation, net input/write) in place of `config.*` usages (`src/libcall.c`).
- Introduced `runtime_context_from_config` so process startup constructs/populates a `RuntimeContext` from the global `CONFIG_t`, and wired boot/input/task execution paths to use these contexts (`src/sin.c`, `src/network.c`).
- Attached a `RuntimeContext` to `TASK_t` so scheduled tasks inherit and carry the runtime dependencies into `execute_task_cb` (`src/task.h`, `src/task.c`) and ensured new tasks copy/adjust the context appropriately.
- Updated tests to populate the new `RuntimeContext` dependency fields where needed (several test sources under `tests/`), and made the input idle callback carry the `RuntimeContext` via `uv_idle_t.data`.

### Testing

- Built the project with `make` and compilation succeeded.  
- Ran the full test suite with `make test` and all tests passed; test harness summary: `tests=124/124` and runtime/compiler/core suites reported PASS.  
- Verified the changes by running `git diff --check` and project test harness output during development to ensure no regressions in runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c0c065800832e929893a6f2139295)