### PR TITLE
Add strict runtime contract diagnostics

### DIFF
--- a/docs/bytecode.md
+++ b/docs/bytecode.md
@@ -125,6 +125,14 @@ then behaves as follows:
 * If the target does not exist or the item name is invalid, it discards supplied
   arguments and pushes `nil`.
 
+By default, discarding arguments in these cases is silent for compatibility. When
+the runtime is started with `--strict-runtime-contracts`, the `F` primitive still
+performs the same stack normalization and return-value behavior, but each
+discarded argument caused by an over-arity code-item call, invalid item name, or
+missing target item sets `error` to `ERR_RUNTIME_INVALIDARGS` and writes a
+diagnostic to `error.msg`. This option is separate from `--strict-validation`,
+which validates bytecode structure before execution.
+
 The IR schema distinguishes the two producers of `F`:
 
 * `IR_OP_ITEM_DEREF` is a plain item dereference and has no IR operand; the

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -66,7 +66,7 @@ if error then
 endif;
 ```
 
-If you call `add` with no arguments, you are effectively calling `add{nil, nil};`, and so the result is `nil`.  Calling `add` with only one parameter also returns `nil` because if you add `nil` to anything, the result is always nil.  Calling `add{1, 2, 3};` returns 3, because the third argument is silently dropped.
+If you call `add` with no arguments, you are effectively calling `add{nil, nil};`, and so the result is `nil`.  Calling `add` with only one parameter also returns `nil` because if you add `nil` to anything, the result is always nil.  Calling `add{1, 2, 3};` returns 3, because the third argument is silently dropped. The default runtime keeps this legacy behavior for compatibility, including when arguments are supplied to a missing item or to an expression that does not resolve to an item name. Starting `sin` with `--strict-runtime-contracts` keeps executing with the same stack/result behavior, but records `ERR_RUNTIME_INVALIDARGS` in `error` and a diagnostic in `error.msg` whenever `F`/item-call evaluation has to discard those arguments.
 
 ## Comments ##
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -56,6 +56,18 @@ validation failure or other failure before installation.
 the call. `load_itemstore` returns a newly allocated item tree on success; the
 caller owns that root and must release it with `destroy_item`.
 
+## Runtime diagnostics options
+
+`--strict-validation` enables bytecode verification before runtime execution of
+code items. `--strict-runtime-contracts` is a separate compatibility diagnostic
+mode for runtime argument contracts. In legacy/default mode, item fetch/call
+execution may silently discard supplied arguments when a code item receives too
+many arguments, when the target item is missing, or when the computed item name
+is invalid. With strict runtime contracts enabled, those stack effects and return
+values are preserved, but the interpreter also sets `error` to
+`ERR_RUNTIME_INVALIDARGS`, writes a detail string to `error.msg`, and logs a
+runtime contract violation.
+
 ## Libcall API boundary
 
 Libcall handlers use the same opcode-handler signature as bytecode opcodes. The

--- a/src/config.h
+++ b/src/config.h
@@ -31,4 +31,5 @@ typedef struct {
   size_t lastconn;      // Last connection processed by net.input
   bool safe_shutdown;   // Determins how to shut down.
   bool strict_validation; // Verify bytecode at runtime before execution.
+  bool strict_runtime_contracts; // Report runtime contract violations that legacy mode tolerates.
 } CONFIG_t;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -130,9 +130,9 @@ static void set_runtime_bytecode_error(const char *label, uint32_t offset,
                                        const char *message) {
   const char *safe_label = label ? label : "<null>";
   const char *safe_message = message ? message : "<no diagnostic>";
-  const char *fmt =
-      "Runtime bytecode validation failed for item '%s' at offset %u: %s";
-  int needed = snprintf(NULL, 0, fmt, safe_label, offset, safe_message);
+  int needed = snprintf(NULL, 0,
+      "Runtime bytecode validation failed for item '%s' at offset %u: %s",
+      safe_label, offset, safe_message);
   if (needed < 0) {
     logerr("Runtime bytecode validation failed.\n");
     set_error_item(ERR_RUNTIME_BYTECODE,
@@ -149,7 +149,9 @@ static void set_runtime_bytecode_error(const char *label, uint32_t offset,
     return;
   }
 
-  snprintf(detail, detail_len, fmt, safe_label, offset, safe_message);
+  snprintf(detail, detail_len,
+      "Runtime bytecode validation failed for item '%s' at offset %u: %s",
+      safe_label, offset, safe_message);
   logerr("%s.\n", detail);
   set_error_item(ERR_RUNTIME_BYTECODE, detail);
   free(detail);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -874,6 +874,7 @@ uint8_t *op_fetchitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
         // - interpreter loop must transfer control to callee without recursion.
         ITEMDEBUG_LOG("Executing item %s\n", i->name);
         ctx->pending_call_item = i;
+        FREE_STR(itemname);
         return NULL;
       }
     } else {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -156,10 +156,53 @@ static void set_runtime_bytecode_error(const char *label, uint32_t offset,
 }
 
 
+static void set_runtime_context_error(RuntimeContext *ctx, int errnum,
+                                      const char *errdetail) {
+  if (!ctx || !ctx->itemroot) return;
+
+  VALUE_t e = {VALUE_int, {.i = errnum}};
+  set_item(ctx->itemroot, "error", e);
+
+  const char *base =
+      (errnum >= 0 && errnum < MAXERRORS && errmsg[errnum])
+          ? errmsg[errnum]
+          : "Unknown error";
+  int needed = errdetail ? snprintf(NULL, 0, "%s (%s)", base, errdetail)
+                         : snprintf(NULL, 0, "%s", base);
+  VALUE_t msg = VALUE_NIL;
+  if (needed >= 0) {
+    msg.type = VALUE_str;
+    msg.s = alloc_malloc((size_t)needed + 1u);
+    if (msg.s) {
+      if (errdetail) {
+        snprintf(msg.s, (size_t)needed + 1u, "%s (%s)", base, errdetail);
+      } else {
+        snprintf(msg.s, (size_t)needed + 1u, "%s", base);
+      }
+    }
+  }
+  if (msg.type != VALUE_str || !msg.s) {
+    msg.type = VALUE_str;
+    msg.s = strdup(base);
+  }
+  if (msg.s) {
+    set_item(ctx->itemroot, "error.msg", msg);
+  } else {
+    set_item(ctx->itemroot, "error.msg", VALUE_NIL);
+  }
+
+  set_item(ctx->itemroot, "error.code", VALUE_NIL);
+  set_item(ctx->itemroot, "error.stage", VALUE_NIL);
+  set_item(ctx->itemroot, "error.file", VALUE_NIL);
+  set_item(ctx->itemroot, "error.line", VALUE_NIL);
+  set_item(ctx->itemroot, "error.column", VALUE_NIL);
+  set_item(ctx->itemroot, "error.excerpt", VALUE_NIL);
+}
+
 static void report_strict_runtime_contract(RuntimeContext *ctx, const char *detail) {
   if (!ctx || !ctx->strict_runtime_contracts) return;
   logerr("Runtime contract violation: %s.\n", detail ? detail : "<no detail>");
-  set_error_item(ERR_RUNTIME_INVALIDARGS, detail);
+  set_runtime_context_error(ctx, ERR_RUNTIME_INVALIDARGS, detail);
 }
 
 static bool verify_runtime_bytecode(RuntimeContext *ctx, ITEM_t *item) {

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -155,6 +155,13 @@ static void set_runtime_bytecode_error(const char *label, uint32_t offset,
   free(detail);
 }
 
+
+static void report_strict_runtime_contract(RuntimeContext *ctx, const char *detail) {
+  if (!ctx || !ctx->strict_runtime_contracts) return;
+  logerr("Runtime contract violation: %s.\n", detail ? detail : "<no detail>");
+  set_error_item(ERR_RUNTIME_INVALIDARGS, detail);
+}
+
 static bool verify_runtime_bytecode(RuntimeContext *ctx, ITEM_t *item) {
   if (!ctx->strict_validation || !item || item->type != ITEM_code) return true;
 
@@ -776,6 +783,7 @@ uint8_t *op_fetchitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
       logerr("Unable to fetch item '%s': failed to resolve canonical name.\n", itemname.s);
       while (arg_count > 0) {
         DEBUG_LOG("Discarding argument for invalid canonical fetch name.\n");
+        report_strict_runtime_contract(ctx, "OP_FETCHITEM discarded argument for invalid canonical fetch name");
         throwaway_stack(VM->stack);
         arg_count--;
       }
@@ -799,6 +807,7 @@ uint8_t *op_fetchitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
         // If so, lose 'em.
         while (arg_count > i->bytecode[1]) {
           DEBUG_LOG("Popping unneeded argument.\n");
+          report_strict_runtime_contract(ctx, "OP_FETCHITEM discarded extra argument for target item");
           throwaway_stack(VM->stack);
           arg_count--;
         }
@@ -828,6 +837,7 @@ uint8_t *op_fetchitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
       // We need to lose any values on the stack which were passed as args.
         while (arg_count > 0) {
           DEBUG_LOG("Popping unneeded argument.\n");
+          report_strict_runtime_contract(ctx, "OP_FETCHITEM discarded argument for missing target item");
           throwaway_stack(VM->stack);
           arg_count--;
         }
@@ -838,6 +848,7 @@ uint8_t *op_fetchitem(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item) {
     logerr("Unable to fetch item: invalid item type for name: %d.\n", itemname.type);
     while (arg_count > 0) {
       DEBUG_LOG("Discarding argument for invalid item fetch name type.\n");
+      report_strict_runtime_contract(ctx, "OP_FETCHITEM discarded argument for invalid item fetch name type");
       throwaway_stack(VM->stack);
       arg_count--;
     }

--- a/src/item_hash.c
+++ b/src/item_hash.c
@@ -226,10 +226,10 @@ uint32_t murmur3_32(const char *key, size_t len, uint32_t seed) {
   uint32_t k1 = 0;
   switch (len & 3) {
     case 3:
-      k1 ^= tail[2] << 16;
+      k1 ^= ((uint32_t)tail[2]) << 16;
       __attribute__((fallthrough));
     case 2:
-      k1 ^= tail[1] << 8;
+      k1 ^= ((uint32_t)tail[1]) << 8;
       __attribute__((fallthrough));
     case 1:
       k1 ^= tail[0];

--- a/src/item_persist.c
+++ b/src/item_persist.c
@@ -197,7 +197,7 @@ static bool read_u8(FILE *file, uint8_t *value, const char *context) {
 static bool read_u16_le(FILE *file, uint16_t *value, const char *context) {
   uint8_t bytes[2];
   if (!read_bytes(file, bytes, sizeof(bytes), context)) return false;
-  *value = (uint16_t)bytes[0] | ((uint16_t)bytes[1] << 8);
+  *value = (uint16_t)(((uint16_t)bytes[0]) | ((uint16_t)bytes[1] << 8));
   return true;
 }
 

--- a/src/runtime_context.h
+++ b/src/runtime_context.h
@@ -48,6 +48,7 @@ struct RuntimeContext {
   LibcallNetworkDeps network;
   bool *safe_shutdown;
   bool strict_validation;
+  bool strict_runtime_contracts;
 
   // Owned by this RuntimeContext invocation and freely mutated while the
   // interpreter runs. The bytecode and ITEM_t objects referenced by these

--- a/src/sin.c
+++ b/src/sin.c
@@ -52,6 +52,7 @@ static void runtime_context_from_config(RuntimeContext *ctx, VM_t *vm) {
   ctx->network.inputline_name = config.inputline;
   ctx->network.inputtext_name = config.inputtext;
   ctx->strict_validation = config.strict_validation;
+  ctx->strict_runtime_contracts = config.strict_runtime_contracts;
   (void)runtime_init(ctx, vm);
 }
 
@@ -99,6 +100,9 @@ void usage() {
   logmsg("\t\t\t  given must exist or the interpreter will not run.\n");
   logmsg("     --strict-validation\n");
   logmsg("\t\t\t  Verify bytecode before runtime execution.\n");
+  logmsg("     --strict-runtime-contracts\n");
+  logmsg("\t\t\t  Report runtime argument contract violations that legacy\n");
+  logmsg("\t\t\t  mode silently tolerates.\n");
 }
 
 static ITEM_t *load_or_create_itemstore(const char *filename) {
@@ -123,9 +127,9 @@ static ITEM_t *load_or_create_itemstore(const char *filename) {
   return make_root_item("root");
 }
 
-static bool strict_validation_requested(int argc, char **argv) {
+static bool flag_requested(int argc, char **argv, const char *flag) {
   for (int i = 1; i < argc; i++) {
-    if (strcmp(argv[i], "--strict-validation") == 0) return true;
+    if (strcmp(argv[i], flag) == 0) return true;
   }
   return false;
 }
@@ -156,7 +160,8 @@ int main(int argc, char **argv) {
   /* Itemstores named with -i are loaded while options are processed. Detect
    * this global validation policy first so its effect is independent of
    * command-line option order. */
-  config.strict_validation = strict_validation_requested(argc, argv);
+  config.strict_validation = flag_requested(argc, argv, "--strict-validation");
+  config.strict_runtime_contracts = flag_requested(argc, argv, "--strict-runtime-contracts");
 
   // Do the very early preparations, for things which are needed
   // before even the options are processed.
@@ -184,6 +189,7 @@ int main(int argc, char **argv) {
     {"port", optional_argument, 0, 'p'},
     {"srcroot", required_argument, 0, 's'},
     {"strict-validation", no_argument, 0, 1000},
+    {"strict-runtime-contracts", no_argument, 0, 1001},
     {NULL, 0, 0, '\0'}
   };
   while ((opt = getopt_long(argc, argv, "bd:hi:l::n:o:p:s:", options, NULL)) != -1) {
@@ -302,6 +308,10 @@ int main(int argc, char **argv) {
       }
       case 1000: {
         config.strict_validation = true;
+        break;
+      }
+      case 1001: {
+        config.strict_runtime_contracts = true;
         break;
       }
       default: {

--- a/tests/compiler/test_emitbc_invariants.c
+++ b/tests/compiler/test_emitbc_invariants.c
@@ -210,7 +210,7 @@ static void test_emitbc_label_heavy_jump_targets_in_bounds(void) {
     }
     if (op == 'p' || op == 'P') pc += 8;
     else if (op == 'l' || op == 'B') {
-      uint16_t n = (uint16_t)out.bytecode[pc] | ((uint16_t)out.bytecode[pc + 1] << 8);
+      uint16_t n = (uint16_t)(((uint16_t)out.bytecode[pc]) | ((uint16_t)out.bytecode[pc + 1] << 8));
       pc += 2 + n;
     } else if (op == 'e' || op == 'c' || op == 'f' || op == 'g') pc += 1;
     else if (op == 'F') pc += 2;

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -823,6 +823,49 @@ void test_strict_runtime_contracts_reports_missing_item_arguments(void) {
   teardown_runtime();
 }
 
+void test_strict_runtime_contracts_uses_context_itemroot(void) {
+  memset(&config, 0, sizeof(config));
+  init_errmsg();
+  ITEM_t *root = make_root_item("root");
+  ASSERT_NOT_NULL(root);
+  VM_t *vm = make_vm();
+  ASSERT_NOT_NULL(vm);
+
+  uint8_t code[64] = {0};
+  size_t pos = 0;
+  code[pos++] = 0;
+  code[pos++] = 0;
+  code[pos++] = 'p'; emit_i64(code, &pos, 42);
+  code[pos++] = 'l'; emit_str(code, &pos, "strict_runtime.context_missing");
+  code[pos++] = 'F'; code[pos++] = 1; code[pos++] = 0;
+  code[pos++] = 'h';
+  uint8_t *bytecode = malloc(pos);
+  ASSERT_NOT_NULL(bytecode);
+  memcpy(bytecode, code, pos);
+  ITEM_t *runner = insert_code_item(root, "strict_runtime.context_runner",
+                                    (uint32_t)pos, bytecode);
+  ASSERT_NOT_NULL(runner);
+
+  RuntimeContext ctx;
+  runtime_context_init(&ctx, vm);
+  ctx.itemroot = root;
+  ctx.strict_runtime_contracts = true;
+  VALUE_t result = interpret(&ctx, runner);
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+
+  ITEM_t *err = find_item(root, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(ERR_RUNTIME_INVALIDARGS, err->value.i);
+  ITEM_t *msg = find_item(root, "error.msg");
+  ASSERT_NOT_NULL(msg);
+  ASSERT_EQ_INT(VALUE_str, msg->value.type);
+  ASSERT_TRUE(strstr(msg->value.s, "missing target item") != NULL);
+
+  destroy_vm(vm);
+  destroy_item(root);
+  memset(&config, 0, sizeof(config));
+}
+
 void test_strict_validation_runtime_opt_in(void) {
   setup_runtime();
   uint8_t code[] = {0, 0, 'e', 1, 'h'};

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -53,6 +53,7 @@ static VALUE_t run_interpret(ITEM_t *item) {
   runtime_context_init(&ctx, config.vm);
   ctx.itemroot = config.itemroot;
   ctx.strict_validation = config.strict_validation;
+  ctx.strict_runtime_contracts = config.strict_runtime_contracts;
   return interpret(&ctx, item);
 }
 
@@ -740,6 +741,85 @@ void test_interpreter_truncated_single_byte_operands(void) {
   setup_runtime();
   assert_truncated_bytecode_for_opcode("test.truncated_getlocal", 'e', "OP_GETLOCAL");
   assert_truncated_bytecode_for_opcode("test.truncated_libcall_token", 'M', "OP_LIBCALL");
+  teardown_runtime();
+}
+
+static void assert_error_nil(void) {
+  ITEM_t *err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(VALUE_nil, err->value.type);
+}
+
+static void assert_strict_runtime_contract_detail(const char *needle) {
+  ITEM_t *err = find_item(config.itemroot, "error");
+  ASSERT_NOT_NULL(err);
+  ASSERT_EQ_INT(ERR_RUNTIME_INVALIDARGS, err->value.i);
+  ITEM_t *msg = find_item(config.itemroot, "error.msg");
+  ASSERT_NOT_NULL(msg);
+  ASSERT_EQ_INT(VALUE_str, msg->value.type);
+  ASSERT_TRUE(strstr(msg->value.s, needle) != NULL);
+}
+
+static VALUE_t run_fetch_with_one_int_arg(const char *runner_name, VALUE_t fetch_name) {
+  uint8_t code[256] = {0};
+  size_t pos = 0;
+  code[pos++] = 0;
+  code[pos++] = 0;
+  code[pos++] = 'p'; emit_i64(code, &pos, 42);
+  if (fetch_name.type == VALUE_str) {
+    code[pos++] = 'l'; emit_str(code, &pos, fetch_name.s);
+  } else if (fetch_name.type == VALUE_int) {
+    code[pos++] = 'p'; emit_i64(code, &pos, fetch_name.i);
+  } else {
+    ASSERT_TRUE(false);
+  }
+  code[pos++] = 'F'; code[pos++] = 1; code[pos++] = 0;
+  code[pos++] = 'h';
+  return run_code(runner_name, code, pos);
+}
+
+void test_strict_runtime_contracts_default_preserves_fetch_argument_drops(void) {
+  setup_runtime();
+  config.strict_runtime_contracts = false;
+  VALUE_t name = {VALUE_str, {.s = "missing.default"}};
+  VALUE_t result = run_fetch_with_one_int_arg("strict_runtime.default_runner", name);
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  assert_error_nil();
+  teardown_runtime();
+}
+
+void test_strict_runtime_contracts_reports_too_many_item_arguments(void) {
+  setup_runtime();
+  uint8_t target_code[] = {0, 0, 'h'};
+  uint8_t *target = malloc(sizeof(target_code));
+  ASSERT_NOT_NULL(target);
+  memcpy(target, target_code, sizeof(target_code));
+  ASSERT_NOT_NULL(insert_code_item(config.itemroot, "strict_runtime.target", sizeof(target_code), target));
+  config.strict_runtime_contracts = true;
+  VALUE_t name = {VALUE_str, {.s = "strict_runtime.target"}};
+  VALUE_t result = run_fetch_with_one_int_arg("strict_runtime.too_many_runner", name);
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  assert_strict_runtime_contract_detail("extra argument for target item");
+  teardown_runtime();
+}
+
+void test_strict_runtime_contracts_reports_invalid_item_name_arguments(void) {
+  setup_runtime();
+  config.strict_runtime_contracts = true;
+  VALUE_t name = {VALUE_int, {.i = 7}};
+  VALUE_t result = run_fetch_with_one_int_arg("strict_runtime.invalid_name_runner", name);
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  assert_strict_runtime_contract_detail("invalid item fetch name type");
+  teardown_runtime();
+}
+
+void test_strict_runtime_contracts_reports_missing_item_arguments(void) {
+  setup_runtime();
+  config.strict_runtime_contracts = true;
+  VALUE_t name = {VALUE_str, {.s = "strict_runtime.missing"}};
+  VALUE_t result = run_fetch_with_one_int_arg("strict_runtime.missing_runner", name);
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  assert_strict_runtime_contract_detail("missing target item");
   teardown_runtime();
 }
 

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -152,10 +152,10 @@ void test_error_item_preserves_compiler_diagnostic_fields(void) {
   ASSERT_EQ_INT(VALUE_str, file->value.type);
   ASSERT_TRUE(strcmp(file->value.s, "example.sin") == 0);
 
-  ITEM_t *line = find_item(config.itemroot, "error.line");
-  ASSERT_NOT_NULL(line);
-  ASSERT_EQ_INT(VALUE_int, line->value.type);
-  ASSERT_EQ_INT(7, line->value.i);
+  ITEM_t *line_item = find_item(config.itemroot, "error.line");
+  ASSERT_NOT_NULL(line_item);
+  ASSERT_EQ_INT(VALUE_int, line_item->value.type);
+  ASSERT_EQ_INT(7, line_item->value.i);
 
   ITEM_t *column = find_item(config.itemroot, "error.column");
   ASSERT_NOT_NULL(column);

--- a/tests/interpreter/test_interpret_semantics_golden.c
+++ b/tests/interpreter/test_interpret_semantics_golden.c
@@ -72,12 +72,12 @@ static char *normalize_text(char *text) {
 static int contains_all_lines(const char *expected_lines, const char *actual, int *missing_line) {
   char *copy = strdup(expected_lines);
   ASSERT_NOT_NULL(copy);
-  int line = 0;
+  int marker_line = 0;
   for (char *tok = strtok(copy, "\n"); tok; tok = strtok(NULL, "\n")) {
-    line++;
+    marker_line++;
     if (tok[0] == '\0') continue;
     if (!strstr(actual, tok)) {
-      *missing_line = line;
+      *missing_line = marker_line;
       free(copy);
       return 0;
     }
@@ -153,19 +153,19 @@ static void assert_run_matches(const char *case_name, const char *variant,
     ASSERT_EQ_INT(expected->exit_code, actual->exit_code);
   }
 
-  int line = -1;
-  if (!contains_all_lines(expected->stdout_text, actual->stdout_text, &line)) {
+  int missing_line = -1;
+  if (!contains_all_lines(expected->stdout_text, actual->stdout_text, &missing_line)) {
     fprintf(stderr,
             "[%s/%s] mismatch stdout: expected marker line %d not found\n",
-            case_name, variant, line);
+            case_name, variant, missing_line);
     ASSERT_TRUE(0);
   }
 
-  line = -1;
-  if (!contains_all_lines(expected->stderr_text, actual->stderr_text, &line)) {
+  missing_line = -1;
+  if (!contains_all_lines(expected->stderr_text, actual->stderr_text, &missing_line)) {
     fprintf(stderr,
             "[%s/%s] mismatch stderr: expected marker line %d not found\n",
-            case_name, variant, line);
+            case_name, variant, missing_line);
     ASSERT_TRUE(0);
   }
 }

--- a/tests/network/test_network.c
+++ b/tests/network/test_network.c
@@ -14,7 +14,7 @@
 #include "runtime_context.h"
 
 CONFIG_t config;
-const char *test_harness_current_suite(void){return "network";} const char *test_harness_current_test(void){return "network";} void test_harness_failf(const char *file,int line,const char *fmt,...){fprintf(stderr,"fail %s:%d %s\n",file,line,fmt); exit(1);} 
+const char *test_harness_current_suite(void){return "network";} const char *test_harness_current_test(void){return "network";} void test_harness_failf(const char *file,int line_no,const char *fmt,...){fprintf(stderr,"fail %s:%d %s\n",file,line_no,fmt); exit(1);}
 
 typedef void (*test_fn_t)(void);
 typedef struct { const char *name; test_fn_t fn; } test_case_t;

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -156,6 +156,10 @@ void test_value_comparison_string_helpers(void);
 void test_value_comparison_mismatched_type_equality_quirk(void);
 void test_value_comparison_unsupported_ordering_is_false(void);
 void test_interpreter_truncated_single_byte_operands(void);
+void test_strict_runtime_contracts_default_preserves_fetch_argument_drops(void);
+void test_strict_runtime_contracts_reports_too_many_item_arguments(void);
+void test_strict_runtime_contracts_reports_invalid_item_name_arguments(void);
+void test_strict_runtime_contracts_reports_missing_item_arguments(void);
 void test_strict_validation_runtime_opt_in(void);
 void test_strict_validation_rejects_null_bytecode(void);
 
@@ -276,6 +280,10 @@ static const test_case_t core_tests[] = {
     {"test_value_comparison_mismatched_type_equality_quirk", test_value_comparison_mismatched_type_equality_quirk},
     {"test_value_comparison_unsupported_ordering_is_false", test_value_comparison_unsupported_ordering_is_false},
     {"test_interpreter_truncated_single_byte_operands", test_interpreter_truncated_single_byte_operands},
+    {"test_strict_runtime_contracts_default_preserves_fetch_argument_drops", test_strict_runtime_contracts_default_preserves_fetch_argument_drops},
+    {"test_strict_runtime_contracts_reports_too_many_item_arguments", test_strict_runtime_contracts_reports_too_many_item_arguments},
+    {"test_strict_runtime_contracts_reports_invalid_item_name_arguments", test_strict_runtime_contracts_reports_invalid_item_name_arguments},
+    {"test_strict_runtime_contracts_reports_missing_item_arguments", test_strict_runtime_contracts_reports_missing_item_arguments},
     {"test_strict_validation_runtime_opt_in", test_strict_validation_runtime_opt_in},
     {"test_strict_validation_rejects_null_bytecode", test_strict_validation_rejects_null_bytecode},
 };

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -160,6 +160,7 @@ void test_strict_runtime_contracts_default_preserves_fetch_argument_drops(void);
 void test_strict_runtime_contracts_reports_too_many_item_arguments(void);
 void test_strict_runtime_contracts_reports_invalid_item_name_arguments(void);
 void test_strict_runtime_contracts_reports_missing_item_arguments(void);
+void test_strict_runtime_contracts_uses_context_itemroot(void);
 void test_strict_validation_runtime_opt_in(void);
 void test_strict_validation_rejects_null_bytecode(void);
 
@@ -284,6 +285,7 @@ static const test_case_t core_tests[] = {
     {"test_strict_runtime_contracts_reports_too_many_item_arguments", test_strict_runtime_contracts_reports_too_many_item_arguments},
     {"test_strict_runtime_contracts_reports_invalid_item_name_arguments", test_strict_runtime_contracts_reports_invalid_item_name_arguments},
     {"test_strict_runtime_contracts_reports_missing_item_arguments", test_strict_runtime_contracts_reports_missing_item_arguments},
+    {"test_strict_runtime_contracts_uses_context_itemroot", test_strict_runtime_contracts_uses_context_itemroot},
     {"test_strict_validation_runtime_opt_in", test_strict_validation_runtime_opt_in},
     {"test_strict_validation_rejects_null_bytecode", test_strict_validation_rejects_null_bytecode},
 };


### PR DESCRIPTION
### Motivation

- Provide a separate runtime diagnostic mode that records argument-contract violations (dropped arguments) without changing the legacy stack/result behaviour. 
- Make the mode opt-in at process startup so bytecode strictness (`--strict-validation`) remains independent of runtime contract reporting.

### Description

- Add a new flag to configuration and runtime context: `strict_runtime_contracts` in `CONFIG_t` (`src/config.h`) and `RuntimeContext` (`src/runtime_context.h`).
- Wire a CLI option `--strict-runtime-contracts` into `src/sin.c`, detect it during startup, include help text, and copy the setting into each `RuntimeContext` in `runtime_context_from_config`.
- Implement `report_strict_runtime_contract(RuntimeContext*, const char*)` in `src/interpret.c` that logs and sets `error`/`error.msg` when enabled, and call it from `op_fetchitem` at the points where the interpreter previously `DEBUG_LOG`/silently discarded arguments (over-arity drops, invalid canonical fetch names, invalid item-name type, and missing targets) while preserving the original stack/result semantics.
- Add regression tests: new tests in `tests/core/test_value_behavior.c` and declarations/registration in `tests/shared/test_compiler.c` that assert legacy silent-dropping by default and verify `ERR_RUNTIME_INVALIDARGS` plus an `error.msg` diagnostic when `strict_runtime_contracts` is enabled.
- Update documentation and CLI help: `docs/concepts.md`, `docs/bytecode.md`, `docs/runtime.md`, and `src/sin.c` help text to describe the new option and that it is separate from `--strict-validation`.

### Testing

- Built the project with `make -j2` and the build completed successfully.
- Ran the full automated test suite with `make test`, which executed the test harness (core, compiler, runtime suites) and completed with all tests passing (total tests executed: 130; status=PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eaddafbdc832ebbab0168c3de09a3)