### PR TITLE
Clarify strict-validation behavior; propagate strict_runtime_contracts to test runtimes and add test

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -59,14 +59,20 @@ caller owns that root and must release it with `destroy_item`.
 ## Runtime diagnostics options
 
 `--strict-validation` enables bytecode verification before runtime execution of
-code items. `--strict-runtime-contracts` is a separate compatibility diagnostic
-mode for runtime argument contracts. In legacy/default mode, item fetch/call
-execution may silently discard supplied arguments when a code item receives too
-many arguments, when the target item is missing, or when the computed item name
-is invalid. With strict runtime contracts enabled, those stack effects and return
-values are preserved, but the interpreter also sets `error` to
-`ERR_RUNTIME_INVALIDARGS`, writes a detail string to `error.msg`, and logs a
-runtime contract violation.
+code items and while loading itemstores. It only checks whether encoded bytecode
+is structurally valid for execution; failures are reported as
+`ERR_RUNTIME_BYTECODE` (or reject the persisted code item during load).
+
+`--strict-runtime-contracts` is a separate compatibility diagnostic mode for
+runtime argument contracts. In default mode, item fetch/call execution may
+silently discard supplied arguments when a code item receives too many arguments,
+when the target item is missing, or when the computed item name is invalid. With
+strict runtime contracts enabled, those stack effects and return values are
+preserved, but the interpreter also sets `error` to `ERR_RUNTIME_INVALIDARGS`,
+writes a detail string to `error.msg`, and logs a runtime contract violation.
+Enabling `--strict-validation` alone does not enable these dropped-argument
+diagnostics; use `--strict-runtime-contracts` when you want runtime contract
+reporting.
 
 ## Libcall API boundary
 

--- a/src/sin.c
+++ b/src/sin.c
@@ -162,6 +162,8 @@ int main(int argc, char **argv) {
    * command-line option order. */
   config.strict_validation = flag_requested(argc, argv, "--strict-validation");
   config.strict_runtime_contracts = flag_requested(argc, argv, "--strict-runtime-contracts");
+  /* Runtime contract diagnostics are intentionally independent from bytecode
+   * validation and remain disabled unless explicitly requested. */
 
   // Do the very early preparations, for things which are needed
   // before even the options are processed.

--- a/tests/compiler/test_sys_compile_libcall.c
+++ b/tests/compiler/test_sys_compile_libcall.c
@@ -16,6 +16,7 @@ static RuntimeContext *test_ctx(void) {
   runtime_context_init(&test_runtime_ctx, config.vm);
   test_runtime_ctx.itemroot = config.itemroot;
   test_runtime_ctx.strict_validation = config.strict_validation;
+  test_runtime_ctx.strict_runtime_contracts = config.strict_runtime_contracts;
   return &test_runtime_ctx;
 }
 uint8_t *lc_sys_compile(RuntimeContext *ctx, uint8_t *nextop, ITEM_t *item);

--- a/tests/core/test_libcall_registry.c
+++ b/tests/core/test_libcall_registry.c
@@ -32,6 +32,7 @@ static RuntimeContext *test_ctx(void) {
   runtime_context_init(&test_runtime_ctx, config.vm);
   test_runtime_ctx.itemroot = config.itemroot;
   test_runtime_ctx.strict_validation = config.strict_validation;
+  test_runtime_ctx.strict_runtime_contracts = config.strict_runtime_contracts;
   test_runtime_ctx.maxconns = &config.maxconns;
   test_runtime_ctx.lastconn = &config.lastconn;
   test_runtime_ctx.inputline_name = config.inputline;

--- a/tests/core/test_relative_item_leading_dot.c
+++ b/tests/core/test_relative_item_leading_dot.c
@@ -58,6 +58,7 @@ static VALUE_t compile_and_run(const char *name, const char *source) {
   runtime_context_init(&ctx, config.vm);
   ctx.itemroot = config.itemroot;
   ctx.strict_validation = config.strict_validation;
+  ctx.strict_runtime_contracts = config.strict_runtime_contracts;
   VALUE_t result = interpret(&ctx, code);
 
   free(out->bytecode);

--- a/tests/core/test_value_behavior.c
+++ b/tests/core/test_value_behavior.c
@@ -788,6 +788,17 @@ void test_strict_runtime_contracts_default_preserves_fetch_argument_drops(void) 
   teardown_runtime();
 }
 
+void test_strict_validation_alone_preserves_fetch_argument_drops(void) {
+  setup_runtime();
+  config.strict_validation = true;
+  config.strict_runtime_contracts = false;
+  VALUE_t name = {VALUE_str, {.s = "missing.strict_validation_only"}};
+  VALUE_t result = run_fetch_with_one_int_arg("strict_runtime.strict_validation_only_runner", name);
+  ASSERT_EQ_INT(VALUE_nil, result.type);
+  assert_error_nil();
+  teardown_runtime();
+}
+
 void test_strict_runtime_contracts_reports_too_many_item_arguments(void) {
   setup_runtime();
   uint8_t target_code[] = {0, 0, 'h'};

--- a/tests/interpreter/test_interpret_semantics_golden.c
+++ b/tests/interpreter/test_interpret_semantics_golden.c
@@ -235,6 +235,7 @@ void test_interpret_rejects_malformed_bytecode_before_execution(void) {
   runtime_context_init(&ctx, config.vm);
   ctx.itemroot = config.itemroot;
   ctx.strict_validation = config.strict_validation;
+  ctx.strict_runtime_contracts = config.strict_runtime_contracts;
   VALUE_t result = interpret(&ctx, code);
   ASSERT_EQ_INT(VALUE_nil, result.type);
   ITEM_t *err = find_item(config.itemroot, "error");

--- a/tests/shared/test_compiler.c
+++ b/tests/shared/test_compiler.c
@@ -157,6 +157,7 @@ void test_value_comparison_mismatched_type_equality_quirk(void);
 void test_value_comparison_unsupported_ordering_is_false(void);
 void test_interpreter_truncated_single_byte_operands(void);
 void test_strict_runtime_contracts_default_preserves_fetch_argument_drops(void);
+void test_strict_validation_alone_preserves_fetch_argument_drops(void);
 void test_strict_runtime_contracts_reports_too_many_item_arguments(void);
 void test_strict_runtime_contracts_reports_invalid_item_name_arguments(void);
 void test_strict_runtime_contracts_reports_missing_item_arguments(void);
@@ -282,6 +283,7 @@ static const test_case_t core_tests[] = {
     {"test_value_comparison_unsupported_ordering_is_false", test_value_comparison_unsupported_ordering_is_false},
     {"test_interpreter_truncated_single_byte_operands", test_interpreter_truncated_single_byte_operands},
     {"test_strict_runtime_contracts_default_preserves_fetch_argument_drops", test_strict_runtime_contracts_default_preserves_fetch_argument_drops},
+    {"test_strict_validation_alone_preserves_fetch_argument_drops", test_strict_validation_alone_preserves_fetch_argument_drops},
     {"test_strict_runtime_contracts_reports_too_many_item_arguments", test_strict_runtime_contracts_reports_too_many_item_arguments},
     {"test_strict_runtime_contracts_reports_invalid_item_name_arguments", test_strict_runtime_contracts_reports_invalid_item_name_arguments},
     {"test_strict_runtime_contracts_reports_missing_item_arguments", test_strict_runtime_contracts_reports_missing_item_arguments},


### PR DESCRIPTION
### Motivation

- Clarify that `--strict-validation` performs structural bytecode validation (during load and before execution) and does not enable runtime argument-contract diagnostics. 
- Ensure test runtime contexts mirror the global `config.strict_runtime_contracts` flag so tests exercise the intended runtime behavior.
- Add a unit test to assert that enabling `strict_validation` alone does not change dropped-argument behavior.

### Description

- Updated documentation in `docs/runtime.md` to explain that `--strict-validation` validates encoded bytecode for structure (reported as `ERR_RUNTIME_BYTECODE`) and that `--strict-runtime-contracts` is required to enable dropped-argument diagnostics. 
- Added a clarifying comment in `src/sin.c` noting that runtime contract diagnostics remain disabled unless explicitly requested. 
- Propagated `config.strict_runtime_contracts` into test `RuntimeContext` initializers in `tests/*` so test contexts now set `ctx.strict_runtime_contracts = config.strict_runtime_contracts` (files modified include `tests/compiler/test_sys_compile_libcall.c`, `tests/core/test_libcall_registry.c`, `tests/core/test_relative_item_leading_dot.c`, and `tests/interpreter/test_interpret_semantics_golden.c`). 
- Added a new test `test_strict_validation_alone_preserves_fetch_argument_drops` in `tests/core/test_value_behavior.c` and registered it in `tests/shared/test_compiler.c` to verify that `strict_validation` without `strict_runtime_contracts` preserves previous behavior.

### Testing

- Ran the unit tests covering the modified areas, including `test_value_behavior`, `test_interpret_semantics_golden`, `test_libcall_registry`, and `test_sys_compile_libcall`, and the full test suite registration updates; all tests passed. 
- The new `test_strict_validation_alone_preserves_fetch_argument_drops` executed successfully and confirmed that `strict_validation` alone does not enable runtime contract diagnostics. 
- No regressions observed in related interpreter and bytecode validation tests after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb7a268e8832e8d58cddcf9c84025)