### PR TITLE
Document runtime ownership boundaries

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,76 @@
+# Runtime ownership and API boundaries
+
+This page summarizes the ownership contracts between the interpreter runtime,
+the itemstore, and native library-call handlers.
+
+## Runtime context and interpreter
+
+`RuntimeContext` is the execution context passed to opcode and libcall handlers.
+It borrows process-level dependencies such as the VM, itemstore root, libuv loop,
+configuration strings, network state, and shutdown flag. Runtime execution may
+mutate those dependencies, but the context does not own or free them.
+
+The context owns only its per-invocation interpreter bookkeeping, such as the
+runtime decoder, current item pointer, pending call item pointer, opcode table,
+and interpreter-initialization flag. The bytecode and items referenced by that
+bookkeeping remain owned by the itemstore or by the caller that supplied them.
+
+`interpret(ctx, item)` returns a `VALUE_t` by value. The caller owns that returned
+value and must free any string payload in it when the value is no longer needed.
+The interpreter borrows and mutates `ctx->vm`: it uses the existing VM stack and
+call stack, pushes and pops values while executing, and returns the top-level
+return value after popping it from the stack. It does not create an isolated VM
+stack for the call.
+
+During execution, the interpreter sets the executing code item's `inuse` flag to
+`true` and clears it when that top-level frame exits or aborts. Internal calls
+between code items update `inuse` as frames are entered and returned. The flag is
+used to prevent deletion or replacement of running code; it is not an ownership
+claim on the item.
+
+Nested calls to `interpret` with the same `RuntimeContext` are supported for
+runtime code paths that need to execute temporary or secondary code: the
+interpreter saves and restores decoder/current-item state around each call. The
+VM stack and call stack are still shared, so nested callers must account for the
+stack effects of both the nested code and its returned `VALUE_t`.
+
+## Itemstore ownership
+
+The item tree owns all `ITEM_t` nodes reachable from the root. Parent and child
+links are borrowed references within that tree; `destroy_item` recursively frees
+an item, its children, its child hash table, its ordered child-pointer array, its
+owned code bytecode buffer, and any owned string payload in a value item.
+
+Value items own their stored `VALUE_t` payload. When `make_item`, `insert_item`,
+or `set_item` stores a string `VALUE_t`, ownership of the string buffer transfers
+to the itemstore. Callers must not free or reuse that string after a successful
+store. Replacing a value item frees the previous owned payload.
+
+Code items own their bytecode buffers. `make_item` takes ownership of the
+bytecode pointer for code items, and `insert_code_item` takes ownership of the
+bytecode pointer when it successfully installs it. Callers retain ownership on
+validation failure or other failure before installation.
+
+`get_itemfilename` allocates and returns a path string for the caller to free.
+`save_itemsource` borrows both the item and source text only for the duration of
+the call. `load_itemstore` returns a newly allocated item tree on success; the
+caller owns that root and must release it with `destroy_item`.
+
+## Libcall API boundary
+
+Libcall handlers use the same opcode-handler signature as bytecode opcodes. The
+compiler emits bytecode that evaluates libcall arguments first, so handlers find
+their arguments on the VM stack. Each handler is responsible for consuming the
+number of arguments declared in the libcall registry and for leaving exactly one
+return value on the stack before returning `nextop`.
+
+Arguments popped from the stack are owned by the handler. If a popped argument is
+a string and the handler does not transfer it into the itemstore or return it to
+Sinistra code, the handler must free it. Arguments left in place, such as the
+string-mutating `str.*` calls, remain owned by the stack and become the return
+value.
+
+A libcall should push `VALUE_NIL`, `VALUE_FALSE`, or another explicit value for
+failure cases that are visible to Sinistra code. Returning `NULL` from a handler
+is reserved for fatal interpreter/opcode failures and causes interpretation to
+abort with `nil`.

--- a/src/interpret.h
+++ b/src/interpret.h
@@ -9,4 +9,18 @@
 #include "runtime_context.h"
 
 void init_interpreter(RuntimeContext *ctx);
+
+// Executes a code item in the supplied runtime context. The returned VALUE_t is
+// transferred to the caller by value; if it contains a string payload, the
+// caller owns that payload and must free it when finished. interpret() borrows
+// ctx, item, the itemstore, and ctx->vm, but mutates the VM stack/callstack while
+// executing. The top-level return value is popped from the stack before it is
+// returned.
+//
+// The executing ITEM_t has its inuse flag set while its frame is active and
+// cleared when that frame exits or aborts; the flag protects running code from
+// deletion/replacement and does not transfer item ownership. Nested calls using
+// the same RuntimeContext are supported: decoder/current-item state is saved and
+// restored around the call, but the VM stack and callstack remain shared and are
+// therefore intentionally affected by nested execution.
 VALUE_t interpret(RuntimeContext *ctx, ITEM_t *item);

--- a/src/item.h
+++ b/src/item.h
@@ -53,28 +53,50 @@ struct Item {
 
 // Itemstore API
 ITEM_t *make_root_item(const char *name);
-// make_item takes ownership of string payloads inside value for value items,
-// and takes ownership of bytecode for code items.
+// make_item creates an item owned by its parent/itemstore. For ITEM_value, the
+// item takes ownership of value, including any VALUE_str payload. For ITEM_code,
+// the item takes ownership of bytecode and frees it from destroy_item(); value is
+// ignored. On failure before an item is constructed, the caller still owns the
+// supplied payloads.
 ITEM_t *make_item(const char *name, ITEM_t *parent, ITEM_e type,
                                 VALUE_t value, uint8_t *bytecode, int len);
+// Recursively destroys item and all children. Frees owned bytecode for code
+// items, owned VALUE_t string payloads for value items, the child table, ordered
+// child-pointer array, and the ITEM_t itself.
 void destroy_item(ITEM_t *item);    
-// insert_item/set_item take ownership of string payloads inside value.
+// insert_item creates or replaces a value item. On success, the itemstore takes
+// ownership of value, including any VALUE_str payload; callers must not free the
+// string after transfer. Existing value payloads or code bytecode are freed
+// before replacement. If validation fails or replacement is rejected before the
+// value is stored, the caller retains ownership of value.
 ITEM_t *insert_item(ITEM_t *root, const char *item_name, VALUE_t value);
-// insert_code_item takes ownership of bytecode on success.
+// insert_code_item creates or replaces a code item. On success, the itemstore
+// takes ownership of bytecode and frees any previous code bytecode/value payload.
+// If validation fails or installation does not reach the final item, the caller
+// retains ownership of bytecode.
 ITEM_t *insert_code_item(ITEM_t *root, const char *item_name, uint32_t len,
                                                         uint8_t *bytecode);
 ITEM_t *find_item(ITEM_t *root, const char *item_name);
 ITEM_t *find_item_cached(ITEM_t *root, const char *item_name, bool *found);
 ITEM_t *find_item_by_index(ITEM_t *parent, const size_t index);
 void delete_item(ITEM_t *root, const char *item_name);
+// set_item creates or replaces a value item. The itemstore takes ownership of
+// value, including any VALUE_str payload, whether updating an existing item or
+// inserting a new one. If validation fails, the caller retains ownership.
 void set_item(ITEM_t *root, const char *item_name, VALUE_t value);
 void get_itemname(ITEM_t *item, char *itemname);
-// Returns a newly allocated string owned by the caller.
+// Returns a newly allocated source filename string owned by the caller; free it
+// with free(). The item is borrowed and not modified.
 char *get_itemfilename(ITEM_t *item);
+// Borrows item and source for the duration of the call. Does not take ownership
+// of source or modify/free it.
 bool save_itemsource(ITEM_t *item, char *source);
 bool itemstore_durability_requires_sync(ITEMSTORE_DURABILITY_e durability);
 void itemstore_set_sync_hook_for_tests(ITEMSTORE_SYNC_HOOK_t hook);
 bool save_itemstore(const char *filename, ITEM_t *root);
+// Loads and returns a newly allocated item tree. The caller owns the returned
+// root and must destroy it with destroy_item(); NULL indicates failure and
+// transfers no ownership.
 ITEM_t *load_itemstore(const char *filename); 
 void dump_item(ITEM_t *item, char *item_name, bool isroot);
 uint64_t get_itemstore_generation(void);

--- a/src/libcall.h
+++ b/src/libcall.h
@@ -8,3 +8,21 @@
 #pragma once
 
 #include "libcall_registry.h"
+
+// Libcall handlers use the OP_t opcode-handler ABI:
+//   uint8_t *handler(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item)
+// The compiler emits argument-evaluation bytecode before OP_LIBCALL, so handlers
+// receive their arguments on ctx->vm->stack. A handler must consume exactly the
+// number of arguments declared in the registry entry and leave exactly one
+// VALUE_t return value on the stack before returning nextop.
+//
+// Popped argument VALUE_t objects become owned by the handler. String payloads
+// in popped arguments must be freed unless the handler transfers ownership into
+// the itemstore or returns the same value to Sinistra code. Handlers that mutate
+// an argument in place without popping it leave that stack-owned value as the
+// return value. Return values pushed onto the stack transfer ownership to the VM
+// stack.
+//
+// Return nextop after normal completion, including Sinistra-visible failures that
+// push nil/false. Return NULL only for fatal interpreter failures; interpret()
+// treats NULL as an abort and returns VALUE_NIL.


### PR DESCRIPTION
### Motivation
- Clarify ownership and lifetime contracts between the interpreter, VM, and itemstore to avoid confusion and unsafe memory usage. 
- Make libcall handler expectations explicit so native handlers correctly manage stack values and string payloads. 
- Provide a single reference (`docs/runtime.md`) that describes runtime context, nested interpretation, and itemstore ownership semantics.

### Description
- Add detailed ownership and behavior comments to `src/interpret.h` documenting the return-value ownership of `interpret()`, that the VM stack/callstack are borrowed and mutated, how the executing item's `inuse` flag is set/cleared, and that nested calls save/restore decoder/current-item state while sharing the VM stack. 
- Extend `src/item.h` API comments to state that `make_item`, `insert_code_item` take ownership of bytecode for code items, `insert_item`/`set_item` take ownership of string `VALUE_t` payloads on success, `get_itemfilename` returns a newly allocated string the caller must free, `save_itemsource` only borrows its arguments, `load_itemstore` returns a newly allocated item tree owned by the caller, and `destroy_item` frees owned bytecode and value payloads. 
- Update `src/libcall.h` to document the libcall handler ABI (`uint8_t *handler(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item)`), expected stack effects (consume declared args and leave one return value), argument ownership rules (popped args become handler-owned, strings must be freed unless transferred/returned), and that returning `NULL` signals a fatal interpreter failure. 
- Add `docs/runtime.md` describing the `RuntimeContext` borrowing model, itemstore ownership boundaries, and libcall API contracts as a human-readable summary for developers.

### Testing
- Ran the full test suite with `make test`, which built the project and executed the tests; all tests passed (`status=PASS`, `tests=124/124`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c181a0e58832e89350570b9f4c3fd)